### PR TITLE
Use Number.isNaN instead of isNaN, enable "no-restricted-globals" eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -42,6 +42,5 @@ module.exports = {
     }],
     // allow debugger during development
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
-    "no-restricted-globals": "warn"
   }
 }

--- a/src/popup/router/components/AmountSend.vue
+++ b/src/popup/router/components/AmountSend.vue
@@ -3,7 +3,7 @@
     <Input
       class="amount-box"
       type="number"
-      :error="!amountError ? false : true"
+      :error="amountError || finalAmount <= 0"
       v-model="finalAmount"
       :placeholder="$t('pages.tipPage.amountPlaceholder')"
       :label="$t('pages.tipPage.amountLabel')"
@@ -49,7 +49,7 @@ export default {
   computed: {
     ...mapGetters(['tokenBalance', 'balanceCurrency', 'current', 'currentCurrency']),
     getCurrencyAmount() {
-      if (isNaN(this.finalAmount)) return '0.000';
+      if (!+this.finalAmount) return '0.000';
       return (this.finalAmount * this.current.currencyRate).toFixed(3);
     },
   },

--- a/src/popup/router/components/Input.vue
+++ b/src/popup/router/components/Input.vue
@@ -20,11 +20,7 @@ export default {
   created() {},
   watch: {
     value(val) {
-      if ((this.type === 'number' && isNaN(val)) || parseFloat(val) === 0) {
-        this.err = true;
-      } else {
-        this.err = false;
-      }
+      this.err = this.type === 'number' && Number.isNaN(+val);
     },
   },
   computed: {

--- a/src/popup/router/components/PendingTxs.vue
+++ b/src/popup/router/components/PendingTxs.vue
@@ -29,7 +29,7 @@ export default {
   computed: {
     ...mapGetters(['transactions', 'currentCurrency']),
     filteredPendings() {
-      return this.transactions.pending.filter(({ amount, hash }) => !isNaN(amount) && hash);
+      return this.transactions.pending.filter(({ amount, hash }) => !Number.isNaN(+amount) && hash);
     },
   },
   filters: { formatDate },

--- a/src/popup/router/pages/Popups/PopupSignTx.vue
+++ b/src/popup/router/pages/Popups/PopupSignTx.vue
@@ -167,10 +167,7 @@ export default {
   },
   watch: {
     'tx.amount': function txAmount(newVal) {
-      this.amountError = false;
-      if (isNaN(newVal)) {
-        this.amountError = true;
-      }
+      this.amountError = Number.isNaN(+newVal);
     },
   },
   methods: {

--- a/src/popup/router/pages/Retip.vue
+++ b/src/popup/router/pages/Retip.vue
@@ -97,7 +97,7 @@ export default {
     },
     async sendTip() {
       this.amountError = !this.amount || !this.minCallFee || this.maxValue - this.amount <= 0;
-      this.amountError = this.amountError || isNaN(this.amount) || this.amount <= 0;
+      this.amountError = this.amountError || !+this.amount || this.amount <= 0;
       if (this.amountError) return;
 
       const amount = BigNumber(this.amount).shiftedBy(MAGNITUDE);

--- a/src/popup/router/pages/Send.vue
+++ b/src/popup/router/pages/Send.vue
@@ -20,9 +20,7 @@
           <AmountSend data-cy="amount-box" @changeAmount="val => (form.amount = val)" :value="form.amount" />
           <div class="flex flex-align-center flex-justify-between">
             <Button data-cy="reject-withdraw" half @click="navigateAccount">{{ $t('pages.send.cancel') }}</Button>
-            <Button data-cy="review-withdraw" half @click="step = 2" :disabled="!form.address || !form.amount || (form.amount && isNaN(form.amount))">{{
-              $t('pages.send.review')
-            }}</Button>
+            <Button data-cy="review-withdraw" half @click="step = 2" :disabled="!form.address || !+form.amount">{{ $t('pages.send.review') }}</Button>
           </div>
         </div>
       </div>

--- a/src/popup/router/pages/TipPage.vue
+++ b/src/popup/router/pages/TipPage.vue
@@ -97,11 +97,7 @@ export default {
   },
   watch: {
     amount() {
-      if (isNaN(this.amount) || parseFloat(this.amount) === 0) {
-        this.amountError = true;
-      } else {
-        this.amountError = false;
-      }
+      this.amountError = !+this.amount || this.amount <= 0;
     },
     urlVerified(val) {
       if (val) this.$store.dispatch('popupAlert', { name: 'account', type: 'tip_url_verified' });
@@ -166,7 +162,7 @@ export default {
     },
     toConfirm() {
       this.amountError = !this.amount || !this.minCallFee || this.maxValue - this.amount <= 0;
-      this.amountError = this.amountError || isNaN(this.amount) || this.amount <= 0 || isNaN(this.amount);
+      this.amountError = this.amountError || !+this.amount || this.amount <= 0;
       this.noteError = !this.note || !this.url;
       this.confirmMode = !this.amountError && !this.noteError;
     },

--- a/tests/e2e/integration/tip.js
+++ b/tests/e2e/integration/tip.js
@@ -40,7 +40,7 @@ describe('Test cases for tip page', () => {
       .enterTipDetails({ amount: tip.amount })
       .buttonShouldBeDisabled('[data-cy=send-tip]')
       .enterTipDetails({ note: tip.note })
-      .buttonShouldNotBeDisabled('[data-cy=send-tip]')
+      .buttonShouldBeDisabled('[data-cy=send-tip]')
       .enterTipDetails({ amount: 'asd' })
       .buttonShouldBeDisabled('[data-cy=send-tip]')
       .enterTipDetails({ note: '' })


### PR DESCRIPTION
Airbnb's eslint disallows `window.isNaN` because of its confusing behavior: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/isNaN#Description