### PR TITLE
Prevent multiple permission request popups for the same url

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -21,8 +21,9 @@ import WalletController from './wallet-controller';
 import Logger from './lib/logger';
 
 const controller = new WalletController();
+const inBackground = window.location.href.includes('_generated_background_page.html');
 
-if (process.env.IS_EXTENSION && require.main.i === module.id) {
+if (process.env.IS_EXTENSION && require.main.i === module.id && inBackground) {
   Logger.init({ background: true });
   RedirectChainNames.init();
 

--- a/src/popup/router/pages/Popups/Connect.vue
+++ b/src/popup/router/pages/Popups/Connect.vue
@@ -3,7 +3,7 @@
     <div class="flex identiconContainer">
       <div class="identicon">
         <img :src="faviconUrl" @error="imageError = true" v-if="!imageError" />
-        <ae-identicon :address="data.host" size="base" v-if="imageError" />
+        <ae-identicon :address="data.host || ''" size="base" v-if="imageError" />
         <div class="accountName" data-cy="name">{{ data.name }}</div>
         <div class="hostname" data-cy="host">{{ data.host }}</div>
       </div>


### PR DESCRIPTION
* Fix problem in Firefox with openning multiple duplicates of connection popup
* Make method shouldOpenPopup with promises
* Get active tabs and remove if there is opened connection popup for url
* Cleanup and refactor