### PR TITLE
Explicit assets import

### DIFF
--- a/src/manifest.js
+++ b/src/manifest.js
@@ -33,7 +33,7 @@ module.exports = (isProd, browser) => ({
     default_popup: 'popup/popup.html',
   },
   background: {
-    scripts: ['background.js'],
+    scripts: ['other/background.js'],
     persistent: true,
   },
   options_ui: {
@@ -45,7 +45,7 @@ module.exports = (isProd, browser) => ({
       run_at: 'document_start',
       all_frames: !isProd && browser === 'chrome',
       matches: ['https://*/*', 'http://*/*'],
-      js: ['inject.js'],
+      js: ['other/inject.js'],
     },
   ],
   web_accessible_resources: ['inject.js', 'phishing/phishing.html', 'phishing/phishing.js', 'popup/CameraRequestPermission.html'],

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -4,6 +4,7 @@ import { setInterval } from 'timers';
 import { NOTIFICATION_METHODS } from './popup/utils/constants';
 import { detectBrowser } from './popup/utils/helper';
 import { getSDK } from './lib/background-utils';
+import iconUrl from './icons/icon_48.png';
 
 global.browser = require('webextension-polyfill');
 
@@ -59,7 +60,7 @@ export default class Notification {
     let params = {
       type: 'basic',
       title,
-      iconUrl: browser.runtime.getURL('../../../icons/icon_48.png'),
+      iconUrl,
       message,
       priority: 2,
     };

--- a/src/phishing/App.vue
+++ b/src/phishing/App.vue
@@ -2,7 +2,7 @@
   <div class="content">
     <ae-main>
       <ae-panel class="text-center">
-        <img :src="logo" alt="SuperHero logo" />
+        <img src="../icons/icon_128.png" alt="SuperHero logo" />
         <h1><ae-icon fill="primary" face="round" name="info" />SuperHero Phishing Detection</h1>
         <p>
           This domain is currently on the SuperHero domain warning list. This means that based on information available to us, SuperHero believes this domain could currently
@@ -28,13 +28,11 @@
 
 <script>
 import { setInterval } from 'timers';
-import { getPhishingUrls, setPhishingUrl } from '../popup/utils/phishing-detect';
 
 export default {
   name: 'App',
   data() {
     return {
-      logo: browser.runtime.getURL('../../../icons/icon_128.png'),
       href: null,
       hostname: null,
     };

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <ae-main :class="aeppPopup ? 'ae-main-popup ae-main-wave' : waveBg ? 'ae-main-wave' : ''" :style="waveBg ? { 'background-image': `url(${wave_bg}) !important` } : {}">
+  <ae-main :class="aeppPopup ? 'ae-main-popup ae-main-wave' : waveBg ? 'ae-main-wave' : ''">
     <Header @toggle-sidebar="showSidebar = !showSidebar" />
 
     <router-view :key="$route.fullPath" />
@@ -33,7 +33,6 @@ export default {
     NodeConnectionStatus,
   },
   data: () => ({
-    wave_bg: browser.runtime.getURL('../icons/background-big-wave.png'),
     showSidebar: false,
   }),
   computed: {
@@ -130,6 +129,7 @@ export default {
   &.ae-main-wave {
     background-position: 100% 100% !important;
     background-repeat: no-repeat !important;
+    background-image: url('../icons/background-big-wave.png') !important;
   }
 
   padding-top: 50px;

--- a/src/popup/router/components/AccountInfo.vue
+++ b/src/popup/router/components/AccountInfo.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="account-info">
     <div class="title">
-      <img :src="account_icon" />
+      <img src="../../../icons/account-name-icon.png" />
       <div class="account-name" data-cy="account-name">
         <template v-if="activeAccountName.includes('.chain')">{{ activeAccountName }}</template>
         <router-link to="/names" v-else>Claim your .chain name</router-link>
@@ -19,12 +19,11 @@
 
 <script>
 import { mapGetters } from 'vuex';
-import Copyicon from '../../../icons/copy.svg';
+import Copyicon from '../../../icons/copy.svg?vue-component';
 
 export default {
   components: { Copyicon },
   data: () => ({
-    account_icon: browser.runtime.getURL('../icons/account-name-icon.png'),
     copied: false,
   }),
   computed: mapGetters(['account', 'activeAccountName']),

--- a/src/popup/router/components/BalanceInfo.vue
+++ b/src/popup/router/components/BalanceInfo.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="external-svg" :style="{ 'background-image': 'url(' + accbalanceBG + ')' }" data-cy="balance-info">
+  <div class="external-svg" data-cy="balance-info">
     <span class="title">{{ $t('pages.account.balance') }}</span>
     <div class="balance no-sign">
       <div class="amount">
@@ -31,7 +31,7 @@
 
 <script>
 import { mapGetters } from 'vuex';
-import ExpandedAngleArrow from '../../../icons/expanded-angle-arrow.svg';
+import ExpandedAngleArrow from '../../../icons/expanded-angle-arrow.svg?vue-component';
 
 export default {
   components: {
@@ -39,7 +39,6 @@ export default {
   },
   data() {
     return {
-      accbalanceBG: browser.runtime.getURL('../icons/acc_balance.png'),
       dropdown: {
         currencies: false,
       },
@@ -136,6 +135,7 @@ export default {
   height: 84px;
   position: relative;
   text-align: center;
+  background-image: url('../../../icons/acc_balance.png');
   .title {
     position: absolute;
     left: 20px;

--- a/src/popup/router/components/CheckBox.vue
+++ b/src/popup/router/components/CheckBox.vue
@@ -1,8 +1,8 @@
 <template>
   <label class="checkbox-container">
-    <slot class="checkbox-holder"></slot>
+    <slot class="checkbox-holder" />
     <input :value="val" v-model="checked" @change="onChange" :type="getType" :name="name" />
-    <span class="checkmark" :style="{ 'background-image': `url(${checked ? checkboxChecked : checkboxUnchecked})` }"></span>
+    <span class="checkmark" :class="{ checked }" />
   </label>
 </template>
 
@@ -12,8 +12,6 @@ export default {
   data() {
     return {
       checkedProxy: false,
-      checkboxUnchecked: browser.runtime.getURL('../icons/checkbox-unchecked.svg'),
-      checkboxChecked: browser.runtime.getURL('../icons/checkbox-checked.svg'),
     };
   },
   computed: {
@@ -58,12 +56,16 @@ export default {
     width: 0;
   }
   .checkmark {
-    background: no-repeat;
+    background: no-repeat url('../../../icons/checkbox-unchecked.svg');
     position: absolute;
     top: 0;
     left: 0;
     height: 20px;
     width: 20px;
+
+    &.checked {
+      background-image: url('../../../icons/checkbox-checked.svg');
+    }
   }
 }
 .checkbox-holder {

--- a/src/popup/router/components/ClaimTipButton.vue
+++ b/src/popup/router/components/ClaimTipButton.vue
@@ -6,7 +6,7 @@
 
 <script>
 import Button from './Button';
-import Claim from '../../../icons/claim.svg';
+import Claim from '../../../icons/claim.svg?vue-component';
 import openUrl from '../../utils/openUrl';
 
 export default {

--- a/src/popup/router/components/Header.vue
+++ b/src/popup/router/components/Header.vue
@@ -24,10 +24,10 @@
 
 <script>
 import { mapGetters } from 'vuex';
-import Arrow from '../../../icons/arrow.svg';
-import Bell from '../../../icons/bell.svg';
-import Hamburger from '../../../icons/hamburger.svg';
-import Logo from '../../../icons/logo-small.svg';
+import Arrow from '../../../icons/arrow.svg?vue-component';
+import Bell from '../../../icons/bell.svg?vue-component';
+import Hamburger from '../../../icons/hamburger.svg?vue-component';
+import Logo from '../../../icons/logo-small.svg?vue-component';
 
 export default {
   components: { Arrow, Bell, Hamburger, Logo },

--- a/src/popup/router/components/PendingTxs.vue
+++ b/src/popup/router/components/PendingTxs.vue
@@ -20,7 +20,7 @@
 import { mapGetters } from 'vuex';
 import { setInterval, clearInterval } from 'timers';
 import { formatDate } from '../../utils';
-import Eye from '../../../icons/eye.svg';
+import Eye from '../../../icons/eye.svg?vue-component';
 
 export default {
   components: {

--- a/src/popup/router/components/SidebarMenu.vue
+++ b/src/popup/router/components/SidebarMenu.vue
@@ -93,8 +93,8 @@
 
 <script>
 import { mapGetters } from 'vuex';
-import Close from '../../../icons/close.svg';
-import Arrow from '../../../icons/arrow-current-color.svg';
+import Close from '../../../icons/close.svg?vue-component';
+import Arrow from '../../../icons/arrow-current-color.svg?vue-component';
 
 export default {
   components: { Close, Arrow },

--- a/src/popup/router/components/TransactionFilters.vue
+++ b/src/popup/router/components/TransactionFilters.vue
@@ -14,7 +14,7 @@
 
 <script>
 import { mapGetters } from 'vuex';
-import FilterArrow from '../../../icons/filter-arrow.svg';
+import FilterArrow from '../../../icons/filter-arrow.svg?vue-component';
 
 export default {
   props: [''],

--- a/src/popup/router/components/TransactionItem.vue
+++ b/src/popup/router/components/TransactionItem.vue
@@ -10,7 +10,9 @@
       </div>
       <div class="holder">
         <span class="url" @click="visitTipUrl">{{ tipUrl }}</span>
-        <span class="seeTransaction" @click="seeTx(transactionData.hash)"><img :src="eye"/></span>
+        <span class="seeTransaction" @click="seeTx(transactionData.hash)">
+          <img src="../../../icons/eye.png" />
+        </span>
       </div>
     </ae-list-item>
   </div>
@@ -27,7 +29,6 @@ export default {
   props: ['transactionData', 'recent', 'dark'],
   data() {
     return {
-      eye: browser.runtime.getURL('../icons/eye.png'),
       status: '',
       tipUrl: null,
       checkSdk: null,

--- a/src/popup/router/components/Welcome.vue
+++ b/src/popup/router/components/Welcome.vue
@@ -13,8 +13,8 @@
 </template>
 
 <script>
-import Logo from '../../../icons/logo.svg';
-import Welcome from '../../../icons/welcome.svg';
+import Logo from '../../../icons/logo.svg?vue-component';
+import Welcome from '../../../icons/welcome.svg?vue-component';
 
 export default {
   components: {

--- a/src/popup/router/pages/AboutSettings.vue
+++ b/src/popup/router/pages/AboutSettings.vue
@@ -17,7 +17,7 @@
 </template>
 
 <script>
-import Logo from '../../../icons/logo.svg';
+import Logo from '../../../icons/logo.svg?vue-component';
 import openUrl from '../../utils/openUrl';
 
 export default {

--- a/src/popup/router/pages/Account.vue
+++ b/src/popup/router/pages/Account.vue
@@ -27,7 +27,7 @@
 import { mapGetters } from 'vuex';
 import { setTimeout, clearInterval } from 'timers';
 import { currencyConv } from '../../utils/helper';
-import Heart from '../../../icons/heart.svg';
+import Heart from '../../../icons/heart.svg?vue-component';
 import RecentTransactions from '../components/RecentTransactions';
 import ClaimTipButton from '../components/ClaimTipButton';
 import BalanceInfo from '../components/BalanceInfo';

--- a/src/popup/router/pages/Index.vue
+++ b/src/popup/router/pages/Index.vue
@@ -21,7 +21,7 @@
 
 <script>
 import { mapGetters } from 'vuex';
-import Logo from '../../../icons/logo.svg';
+import Logo from '../../../icons/logo.svg?vue-component';
 import CheckBox from '../components/CheckBox';
 
 export default {

--- a/src/popup/router/pages/Intro.vue
+++ b/src/popup/router/pages/Intro.vue
@@ -65,10 +65,10 @@
 <script>
 import { mapGetters } from 'vuex';
 import { generateMnemonic, mnemonicToSeed } from '@aeternity/bip39';
-import Claim from '../../../icons/claim.svg';
-import Heart from '../../../icons/heart.svg';
-import LeftArrow from '../../../icons/left-arrow.svg';
-import RightArrow from '../../../icons/right-arrow.svg';
+import Claim from '../../../icons/claim.svg?vue-component';
+import Heart from '../../../icons/heart.svg?vue-component';
+import LeftArrow from '../../../icons/left-arrow.svg?vue-component';
+import RightArrow from '../../../icons/right-arrow.svg?vue-component';
 import Button from '../components/Button';
 
 export default {

--- a/src/popup/router/pages/Notifications.vue
+++ b/src/popup/router/pages/Notifications.vue
@@ -2,7 +2,7 @@
   <div class="popup">
     <ae-list class="noti-list">
       <ae-list-item fill="neutral" v-for="(noti, i) in notifications" :key="i" class="noti">
-        <img :src="icon" />
+        <img src="../../../icons/icon_48.png" />
         <span> {{ noti.content }} </span>
       </ae-list-item>
     </ae-list>
@@ -13,7 +13,6 @@
 import { mapGetters } from 'vuex';
 
 export default {
-  data: () => ({ icon: browser.runtime.getURL('../icons/icon_48.png') }),
   computed: mapGetters(['notifications']),
 };
 </script>

--- a/src/popup/router/pages/Receive.vue
+++ b/src/popup/router/pages/Receive.vue
@@ -10,7 +10,7 @@
         <!-- <a @click="exchange" class="block mt-15">{{ $t('pages.receive.transferExchange') }}</a> -->
         <!-- <div class="flex flex flex-align-center flex-justify-between mt-20 mb-35">
           <a @click="purchase" class="block">{{ $t('pages.receive.purchase') }}</a>
-          <img :src="changelly" alt="" />
+          <img src="../../../icons/changelly.png" alt="" />
         </div> -->
       </div>
       <Button @click="purchase">{{ $t('pages.receive.purchase') }}</Button>
@@ -37,7 +37,6 @@ export default {
     return {
       jellySwapUrl: 'https://app.jelly.market',
       changellyUrl: 'https://changelly.com/processing',
-      changelly: browser.runtime.getURL('../../../icons/changelly.png'),
     };
   },
   computed: {

--- a/src/popup/router/pages/Retip.vue
+++ b/src/popup/router/pages/Retip.vue
@@ -37,7 +37,7 @@ import { MAGNITUDE, calculateFee, TX_TYPES, BACKEND_URL } from '../../utils/cons
 import { pollGetter } from '../../utils/helper';
 import { setPendingTx } from '../../utils';
 import openUrl from '../../utils/openUrl';
-import CheckIcon from '../../../icons/check-icon.svg';
+import CheckIcon from '../../../icons/check-icon.svg?vue-component';
 import AmountSend from '../components/AmountSend';
 
 export default {

--- a/src/popup/router/pages/Send.vue
+++ b/src/popup/router/pages/Send.vue
@@ -106,9 +106,9 @@ import AmountSend from '../components/AmountSend';
 import Textarea from '../components/Textarea';
 import AccountInfo from '../components/AccountInfo';
 import BalanceInfo from '../components/BalanceInfo';
-import QrIcon from '../../../icons/qr-code.svg';
-import AlertExclamination from '../../../icons/alert-exclamation.svg';
-import Heart from '../../../icons/heart.svg';
+import QrIcon from '../../../icons/qr-code.svg?vue-component';
+import AlertExclamination from '../../../icons/alert-exclamation.svg?vue-component';
+import Heart from '../../../icons/heart.svg?vue-component';
 
 export default {
   name: 'Send',

--- a/src/popup/router/pages/SuccessTip.vue
+++ b/src/popup/router/pages/SuccessTip.vue
@@ -42,7 +42,7 @@
 
 <script>
 import { mapGetters } from 'vuex';
-import Heart from '../../../icons/heart.svg';
+import Heart from '../../../icons/heart.svg?vue-component';
 import Textarea from '../components/Textarea';
 import openUrl from '../../utils/openUrl';
 

--- a/src/popup/router/pages/TermsOfService.vue
+++ b/src/popup/router/pages/TermsOfService.vue
@@ -22,8 +22,8 @@
 </template>
 
 <script>
-import ArrowDown from '../../../icons/arrow-down.svg';
-import ArrowRight from '../../../icons/arrow-right.svg';
+import ArrowDown from '../../../icons/arrow-down.svg?vue-component';
+import ArrowRight from '../../../icons/arrow-right.svg?vue-component';
 
 export default {
   components: {

--- a/src/popup/router/pages/TipPage.vue
+++ b/src/popup/router/pages/TipPage.vue
@@ -55,7 +55,7 @@ import axios from 'axios';
 import { MAGNITUDE, calculateFee, TX_TYPES, BACKEND_URL } from '../../utils/constants';
 import { escapeSpecialChars, pollGetter, aeToAettos } from '../../utils/helper';
 import { setPendingTx } from '../../utils';
-import CheckIcon from '../../../icons/check-icon.svg';
+import CheckIcon from '../../../icons/check-icon.svg?vue-component';
 import AmountSend from '../components/AmountSend';
 import Textarea from '../components/Textarea';
 import Input from '../components/Input';

--- a/src/redirect/App.vue
+++ b/src/redirect/App.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script>
-import Logo from '../icons/logo.svg';
+import Logo from '../icons/logo.svg?vue-component';
 
 export default {
   name: 'App',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,8 +29,8 @@ const commonConfig = {
   mode: process.env.NODE_ENV,
   context: path.resolve(__dirname, 'src'),
   entry: {
-    background: './background.js',
-    inject: './inject.js',
+    'other/background': './background.js',
+    'other/inject': './inject.js',
     'popup/popup': './popup/popup.js',
     'options/options': './options/options.js',
     'phishing/phishing': './phishing/phishing.js',
@@ -40,6 +40,7 @@ const commonConfig = {
   node: { fs: 'empty', net: 'empty', tls: 'empty' },
   output: {
     filename: '[name].js',
+    publicPath: '../',
   },
   resolve: {
     extensions: ['.js', '.vue'],
@@ -72,28 +73,36 @@ const commonConfig = {
         use: [MiniCssExtractPlugin.loader, 'css-loader', 'sass-loader?indentedSyntax'],
       },
       {
-        test: /\.(png|jpg|gif|ico)$/,
-        loader: 'file-loader',
-        options: {
-          name: '[name].[ext]?emitFile=false',
-        },
-      },
-      {
-        test: /\.svg$/,
-        loader: 'vue-svg-loader',
+        test: /\.(png|jpg|gif|svg|ico)$/,
+        oneOf: [
+          {
+            test: /\.svg$/,
+            resourceQuery: /vue-component/,
+            loader: 'vue-svg-loader',
+          },
+          {
+            loader: 'url-loader',
+            options: {
+              name: '[name].[contenthash].[ext]',
+              esModule: false,
+              limit: 4096,
+              outputPath: 'assets/',
+            },
+          },
+        ],
       },
     ],
   },
   plugins: [
     ...commonPlugins,
     new CopyWebpackPlugin([
-      { from: 'icons', to: `icons`, ignore: ['icon.xcf'] },
       { from: 'popup/popup.html', to: `popup/popup.html`, transform: transformHtml },
       { from: 'options/options.html', to: `options/options.html`, transform: transformHtml },
       { from: 'phishing/phishing.html', to: `phishing/phishing.html`, transform: transformHtml },
       { from: 'popup/CameraRequestPermission.html', to: `popup/CameraRequestPermission.html`, transform: transformHtml },
       { from: 'redirect/redirect.html', to: `redirect/index.html`, transform: transformHtml },
-      { from: 'icons/icon_48.png', to: `popup/assets/logo-small.png` },
+      { from: 'icons/icon_48.png', to: `icons/icon_48.png` },
+      { from: 'icons/icon_128.png', to: `icons/icon_128.png` },
     ]),
   ],
 };


### PR DESCRIPTION
`browser.runtime.getURL` can't be used in css, so I proposing to avoid it by using relative paths (they works both in extensions and Cordova).

Importing of svg by default as Vue components is not works in css, so I proposing to enable importing as a component explicitly by adding `?vue-component`.

Also, these changes is needed for web version of the wallet, because there we should avoid the `popup` folder in `dist` and use absolute paths.