### PR TITLE
Avoid overriding of font-family and color for every node

### DIFF
--- a/src/common/base.scss
+++ b/src/common/base.scss
@@ -162,13 +162,13 @@ main {
   background: $bg-color;
   padding:10px 0;
   button {
-      margin-bottom:0 !important;
+    margin-bottom:0 !important;
   }
   .ae-button.round {
-      padding: 0 0.5rem !important;
+    padding: 0 0.5rem !important;
   }
   button .ae-icon {
-      font-size:1.5rem !important;
+    font-size:1.5rem !important;
   }
 }
 .customFileUpload {
@@ -197,14 +197,14 @@ main {
     align-items: center;
   }
   .file-label {
-      padding: 0.5rem 1rem;
-      display:inline-block;
-      font-family: "Inter UI", sans-serif;
-      font-size: 0.8125rem;
-      letter-spacing: 0.02em;
-      line-height: 1rem;
-      color: #76818C;
-      padding-bottom:0;
+    padding: 0.5rem 1rem;
+    display:inline-block;
+    font-family: "Inter UI", sans-serif;
+    font-size: 0.8125rem;
+    letter-spacing: 0.02em;
+    line-height: 1rem;
+    color: #76818C;
+    padding-bottom:0;
   }
   .file-input {
     font-family: "Inter UI", sans-serif;
@@ -229,15 +229,15 @@ main {
     background:$primary-color;
   }
   .ae-badge.alternative{
-      background:$color-alternative;
+    background:$color-alternative;
   }
   .ae-badge.secondary{
-      background:$color-secondary;
+    background:$color-secondary;
   }
   .ae-badge {
-      background:#929CA6;
-      color:#fff !important;
-      font-size:.7rem;
+    background:#929CA6;
+    color:#fff !important;
+    font-size:.7rem;
   }
 }
 .allTransactions .ae-identicon {
@@ -372,11 +372,11 @@ main {
   color: $color-neutral-negative-1;
   font-family: monospace;
   &.invert {
-      color: #fff;
+    color: #fff;
   }
 
   &:after {
-      content: ' AE';
+    content: ' AE';
   }
   &.no-sign:after {
     content: '';
@@ -444,19 +444,19 @@ $range-label-color: $shade-10 !default;
 $range-label-width: 60px !default;
 
 .range-slider {
-    width: 100%;
-    position:relative;
-    .tipAmount {
-        position:absolute;
-        color: #909090;
-        font-size: 0.9rem;
-    }
-    .tipMin {
-        left:0;
-    }
-    .tipMax {
-        right:0;
-    }
+  width: 100%;
+  position:relative;
+  .tipAmount {
+    position:absolute;
+    color: #909090;
+    font-size: 0.9rem;
+  }
+  .tipMin {
+    left:0;
+  }
+  .tipMax {
+    right:0;
+  }
 }
 
 .range-slider__range {
@@ -522,8 +522,8 @@ $range-label-width: 60px !default;
 }
 
 ::-moz-range-track {
-    background: $range-track-color;
-    border: 0;
+  background: $range-track-color;
+  border: 0;
 }
 
 input::-moz-focus-inner,
@@ -597,20 +597,20 @@ input::-moz-focus-outer {
 }
 .custom-ae-input-header {
   position: relative;
-    display: flex;
-    flex: 0 0;
-    justify-content: space-between;
-    align-items: center;
-    align-self: flex-start;
-    width: 100%;
-    padding: 0.5rem 1rem 0 1rem;
+  display: flex;
+  flex: 0 0;
+  justify-content: space-between;
+  align-items: center;
+  align-self: flex-start;
+  width: 100%;
+  padding: 0.5rem 1rem 0 1rem;
 }
 .custom-ae-input-label {
   color: #76818C;
-    font-family: "Inter UI", sans-serif;
-    font-size: 0.8125rem;
-    letter-spacing: 0.02em;
-    line-height: 1rem;
+  font-family: "Inter UI", sans-serif;
+  font-size: 0.8125rem;
+  letter-spacing: 0.02em;
+  line-height: 1rem;
 }
 .tokenExtensions .ae-check-button:after {
   width: 29px;

--- a/src/common/base.scss
+++ b/src/common/base.scss
@@ -791,7 +791,6 @@ button {
   line-height: 12px;
 }
 .popup {
-  color: #555;
   padding: 4px 20px;
   text-align: center;
   font-size: 16px;

--- a/src/common/extension.scss
+++ b/src/common/extension.scss
@@ -1,12 +1,13 @@
 @import './variables';
 
-body, .ae-main, html {
-  background: $bg-color !important;
-  font-size:$font-size;
-  font-family: 'Roboto', sans-serif !important;
-}
-body, html {
+html, body {
   height: 100%;
+}
+html, body, .ae-main {
+  font-family: 'Roboto', sans-serif;
+  font-size: $font-size;
+  color: $white-color;
+  background: $bg-color !important;
 }
 .popup {
   max-width: 357px !important;
@@ -18,13 +19,6 @@ body, html {
 }
 #app {
   font-family: 'Roboto', sans-serif !important;
-}
-:not(svg):not(rect):not(.aemount) {
-  font-family: 'Roboto', sans-serif !important;
-
-  &:not(a) {
-    color: $white-color;
-  }
 }
 .disabled {
   opacity: .4;

--- a/src/common/extension.scss
+++ b/src/common/extension.scss
@@ -36,10 +36,6 @@ a {
 .secondary-bg {
   background:$nav-bg-color;
 }
-.primary-text {
-  color:$text-color;
-  font-size: .88rem;
-}
 .text {
   color: $text-color;
 }

--- a/src/common/extension.scss
+++ b/src/common/extension.scss
@@ -1,280 +1,280 @@
 @import './variables';
 
 body, .ae-main, html {
-    background: $bg-color !important;
-    font-size:$font-size;
-    font-family: 'Roboto', sans-serif !important;
+  background: $bg-color !important;
+  font-size:$font-size;
+  font-family: 'Roboto', sans-serif !important;
 }
 body, html {
-    height: 100%;
+  height: 100%;
 }
 .popup {
-    max-width: 357px !important;
-    margin:0 auto;
-    position:relative;
+  max-width: 357px !important;
+  margin:0 auto;
+  position:relative;
 }
 .popup-no-padding {
-    padding: 4px 0;
+  padding: 4px 0;
 }
 #app {
-    font-family: 'Roboto', sans-serif !important;
+  font-family: 'Roboto', sans-serif !important;
 }
 :not(svg):not(rect):not(.aemount) {
-    font-family: 'Roboto', sans-serif !important;
+  font-family: 'Roboto', sans-serif !important;
 
-    &:not(a) {
-        color: $white-color;
-    }
+  &:not(a) {
+    color: $white-color;
+  }
 }
 .disabled {
-    opacity: .4;
-    pointer-events: none;
+  opacity: .4;
+  pointer-events: none;
 }
 
 a {
-    color: $accent-color;
-    text-decoration: underline;
-    cursor: pointer;
+  color: $accent-color;
+  text-decoration: underline;
+  cursor: pointer;
 }
 .primary-bg {
-    background:$bg-color;
+  background:$bg-color;
 }
 .secondary-bg {
-    background:$nav-bg-color;
+  background:$nav-bg-color;
 }
 .primary-text {
-    color:$text-color;
-    font-size: .88rem;
+  color:$text-color;
+  font-size: .88rem;
 }
 .text {
-    color: $text-color;
+  color: $text-color;
 }
 .primary-title {
-    color: $white-color;
-    font-size: 18px;
-    font-weight: lighter;
-    margin-bottom:27px;
-    margin-left:0 !important;
+  color: $white-color;
+  font-size: 18px;
+  font-weight: lighter;
+  margin-bottom:27px;
+  margin-left:0 !important;
 }
 .primary-title-small {
-    color: #bcbcc4 !important;
-    font-size: 16px;
-    margin-top: 0;
+  color: #bcbcc4 !important;
+  font-size: 16px;
+  margin-top: 0;
 }
 .primary-title-darker {
-    color: $text-color;
+  color: $text-color;
 }
 .secondary-text {
-    color: $secondary-color !important;
+  color: $secondary-color !important;
 }
 .accent-text {
-    color: $accent-color;
+  color: $accent-color;
 }
 .regular-text {
-    font-size:$font-size;
-    text-align: left;
-    font-weight: normal;
+  font-size:$font-size;
+  text-align: left;
+  font-weight: normal;
 }
 .logo{
-    margin:60px 0;
+  margin:60px 0;
 }
 .ae-header {
-    background: $nav-bg-color !important;
-    border-color: $nav-border-color !important;
+  background: $nav-bg-color !important;
+  border-color: $nav-border-color !important;
 }
 .error-msg {
-    color: $secondary-color !important;
-    margin-top:22px;
-    font-size: .88rem;
+  color: $secondary-color !important;
+  margin-top:22px;
+  font-size: .88rem;
 }
 .nav-title  {
-    .title-text {
-        margin-left:15px;
-        font-weight: lighter;
-    }
+  .title-text {
+    margin-left:15px;
+    font-weight: lighter;
+  }
 }
 .arrow-back {
-    cursor: pointer;
+  cursor: pointer;
 }
 
 .heading-1 {
-    font-size:18px;
-    font-weight: normal;
-    margin:8px 0;
+  font-size:18px;
+  font-weight: normal;
+  margin:8px 0;
 }
 .sub-heading {
-    font-size:14px;
-    font-weight: normal;
-    margin:8px 0;
+  font-size:14px;
+  font-weight: normal;
+  margin:8px 0;
 }
 .uppercase {
-    text-transform: uppercase;
+  text-transform: uppercase;
 }
 .link-sm {
-    font-size:11px;
-    margin:8px 0;
+  font-size:11px;
+  margin:8px 0;
 }
 .block {
-    display:block;
+  display:block;
 }
 /* Font size 14*/
 .f-12 {
-    font-size:12px;
+  font-size:12px;
 }
 .f-14 {
-    font-size:14px;
+  font-size:14px;
 }
 .f-16 {
-    font-size:16px;
+  font-size:16px;
 }
 .f-18 {
-    font-size:18px;
+  font-size:18px;
 }
 .f-24 {
-    font-size:24px;
+  font-size:24px;
 }
 .l-1 {
-    line-height: 1.2;
+  line-height: 1.2;
 }
 .balance-box {
-    width:80px;
-    text-align: left;
-    border-left:1px solid $border-color;
-    padding-left:10px;
+  width:80px;
+  text-align: left;
+  border-left:1px solid $border-color;
+  padding-left:10px;
 }
 .amount-box {
-    width: 120px;
+  width: 120px;
 }
 .hidden {
-    visibility: hidden;
+  visibility: hidden;
 }
 .tip-note-preview {
-    border-radius: 5px;
-    border: 1px;
-    padding: 10px;
-    font-size:14px;
-    border:1px dashed $text-color;
-    margin-top:5px;
-    margin-bottom:30px;
-    text-align: left;
-    word-break: break-word;
+  border-radius: 5px;
+  border: 1px;
+  padding: 10px;
+  font-size:14px;
+  border:1px dashed $text-color;
+  margin-top:5px;
+  margin-bottom:30px;
+  text-align: left;
+  word-break: break-word;
 }
 
 /**
 * POPUP WINDWOS
 */
 .popup-aex2 {
-    max-height: 600px;
-    min-height: 600px;
-    margin-bottom:55px;
-    position:relative;
-    // overflow-y:scroll;
-    h2 {
-        word-break: break-word;
-        line-height: 1.8rem;
-        font-size: 1.2rem;
+  max-height: 600px;
+  min-height: 600px;
+  margin-bottom:55px;
+  position:relative;
+  // overflow-y:scroll;
+  h2 {
+    word-break: break-word;
+    line-height: 1.8rem;
+    font-size: 1.2rem;
+  }
+  p {
+    font-weight: normal;
+    word-break: break-word;
+    font-size: 0.9rem;
+  }
+  ul li {
+    border-width:1px !important;
+    border-color:#424242 !important;
+  }
+
+  .permission-set {
+    flex-direction: column;
+    text-align: left;
+    cursor: unset !important;
+    h4 {
+      display: block;
+      width: 100%;
+      margin: 0;
     }
     p {
-        font-weight: normal;
-        word-break: break-word;
-        font-size: 0.9rem;
+      display: block;
+      width: 100%;
+      margin: 0;
     }
-    ul li {
-        border-width:1px !important;
-        border-color:#424242 !important;
-    }
-
-    .permission-set {
-        flex-direction: column;
-        text-align: left;
-        cursor: unset !important;
-        h4 {
-          display: block;
-          width: 100%;
-          margin: 0;
-        }
-        p {
-          display: block;
-          width: 100%;
-          margin: 0;
-        }
-    }
-    ul {
-        padding: 0;
-    }
-    .accountName {
-        font-size: 0.8rem;
-        word-break: break-word;
-        white-space: nowrap;
-    }
-    .hostname {
-        font-size: 0.65rem;
-        word-break: break-word;
-    }
+  }
+  ul {
+    padding: 0;
+  }
+  .accountName {
+    font-size: 0.8rem;
+    word-break: break-word;
+    white-space: nowrap;
+  }
+  .hostname {
+    font-size: 0.65rem;
+    word-break: break-word;
+  }
 }
 
 
 /** Noti styles */
 .noti {
-    font-size: 14px;
-    margin: 14px auto 10px; 
+  font-size: 14px;
+  margin: 14px auto 10px; 
 }
 .noti span {
-    color: $accent-color !important;
-    word-break: break-word;
+  color: $accent-color !important;
+  word-break: break-word;
 }
 .noti a {
-    cursor: pointer;
-    color: $accent-color !important;
+  cursor: pointer;
+  color: $accent-color !important;
 }
 .noti img {
-    width:30px;
-    margin-right: 10px;
+  width:30px;
+  margin-right: 10px;
 }
 .noti-list {
-    margin-top:20px !important;
-    .noti {
-        background:$nav-bg-color;
-        padding-left:10px !important;
-        padding-right: 10px !important;
-        text-align: left;
-        margin:0 !important;
-        border-color:#3a3a47 !important;
-    }
+  margin-top:20px !important;
+  .noti {
+    background:$nav-bg-color;
+    padding-left:10px !important;
+    padding-right: 10px !important;
+    text-align: left;
+    margin:0 !important;
+    border-color:#3a3a47 !important;
+  }
 }
 
 /**
 * Dynamic Margins Utilities Clasess
 */
 @mixin margin-left($i) {
-  margin-left: $i + px;
+margin-left: $i + px;
 }
 @mixin margin-right($i) {
-    margin-right: $i + px;
+  margin-right: $i + px;
 }
 @mixin margin-bottom($i) {
-    margin-bottom: $i + px;
+  margin-bottom: $i + px;
 }
 @mixin margin-top($i) {
-    margin-top: $i + px;
+  margin-top: $i + px;
 }
 @mixin margin-x($i) {
-    margin-left: $i + px;
-    margin-right: $i + px;
+  margin-left: $i + px;
+  margin-right: $i + px;
 }
 @mixin margin-y($i) {
-    margin-top: $i + px;
-    margin-bottom: $i + px;
+  margin-top: $i + px;
+  margin-bottom: $i + px;
 }
 @for $i from 1 through 40 {
-  .ml-#{$i} { @include margin-left($i); }
-  .mr-#{$i} { @include margin-right($i); }
-  .mb-#{$i} { @include margin-bottom($i); }
-  .mt-#{$i} { @include margin-top($i); }
-  .mx-#{$i} { @include margin-x($i); }
-  .my-#{$i} { @include margin-y($i); }
+.ml-#{$i} { @include margin-left($i); }
+.mr-#{$i} { @include margin-right($i); }
+.mb-#{$i} { @include margin-bottom($i); }
+.mt-#{$i} { @include margin-top($i); }
+.mx-#{$i} { @include margin-x($i); }
+.my-#{$i} { @include margin-y($i); }
 }
 .mr-auto {
-    margin-right: auto;
+  margin-right: auto;
 }
 

--- a/src/popup/router/components/AccountInfo.vue
+++ b/src/popup/router/components/AccountInfo.vue
@@ -57,6 +57,7 @@ export default {
     .account-name {
       flex-grow: 1;
       font-weight: 500;
+      color: $white-color;
     }
 
     .copied-alert {

--- a/src/popup/router/components/BalanceInfo.vue
+++ b/src/popup/router/components/BalanceInfo.vue
@@ -152,12 +152,13 @@ export default {
     top: 50%;
     margin-top: -36px;
     font-size: 26px;
-    .amount {
-      font-size: 26px;
-      color: $text-color !important;
-      :last-child {
-        color: $secondary-color !important;
-      }
+    color: $white-color;
+    &,
+    .ae-button {
+      font-family: 'Roboto', sans-serif;
+    }
+    .amount :last-child {
+      color: $secondary-color;
     }
     .ae-button {
       display: block;

--- a/src/popup/router/components/Button.vue
+++ b/src/popup/router/components/Button.vue
@@ -34,6 +34,7 @@ export default {
   background: $button-color !important;
   width: 270px !important;
   border-radius: 5px;
+  font-family: 'Roboto', sans-serif;
   font-size: 18px;
   padding: 0;
   margin: 8px auto;

--- a/src/popup/router/components/Popup.vue
+++ b/src/popup/router/components/Popup.vue
@@ -65,5 +65,6 @@ export default {
 }
 .ae-overlay .ae-modal-light .popup-message {
   font-size: 14px;
+  color: $white-color;
 }
 </style>

--- a/src/popup/router/components/SidebarMenu.vue
+++ b/src/popup/router/components/SidebarMenu.vue
@@ -128,7 +128,6 @@ export default {
   list-style: none;
 
   li {
-    color: #717c87;
     margin: 0;
     border-bottom: 1px solid $bg-color;
 

--- a/src/popup/router/components/Textarea.vue
+++ b/src/popup/router/components/Textarea.vue
@@ -46,6 +46,7 @@ textarea {
   padding: 15px;
   margin-bottom: 22px;
   color: $text-color !important;
+  font-family: 'Roboto', sans-serif;
   font-size: $font-size;
   min-height: 200px !important;
   margin-left: auto;

--- a/src/popup/router/pages/GeneralSettings.vue
+++ b/src/popup/router/pages/GeneralSettings.vue
@@ -89,6 +89,8 @@ export default {
 </script>
 
 <style lang="scss">
+@import '../../../common/variables';
+
 .color-grey {
   background-color: #505058 !important;
   border-radius: 4px;
@@ -128,7 +130,7 @@ export default {
 .language-settings button {
   font-size: 14px;
   width: 100%;
-  color: #000;
+  color: $button-text-color;
   text-align: left;
   margin: 0;
   padding: 0 1rem;

--- a/src/popup/router/pages/Index.vue
+++ b/src/popup/router/pages/Index.vue
@@ -63,9 +63,15 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@import '../../../common/variables';
+
 .install-native-version > * {
   display: block;
   width: 270px;
   margin: 15px auto;
+}
+.primary-text {
+  color: $white-color;
+  font-size: 0.88rem;
 }
 </style>

--- a/src/popup/router/pages/Receive.vue
+++ b/src/popup/router/pages/Receive.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="popup popup-no-padding">
     <div data-cy="top-up-container">
-      <p class="primary-title primary-title-darker text-left mt-20 f-14 mx-20" style="margin-left:20px !important">
+      <p class="primary-title text-left mt-20 f-14 mx-20" style="margin-left:20px !important">
         {{ $t('pages.receive.heading') }}
       </p>
       <AccountInfo />

--- a/src/popup/router/pages/SignTransaction.vue
+++ b/src/popup/router/pages/SignTransaction.vue
@@ -762,11 +762,27 @@ export default {
   font-size: 2rem;
   color: $white-color;
 }
-.spendTxDetailsList .ae-list-item {
-  position: relative;
-  cursor: unset;
-  // text-transform: uppercase;
-  font-size: 0.8rem;
+.spendTxDetailsList {
+  .balance {
+    font-family: Roboto, sans-serif;
+    color: $white-color;
+  }
+
+  .ae-list-item {
+    position: relative;
+    cursor: unset;
+    // text-transform: uppercase;
+    font-size: 0.8rem;
+
+    div .ae-badge {
+      background: $accent-color;
+      font-family: Roboto, sans-serif;
+      color: $white-color;
+      -webkit-box-shadow: 0 0 0 2px $accent-color;
+      box-shadow: 0px 0px 0px 2px $accent-color;
+      border: 2px solid $bg-color;
+    }
+  }
 }
 .spendTxDetailsList .ae-button {
   margin-bottom: 0 !important;
@@ -817,13 +833,6 @@ export default {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-.ae-badge {
-  background: $accent-color !important;
-  color: $white-color !important;
-  -webkit-box-shadow: 0 0 0 2px $accent-color;
-  box-shadow: 0px 0px 0px 2px $accent-color;
-  border: 2px solid $bg-color;
 }
 .extend {
   width: 100%;

--- a/src/popup/router/pages/SuccessTip.vue
+++ b/src/popup/router/pages/SuccessTip.vue
@@ -6,7 +6,7 @@
         <span class="ml-5">{{ $t('pages.successTip.completedHeading') }}</span>
       </div>
     </h3>
-    <p class="primary-title primary-title-darker text-left mb-8 f-16">
+    <p class="primary-title text-left mb-8 f-16">
       {{ $t('pages.successTip.successfullySent') }} <span class="secondary-text" data-cy="tip-amount">{{ amountTip }} {{ $t('pages.appVUE.aeid') }} </span> ({{
         getCurrencyAmount
       }}


### PR DESCRIPTION
Closes this issue:
![image](https://user-images.githubusercontent.com/7098449/77663369-b63fd380-6fc8-11ea-81e0-4ae19c668208.png)

One moment is questionable: 
![image](https://user-images.githubusercontent.com/7098449/77661063-dd48d600-6fc5-11ea-8cef-6244fd7ef0f6.png)

1. After fixes we have different color of `Current language` here (prev. it was overrided by `:not:not:not` with `$white-color`), but it was set in `.sett_info`  intentionally.
2. Same with button: all other buttons in project have `$button-text-color` text color, and in this case it was overrided by `:not:not:not` as well.

Also this colors now match up with designs:
![image](https://user-images.githubusercontent.com/7098449/77663200-885a8f00-6fc8-11ea-9260-f07e5d41d932.png)


