### PR TITLE
Make Cordova to don't use UIWebView on iOS

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -41,6 +41,11 @@
         <allow-intent href="itms:*" />
         <allow-intent href="itms-apps:*" />
         <preference name="AllowBackForwardNavigationGestures" value="true" />
+        <preference name="WKWebViewOnly" value="true" />
+        <feature name="CDVWKWebViewEngine">
+            <param name="ios-package" value="CDVWKWebViewEngine" />
+        </feature>
+        <preference name="CordovaWebViewEngine" value="CDVWKWebViewEngine" />
         <icon height="57" src="resources/ios/icon/icon.png" width="57" />
         <icon height="114" src="resources/ios/icon/icon@2x.png" width="114" />
         <icon height="20" src="resources/ios/icon/icon-20.png" width="20" />


### PR DESCRIPTION
Made according to https://cordova.apache.org/howto/2020/03/18/wkwebviewonly.html

Supposed to fix this warning:

> ITMS-90809: Deprecated API Usage - Apple will stop accepting submissions of new apps that use UIWebView APIs starting from April 2020. See https://developer.apple.com/documentation/uikit/uiwebview for more information.