### PR TITLE
Simplify e2e configs

### DIFF
--- a/src/lib/rpcWallet.js
+++ b/src/lib/rpcWallet.js
@@ -28,7 +28,7 @@ const rpcWallet = {
     await this.initNodes();
     this.initFields();
     this.controller = walletController;
-    if (process.env.EXTENSION_RUNNING_IN_TESTS_BROWSER) await mockLogin();
+    if (process.env.RUNNING_IN_TESTS) await mockLogin();
     const { userAccount } = await browser.storage.local.get('userAccount');
     if (userAccount) {
       this.controller.generateWallet({ seed: stringifyForStorage(userAccount.privateKey) });


### PR DESCRIPTION
I'm working currently on webpack configs, for me would be easier to simplify them a bit.
- can we drop `EXTENSION_RUNNING_IN_TESTS_BROWSER`?
- can we build apps for e2e tests separately?