### PR TITLE
travis: Combine into single job to speedup testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ cache:
   npm: true
   directories:
     - ~/.cache
-jobs:
-  include:
-    - stage: Install dependencies and build
-      script: npm ci && npm run build
-    - stage: Run tests
-      script: npm run test
+script:
+  - npm test
+  - npm run build


### PR DESCRIPTION
Actually, it doesn't make a significant difference (~2 minutes faster). Just Travis won't be needed to run `npm ci` three times. 