### PR TITLE
Confirm connection to unknown origins

### DIFF
--- a/src/lib/wallet.js
+++ b/src/lib/wallet.js
@@ -99,8 +99,10 @@ export default {
         compilerUrl,
         name: 'Superhero',
         onConnection(client, { accept, deny }, origin) {
-          if (NO_POPUP_AEPPS.includes(extractHostName(origin))) accept();
-          else deny();
+          const isAccept =
+            NO_POPUP_AEPPS.includes(extractHostName(origin)) ||
+            window.confirm(`Allow connection to ${origin}?`);
+          (isAccept ? accept : deny)();
         },
         onSubscription: acceptCb,
         onSign: acceptCb,


### PR DESCRIPTION
I have to add this ugly confirm to be able to test reverse iframe on develop branches. The user won't see it in the production version because there superhero.com is whitelisted.