### PR TITLE
Fixes from test report

### DIFF
--- a/src/popup/locales/en.json
+++ b/src/popup/locales/en.json
@@ -176,7 +176,9 @@
       "tipsOnUrl": "Tips on this URL",
       "urlNotExisting": "Tip for this url does not exist",
       "moreOracles": "There are not enough active oracles to verify your claim request, please try again later.",
-      "oracleFailed": "Oracle service check claim failed, please try again later."
+      "oracleFailed": "Oracle service check claim failed, please try again later.",
+      "unknownError": "Error occured during claim request, please try again later.",
+      "noMobileClaim": "Claiming is currently only available on the web extension on desktop"
     },
     "accountPassword": {
       "heading": "",
@@ -437,7 +439,7 @@
       "decryptingPrivateKey": "Decrypting private key",
       "showSeedPhrase": "Show seed phrase",
       "seedRecoveryHeading": "Show seed phrase",
-      "seedRecoverySmall": "Reveals your 12 words used for generating your private key",
+      "seedRecoverySmall": "Your seed phrase (also referred to as private key) serves as the keys or a password to access your account. Never disclose this to anyone. And make sure you back it up on a piece of paper that no one else can see—but that you will never lose. Losing these keys means losing access to your wallet and tips",
       "seedRecoveryBtn": "Show seed phrase",
       "seedPhraseWarning": "Do not share your seed with anyone, it can be used to steal all your accounts",
       "seedPhrase": "Your seed phrase",
@@ -628,11 +630,12 @@
       "availableLabel": "Available",
       "confirm": "Confirm",
       "cancel": "Cancel",
-      "edit": "Edit AE Details",
+      "edit": "Edit Tip Details",
       "whatIsVerifieddUrl": "What is \"Verified\" URL?",
       "whatIsNotVerifiedUrl": "What is \"Not verified\" URL?",
       "notVerifiedUrlInfo": "This URL has not yet been verified. Third party issues prevent us to ensure that tips will be directly delivered to the URL owner. You are sending the tip at your own risk.",
-      "verifiedUrlInfo": "If a URL is marked as verified, it means the owner of this URL is already a fellow Superhero — and that is awesome! An AE address has been included in the URL and tips can be claimed."
+      "verifiedUrlInfo": "If a URL is marked as verified, it means the owner of this URL is already a fellow Superhero — and that is awesome! An AE address has been included in the URL and tips can be claimed.",
+      "enterUrl": "Enter tip url"
     },
     "successTip": {
       "sendMore": "Send More AE",

--- a/src/popup/router/components/BoxButton.vue
+++ b/src/popup/router/components/BoxButton.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="button-container">
-    <div class="button-content" @click="handleClick">
+    <div class="button-content" @click="handleClick" :class="{ disabled }">
       <slot name="icon" />
       <span class="button-text" :class="accent ? 'button-text-accent' : ''">{{ text }}</span>
     </div>
@@ -16,6 +16,11 @@ export default {
     },
     to: String,
     accent: Boolean,
+    disabled: {
+      type: Boolean,
+      default: false,
+      required: false,
+    },
   },
   methods: {
     handleClick() {
@@ -57,6 +62,11 @@ export default {
       &.button-text-accent {
         color: $accent-color;
       }
+    }
+
+    &.disabled {
+      pointer-events: all;
+      opacity: 0.3;
     }
   }
 }

--- a/src/popup/router/components/ClaimTips.vue
+++ b/src/popup/router/components/ClaimTips.vue
@@ -1,5 +1,11 @@
 <template>
-  <BoxButton :text="$t('pages.account.claim')" accent @handleClick="claimTips" class="tour__step4">
+  <BoxButton
+    :text="$t('pages.account.claim')"
+    accent
+    @handleClick="claimTips"
+    class="tour__step4"
+    :disabled="IS_MOBILE"
+  >
     <Claim slot="icon" />
   </BoxButton>
 </template>
@@ -18,44 +24,54 @@ export default {
     BoxButton,
   },
   computed: mapGetters(['sdk', 'tipping', 'account', 'popup']),
