### PR TITLE
Header: Fix back button

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -25,14 +25,12 @@ Vue.prototype.$watchUntilTruly = function watchUntilTruly(getter) {
   });
 };
 
-(async () => {
-  await registerModals();
-  sync(store, router);
-  new Vue({
-    store,
-    router,
-    i18n,
-    render: h => h(App),
-  }).$mount('#app');
-  Logger.init();
-})();
+registerModals();
+sync(store, router);
+new Vue({
+  store,
+  router,
+  i18n,
+  render: h => h(App),
+}).$mount('#app');
+Logger.init();

--- a/src/popup/router/index.js
+++ b/src/popup/router/index.js
@@ -97,7 +97,7 @@ const deviceReadyPromise = new Promise(resolve =>
 const routerReadyPromise = new Promise(resolve => {
   const unbindAfterEach = router.afterEach(() => {
     resolve();
-    unbindAfterEach();
+    setTimeout(unbindAfterEach);
   });
 });
 

--- a/src/popup/router/modals.js
+++ b/src/popup/router/modals.js
@@ -8,7 +8,7 @@ import ErrorLog from './components/Modals/ErrorLog';
 import ConfirmTransactionSign from './components/Modals/ConfirmTransactionSign';
 import ConfirmRawSign from './components/Modals/ConfirmRawSign';
 
-export default async () => {
+export default () => {
   registerModal({ name: 'default', component: Default });
   registerModal({ name: 'claim-success', component: ClaimSuccess });
   registerModal({ name: 'tip-url-status', component: TipUrlStatus });


### PR DESCRIPTION
In the latest release, we have a bug: if the user opens https://wallet.superhero.com/aboutSettings, then press the back arrow button it will result in the exception:

> TypeError: Cannot read property 'path' of undefined
    at a.back (popup.js:107)
    at He (popup.js:27)
    at SVGSVGElement.r (popup.js:27)
    at SVGSVGElement.i._wrapper (popup.js:27)

This happens because `afterEach` hook registered by `vuex-router-sync` is not getting executed the first time because it is shifted by another unregistered hook. 