### PR TITLE
twitter.js: Match only tweet id in tweet link

### DIFF
--- a/src/content-scripts/twitter.js
+++ b/src/content-scripts/twitter.js
@@ -34,7 +34,7 @@ const getTweetId = tweet => {
     return null;
   }
 
-  return status.href.split('/retweets')[0];
+  return status.href.match('.*/status/[0-9]+')[0];
 };
 
 const createSuperheroTipAction = (tweet, tweetId, numActions) => {


### PR DESCRIPTION
Potentially closes #411.
I can't reproduce this issue, but in the case @marc0olo mentioned we should cut part after `/status/numbers/...`, I think this should fix this issue.