+  data: () => ({ IS_MOBILE: !process.env.IS_EXTENSION }),
   methods: {
     async claimTips() {
-      this.$emit('setLoading', true);
-      await this.$watchUntilTruly(() => this.sdk);
-      await this.$watchUntilTruly(() => this.tipping);
-      const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
-      try {
-        const claimAmount = parseFloat(
-          aettosToAe(
-            await this.tipping.methods
-              .unclaimed_for_url(tab.url)
-              .then(r => r.decodedResult)
-              .catch(() => 0),
-          ),
-        );
-        if (!claimAmount) throw new Error(this.$t('pages.claim.noZeroClaim'));
-        await axios
-          .post(`${TIP_SERVICE}`, { url: tab.url, address: this.account.publicKey })
-          .catch(({ response }) => {
-            const { error } = response.data;
-            if (error.includes('MORE_ORACLES_NEEDED'))
-              throw new Error(this.$t('pages.claim.moreOracles'));
-            else if (error.includes('URL_NOT_EXISTING'))
-              throw new Error(this.$t('pages.claim.urlNotExisting'));
-            else if (error.includes('NO_ZERO_AMOUNT_PAYOUT'))
-              throw new Error(this.$t('pages.claim.noZeroClaim'));
-            else if (error.includes('ORACLE_SEVICE_CHECK_CLAIM_FAILED'))
-              throw new Error(this.$t('pages.claim.oracleFailed'));
-            else throw new Error(error);
-          });
-        await axios.post(`${BACKEND_URL}/cache/invalidate/tip`).catch();
-        await axios.post(`${BACKEND_URL}/cache/invalidate/oracle`).catch();
-        this.$emit('setLoading', false);
-        this.$store.dispatch('modals/open', { name: 'claim-success', url: tab.url, claimAmount });
-      } catch (e) {
-        const msg = e.message.replace('Error: ', '');
-        this.$emit('setLoading', false);
-        this.$store.dispatch('modals/open', { name: 'default', msg });
+      if (process.env.IS_EXTENSION) {
+        this.$emit('setLoading', true);
+        await this.$watchUntilTruly(() => this.sdk);
+        await this.$watchUntilTruly(() => this.tipping);
+        const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
+        try {
+          const claimAmount = parseFloat(
+            aettosToAe(
+              await this.tipping.methods
+                .unclaimed_for_url(tab.url)
+                .then(r => r.decodedResult)
+                .catch(() => 1),
+            ),
+          );
+          if (!claimAmount) throw new Error(this.$t('pages.claim.noZeroClaim'));
+          await axios
+            .post(`${TIP_SERVICE}`, { url: tab.url, address: this.account.publicKey })
+            .catch(({ response }) => {
+              const { error = 'UNKNOWN_ERROR' } = response.data;
+              if (error.includes('MORE_ORACLES_NEEDED'))
+                throw new Error(this.$t('pages.claim.moreOracles'));
+              else if (error.includes('URL_NOT_EXISTING'))
+                throw new Error(this.$t('pages.claim.urlNotExisting'));
+              else if (error.includes('NO_ZERO_AMOUNT_PAYOUT'))
+                throw new Error(this.$t('pages.claim.noZeroClaim'));
+              else if (error.includes('ORACLE_SEVICE_CHECK_CLAIM_FAILED'))
+                throw new Error(this.$t('pages.claim.oracleFailed'));
+              else if (error.includes('UNKNOWN_ERROR'))
+                throw new Error(this.$t('pages.claim.unknownError'));
+              else throw new Error(error);
+            });
+          await axios.post(`${BACKEND_URL}/cache/invalidate/tip`).catch();
+          await axios.post(`${BACKEND_URL}/cache/invalidate/oracle`).catch();
+          this.$emit('setLoading', false);
+          this.$store.dispatch('modals/open', { name: 'claim-success', url: tab.url, claimAmount });
+        } catch (e) {
+          const msg = e.message.replace('Error: ', '');
+          this.$emit('setLoading', false);
+          this.$store.dispatch('modals/open', { name: 'default', msg });
+        }
+      } else {
+        this.$store.dispatch('modals/open', {
+          name: 'default',
+          msg: this.$t('pages.claim.noMobileClaim'),
+        });
       }
     },
   },

--- a/src/popup/router/components/Loader.vue
+++ b/src/popup/router/components/Loader.vue
@@ -7,10 +7,10 @@
         <ae-loader v-if="size == 'small'" />
       </div>
       <transition name="fadeOut" v-if="size == 'big'">
-        <span class="mainLoader mainLoaderTransparent" v-if="type == 'transparent'"
-          ><ae-loader
-        /></span>
-        <Welcome class="mainLoader" v-if="type !== 'transparent'" />
+        <span v-if="type == 'transparent'" class="main-loader main-loader-transparent">
+          <ae-loader />
+        </span>
+        <Welcome v-else class="main-loader main-loader-solid" />
       </transition>
     </div>
   </div>
@@ -48,15 +48,13 @@ export default {
   border-right-color: transparent !important;
 }
 
-.mainLoader {
+.main-loader {
   position: fixed;
   width: 100%;
   height: 100%;
   background-color: $bg-color;
   top: 0;
-  z-index: 6;
-  padding-top: 50px;
-  padding-top: calc(50px + env(safe-area-inset-top));
+  z-index: 8;
 
   .ae-loader {
     position: absolute;
@@ -68,8 +66,13 @@ export default {
     border-radius: 3em !important;
   }
 
-  &.mainLoaderTransparent {
+  &.main-loader-transparent {
     opacity: 0.6;
+  }
+
+  &.main-loader-solid {
+    padding-top: 50px;
+    padding-top: calc(50px + env(safe-area-inset-top));
   }
 }
 

--- a/src/popup/router/components/TransactionItem.vue
+++ b/src/popup/router/components/TransactionItem.vue
@@ -61,11 +61,12 @@ export default {
       return this.$t('pages.transactions.received');
     },
     txAmount() {
-      const amount = this.transaction.tx.amount ? this.transaction.tx.amount : 0;
-      return (+aettosToAe(amount)).toFixed(2);
+      const amount = this.transaction.tx.amount || this.transaction.tx.name_fee || 0;
+      const fee = this.transaction.tx.fee || 0;
+      return (+aettosToAe(amount + fee)).toFixed(2);
     },
     txAmountToCurrency() {
-      const amount = this.transaction.tx.amount ? this.transaction.tx.amount : 0;
+      const amount = this.transaction.tx.amount || this.transaction.tx.name_fee || 0;
       const fee = this.transaction.tx.fee || 0;
       const txamount = aettosToAe(amount + fee);
       return (txamount * this.current.currencyRate).toFixed(2);

--- a/src/popup/router/pages/Account.vue
+++ b/src/popup/router/pages/Account.vue
@@ -24,7 +24,7 @@
         >
           <Tip slot="icon" />
         </BoxButton>
-        <ClaimTips @setLoading="val => (loading = val)" v-if="IS_EXTENSION" />
+        <ClaimTips @setLoading="val => (loading = val)" />
         <BoxButton text="Activity" to="transactions" class="tour__step5">
           <Activity slot="icon" />
         </BoxButton>
@@ -76,7 +76,6 @@ export default {
     return {
       backup_seed_notif: false,
       loading: false,
-      IS_EXTENSION: process.env.IS_EXTENSION,
     };
   },
   computed: {

--- a/src/popup/router/pages/Receive.vue
+++ b/src/popup/router/pages/Receive.vue
@@ -35,7 +35,7 @@ export default {
   data() {
     return {
       jellySwapUrl: 'https://app.jelly.market',
-      changellyUrl: 'https://changelly.com/processing',
+      changellyUrl: 'https://changelly.com/buy',
     };
   },
   computed: {

--- a/src/popup/router/pages/Retip.vue
+++ b/src/popup/router/pages/Retip.vue
@@ -6,7 +6,7 @@
         <span class="secondary-text">{{ $t('pages.appVUE.aeid') }}</span>
         {{ $t('pages.tipPage.to') }}
       </div>
-      <UrlBadge :type="urlVerified ? 'verified' : 'not-verified'" />
+      <UrlBadge v-if="tip.url" :type="urlVerified ? 'verified' : 'not-verified'" />
     </div>
 
     <div class="url-bar">
@@ -67,10 +67,11 @@ export default {
       return calculatedMaxValue > 0 ? calculatedMaxValue.toString() : 0;
     },
     urlVerified() {
-      const twitterProfile = getTwitterAccountUrl(this.url);
+      if (!this.tip.url) return false;
+      const twitterProfile = getTwitterAccountUrl(this.tip.url);
       return (
-        this.url &&
-        (this.verifiedUrls.includes(this.url) ||
+        this.tip.url &&
+        (this.verifiedUrls.includes(this.tip.url) ||
           (twitterProfile && this.verifiedUrls.includes(twitterProfile)))
       );
     },
@@ -87,6 +88,7 @@ export default {
     this.loading = true;
     this.verifiedUrls = (await axios.get(`${BACKEND_URL}/verified`)).data;
     await this.$watchUntilTruly(() => this.sdk);
+    await this.$watchUntilTruly(() => this.tippingAddress);
     this.minCallFee = calculateFee(TX_TYPES.contractCall, {
       ...this.sdk.Ae.defaults,
       contractId: this.tippingAddress,

--- a/src/popup/router/pages/TipPage.vue
+++ b/src/popup/router/pages/TipPage.vue
@@ -222,6 +222,7 @@ export default {
       this.amountError = this.amountError || !+this.amount || this.amount <= 0;
       this.noteError = !this.note || !this.url;
       this.confirmMode = !this.amountError && !this.noteError && this.validUrl && this.url;
+      if (this.confirmMode) this.editUrl = false;
     },
     async sendTip() {
       const amount = aeToAettos(this.amount);

--- a/src/popup/utils/helper.js
+++ b/src/popup/utils/helper.js
@@ -47,6 +47,11 @@ const convertToAE = balance => +(balance / 10 ** 18).toFixed(7);
 
 const extractHostName = url => new URL(url.includes('://') ? url : `http://${url}`).hostname;
 
+export const validateUrl = url => {
+  const urlRegex = /(https?:\/\/)?([\w-])+\.{1}([a-zA-Z]{2,63})([/\w-]*)*\/?\??([^#\n\r]*)?#?([^\n\r]*)/g;
+  return urlRegex.test(url);
+};
+
 const detectBrowser = () => {
   if ((navigator.userAgent.indexOf('Opera') || navigator.userAgent.indexOf('OPR')) !== -1) {
     return 'Opera';

--- a/tests/e2e/integration/tip.js
+++ b/tests/e2e/integration/tip.js
@@ -1,5 +1,5 @@
-const tip = { amount: 0.01, note: '#test', url: 'localhost:500' };
-const tip2 = { amount: 0.01, note: '#test1234', url: 'localhost:500', onTip: true };
+const tip = { amount: 0.01, note: '#test', url: 'example.com', edit: true };
+const tip2 = { amount: 0.01, note: '#test1234', url: 'example.com', onTip: true, edit: true };
 
 describe('Test cases for tip page', () => {
   beforeEach(() => {
@@ -35,7 +35,7 @@ describe('Test cases for tip page', () => {
   it('Validate tip details', () => {
     cy.openTip()
       .buttonShouldBeDisabled('[data-cy=send-tip]')
-      .enterTipDetails({ url: tip.url })
+      .enterTipDetails({ url: tip.url, edit: true })
       .buttonShouldBeDisabled('[data-cy=send-tip]')
       .enterTipDetails({ amount: tip.amount })
       .buttonShouldBeDisabled('[data-cy=send-tip]')
@@ -49,7 +49,7 @@ describe('Test cases for tip page', () => {
       .buttonShouldBeDisabled('[data-cy=send-tip]')
       .enterTipDetails({ amount: 0, note: tip.note })
       .buttonShouldBeDisabled('[data-cy=send-tip]')
-      .enterTipDetails({ ...tip })
+      .enterTipDetails({ ...tip, edit: false })
       .buttonShouldNotBeDisabled('[data-cy=send-tip]');
   });
 

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -182,7 +182,7 @@ Cypress.Commands.add('openWithdraw', () => {
     .click();
 });
 
-Cypress.Commands.add('enterTipDetails', ({ url = '', amount = null, note = '' }) => {
+Cypress.Commands.add('enterTipDetails', ({ url = '', amount = null, note = '', edit = false }) => {
   cy.get('[data-cy=input-number]').clear();
   if (amount || amount === 0) {
     cy.get('[data-cy=input-number]').type(amount);
@@ -191,14 +191,11 @@ Cypress.Commands.add('enterTipDetails', ({ url = '', amount = null, note = '' })
   cy.get('[data-cy=textarea]').clear();
   if (note) cy.get('[data-cy=textarea]').type(note);
 
+  if (edit) cy.get('[data-cy=edit-url]').click();
   if (url) {
-    cy.get('[data-cy=edit-url]')
-      .click()
-      .get('[data-cy=input]')
+    cy.get('[data-cy=input]')
       .clear()
-      .type(url)
-      .get('[data-cy=confirm-url]')
-      .click();
+      .type(url);
   }
 });
 
@@ -207,17 +204,6 @@ Cypress.Commands.add('toConfirmTip', (tip = {}) => {
   cy.enterTipDetails({ ...tip })
     .buttonShouldNotBeDisabled('[data-cy=send-tip]')
     .get('[data-cy=send-tip]')
-    .click()
-    .get('.confirmtip-modal--footer')
-    .should('be.visible')
-    .get('[data-cy=cancel-tip]')
-    .click()
-    .wait(1000)
-    .get('[data-cy=send-tip]')
-    .click()
-    .get('.confirmtip-modal--footer')
-    .should('be.visible')
-    .get('[data-cy=to-confirm]')
     .click()
     .get('[data-cy=confirm-tip]')
     .should('be.visible')


### PR DESCRIPTION
* Show claim button in mobile but disabled and on click show modal with message
* Add more info in show seed phrase page
* Disable confirm modal when send tip to unverified url until have endpoint returning problematic for claim urls
* Fix of text in edit tip details button
* Show better error message when backend payfortx times out (when claim medium url for instance)
* Remove cofirm url button when manually enter tip url
* Fix problem with showing amount when tx is name claim