### PR TITLE
Fix typo in cache invalidate URL

### DIFF
--- a/src/popup/router/components/ClaimTips.vue
+++ b/src/popup/router/components/ClaimTips.vue
@@ -60,7 +60,7 @@ export default {
                 throw new Error(this.$t('pages.claim.unknownError'));
               else throw new Error(error);
             });
-          await axios.post(`${BACKEND_URL}/cache/invalidate/tip`).catch();
+          await axios.post(`${BACKEND_URL}/cache/invalidate/tips`).catch();
           await axios.post(`${BACKEND_URL}/cache/invalidate/oracle`).catch();
           this.$emit('setLoading', false);
           this.$store.dispatch('modals/open', { name: 'claim-success', url: tab.url, claimAmount });


### PR DESCRIPTION
This was fixed here https://github.com/aeternity/superhero-wallet/commit/2cddd8ac66c7c0e285632fd9756eb527d7441efa, but maybe after merge or conflicts resolved is wrong again