### PR TITLE
Enable development flag in devmode

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prettier": "prettier \"src/**/*.{js,vue}\" \"tests/**/*.{js,vue}\"",
     "prettier:write": "npm run prettier -- --write",
     "build": "cross-env NODE_ENV=production webpack --hide-modules",
-    "build:dev": "cross-env NODE_ENV=development webpack --hide-modules",
+    "build:dev": "cross-env NODE_ENV=development webpack --hide-modules -d",
     "build-zip": "node scripts/build-zip.js",
     "watch": "npm run build -- --watch",
     "watch:dev": "cross-env HMR=true npm run build:dev -- --watch",


### PR DESCRIPTION
I propose to use `-d` flag for webpack in dev mode. It's much easier to debug with source-maps.
It turns this
![image](https://user-images.githubusercontent.com/7098449/88263108-d714fd00-cd0c-11ea-87ab-a31a69dde578.png)
to
![image](https://user-images.githubusercontent.com/7098449/88263144-e4ca8280-cd0c-11ea-811c-6b12151374d3.png)
