### PR TITLE
Use currency symbols instead of abbreviations

### DIFF
--- a/src/popup/router/components/AmountSend.vue
+++ b/src/popup/router/components/AmountSend.vue
@@ -16,7 +16,7 @@
           {{ $t('pages.appVUE.aeid') }}
         </span>
         <span class="f-14 block l-1" data-cy="amount-currency">
-          {{ currentCurrencySymbol + currencyAmount }}
+          {{ formatCurrency(currencyAmount) }}
         </span>
       </div>
       <div class="balance-box">
@@ -25,7 +25,7 @@
           {{ tokenBalance }} {{ $t('pages.appVUE.aeid') }}
         </span>
         <span class="f-14 block l-1" data-cy="balance-currency">
-          {{ currentCurrencySymbol + balanceCurrency }}
+          {{ formatCurrency(balanceCurrency) }}
         </span>
       </div>
     </div>
@@ -43,7 +43,7 @@ export default {
   },
   props: ['amountError', 'value', 'errorMsg'],
   computed: {
-    ...mapGetters(['tokenBalance', 'balanceCurrency', 'currentCurrencySymbol']),
+    ...mapGetters(['tokenBalance', 'balanceCurrency', 'formatCurrency']),
     currencyAmount() {
       return ((this.value || 0) * this.$store.state.current.currencyRate).toFixed(2);
     },

--- a/src/popup/router/components/AmountSend.vue
+++ b/src/popup/router/components/AmountSend.vue
@@ -16,7 +16,7 @@
           {{ $t('pages.appVUE.aeid') }}
         </span>
         <span class="f-14 block l-1" data-cy="amount-currency">
-          {{ currencyAmount }} {{ currentCurrency }}
+          {{ currentCurrencySymbol + currencyAmount }}
         </span>
       </div>
       <div class="balance-box">
@@ -25,7 +25,7 @@
           {{ tokenBalance }} {{ $t('pages.appVUE.aeid') }}
         </span>
         <span class="f-14 block l-1" data-cy="balance-currency">
-          {{ balanceCurrency }} {{ currentCurrency }}
+          {{ currentCurrencySymbol + balanceCurrency }}
         </span>
       </div>
     </div>
@@ -43,7 +43,7 @@ export default {
   },
   props: ['amountError', 'value', 'errorMsg'],
   computed: {
-    ...mapGetters(['tokenBalance', 'balanceCurrency', 'currentCurrency']),
+    ...mapGetters(['tokenBalance', 'balanceCurrency', 'currentCurrencySymbol']),
     currencyAmount() {
       return ((this.value || 0) * this.$store.state.current.currencyRate).toFixed(2);
     },

--- a/src/popup/router/components/BalanceInfo.vue
+++ b/src/popup/router/components/BalanceInfo.vue
@@ -11,8 +11,8 @@
         <span class="approx-sign">~</span>
         <li data-cy="currency-dropdown" class="dropdown-container" :class="dropdown ? 'show' : ''">
           <ae-button data-cy="toggle-currency-dropdown" @click="dropdown = !dropdown">
+            <span class="currency">{{ currentCurrencySymbol }}</span>
             {{ balanceCurrency }}
-            <span class="currency">{{ currentCurrency }}</span>
             <ExpandedAngleArrow />
           </ae-button>
           <ul class="sub-dropdown">
@@ -42,7 +42,7 @@ export default {
   data: () => ({ dropdown: false }),
   computed: {
     ...mapState(['current', 'currencies']),
-    ...mapGetters(['tokenBalance', 'balanceCurrency', 'currentCurrency']),
+    ...mapGetters(['tokenBalance', 'balanceCurrency', 'currentCurrencySymbol']),
   },
   methods: {
     async switchCurrency(currency) {

--- a/src/popup/router/components/BalanceInfo.vue
+++ b/src/popup/router/components/BalanceInfo.vue
@@ -11,8 +11,7 @@
         <span class="approx-sign">~</span>
         <li data-cy="currency-dropdown" class="dropdown-container" :class="dropdown ? 'show' : ''">
           <ae-button data-cy="toggle-currency-dropdown" @click="dropdown = !dropdown">
-            <span class="currency">{{ currentCurrencySymbol }}</span>
-            {{ balanceCurrency }}
+            {{ formatCurrency(balanceCurrency) }}
             <ExpandedAngleArrow />
           </ae-button>
           <ul class="sub-dropdown">
@@ -42,7 +41,7 @@ export default {
   data: () => ({ dropdown: false }),
   computed: {
     ...mapState(['current', 'currencies']),
-    ...mapGetters(['tokenBalance', 'balanceCurrency', 'currentCurrencySymbol']),
+    ...mapGetters(['tokenBalance', 'balanceCurrency', 'formatCurrency']),
   },
   methods: {
     async switchCurrency(currency) {
@@ -65,10 +64,6 @@ export default {
   .approx-sign {
     margin-top: 3px;
     color: $text-color;
-  }
-
-  .currency {
-    color: $white-color;
   }
 
   li {

--- a/src/popup/router/components/InviteItem.vue
+++ b/src/popup/router/components/InviteItem.vue
@@ -3,7 +3,7 @@
     <div class="invite-info">
       <span class="primary">{{ balance }} {{ $t('pages.appVUE.aeid') }}</span>
       <!--eslint-disable vue-i18n/no-raw-text-->
-      ({{ currentCurrencySymbol + (balance * current.currencyRate).toFixed(2) }})
+      ({{ formatCurrency((balance * current.currencyRate).toFixed(2)) }})
       <!--eslint-enable vue-i18n/no-raw-text-->
       <span class="date">{{ createdAt | formatDate }}</span>
     </div>
@@ -41,7 +41,7 @@ export default {
   data: () => ({ topUp: false, topUpAmount: 0, balance: 0 }),
   computed: {
     ...mapState(['sdk', 'current']),
-    ...mapGetters(['currentCurrencySymbol']),
+    ...mapGetters(['formatCurrency']),
     link() {
       const secretKey = Crypto.encodeBase58Check(Buffer.from(this.secretKey, 'hex'));
       return new URL(

--- a/src/popup/router/components/InviteItem.vue
+++ b/src/popup/router/components/InviteItem.vue
@@ -2,10 +2,9 @@
   <div class="invite-row">
     <div class="invite-info">
       <span class="primary">{{ balance }} {{ $t('pages.appVUE.aeid') }}</span>
-      <!--eslint-disable-line vue-i18n/no-raw-text-->
-      ({{ (balance * current.currencyRate).toFixed(2) }}
-      <!--eslint-disable-next-line vue-i18n/no-raw-text-->
-      {{ current.currency.toUpperCase() }})
+      <!--eslint-disable vue-i18n/no-raw-text-->
+      ({{ currentCurrencySymbol + (balance * current.currencyRate).toFixed(2) }})
+      <!--eslint-enable vue-i18n/no-raw-text-->
       <span class="date">{{ createdAt | formatDate }}</span>
     </div>
     <div class="invite-link">
@@ -25,7 +24,7 @@
 </template>
 
 <script>
-import { mapState } from 'vuex';
+import { mapState, mapGetters } from 'vuex';
 import { AmountFormatter, Crypto } from '@aeternity/aepp-sdk/es';
 import AmountSend from './AmountSend';
 import Button from './Button';
@@ -42,6 +41,7 @@ export default {
   data: () => ({ topUp: false, topUpAmount: 0, balance: 0 }),
   computed: {
     ...mapState(['sdk', 'current']),
+    ...mapGetters(['currentCurrencySymbol']),
     link() {
       const secretKey = Crypto.encodeBase58Check(Buffer.from(this.secretKey, 'hex'));
       return new URL(

--- a/src/popup/router/components/TransactionItem.vue
+++ b/src/popup/router/components/TransactionItem.vue
@@ -5,10 +5,9 @@
         <span data-cy="amount">{{ txAmount }}</span>
         {{ $t('pages.appVUE.aeid') }}
         <span class="text" data-cy="currency-amount">
-          <!--eslint-disable-line vue-i18n/no-raw-text-->
-          ({{ txAmountToCurrency }}
-          <!--eslint-disable-next-line vue-i18n/no-raw-text-->
-          {{ current.currency.toUpperCase() }})
+          <!--eslint-disable vue-i18n/no-raw-text-->
+          ({{ currentCurrencySymbol + txAmountToCurrency }})
+          <!--eslint-enable vue-i18n/no-raw-text-->
         </span>
       </span>
       <span class="status">{{ status }}</span>
@@ -62,7 +61,7 @@ export default {
   },
   computed: {
     ...mapState(['sdk', 'current']),
-    ...mapGetters(['account', 'activeNetwork']),
+    ...mapGetters(['account', 'activeNetwork', 'currentCurrencySymbol']),
     status() {
       if (
         this.transaction.tx.sender_id === this.account.publicKey ||

--- a/src/popup/router/components/TransactionItem.vue
+++ b/src/popup/router/components/TransactionItem.vue
@@ -6,7 +6,7 @@
         {{ $t('pages.appVUE.aeid') }}
         <span class="text" data-cy="currency-amount">
           <!--eslint-disable vue-i18n/no-raw-text-->
-          ({{ currentCurrencySymbol + txAmountToCurrency }})
+          ({{ formatCurrency(txAmountToCurrency) }})
           <!--eslint-enable vue-i18n/no-raw-text-->
         </span>
       </span>
@@ -61,7 +61,7 @@ export default {
   },
   computed: {
     ...mapState(['sdk', 'current']),
-    ...mapGetters(['account', 'activeNetwork', 'currentCurrencySymbol']),
+    ...mapGetters(['account', 'activeNetwork', 'formatCurrency']),
     status() {
       if (
         this.transaction.tx.sender_id === this.account.publicKey ||

--- a/src/popup/router/pages/Send.vue
+++ b/src/popup/router/pages/Send.vue
@@ -78,8 +78,7 @@
                 <!--eslint-disable-line vue-i18n/no-raw-text-->
                 ~
                 <span>
-                  {{ (form.amount * current.currencyRate).toFixed(3) }}
-                  {{ current.currency.toUpperCase() }}
+                  {{ currentCurrencySymbol + (form.amount * current.currencyRate).toFixed(3) }}
                 </span>
               </span>
             </div>
@@ -191,7 +190,7 @@ export default {
   },
   computed: {
     ...mapState(['balance', 'current', 'sdk']),
-    ...mapGetters(['account', 'activeNetwork']),
+    ...mapGetters(['account', 'activeNetwork', 'currentCurrencySymbol']),
     validAddress() {
       return checkAddress(this.form.address) || chekAensName(this.form.address);
     },

--- a/src/popup/router/pages/Send.vue
+++ b/src/popup/router/pages/Send.vue
@@ -78,7 +78,7 @@
                 <!--eslint-disable-line vue-i18n/no-raw-text-->
                 ~
                 <span>
-                  {{ currentCurrencySymbol + (form.amount * current.currencyRate).toFixed(3) }}
+                  {{ formatCurrency((form.amount * current.currencyRate).toFixed(3)) }}
                 </span>
               </span>
             </div>
@@ -190,7 +190,7 @@ export default {
   },
   computed: {
     ...mapState(['balance', 'current', 'sdk']),
-    ...mapGetters(['account', 'activeNetwork', 'currentCurrencySymbol']),
+    ...mapGetters(['account', 'activeNetwork', 'formatCurrency']),
     validAddress() {
       return checkAddress(this.form.address) || chekAensName(this.form.address);
     },

--- a/src/popup/router/pages/SuccessTip.vue
+++ b/src/popup/router/pages/SuccessTip.vue
@@ -12,7 +12,7 @@
         >{{ amountTip }} {{ $t('pages.appVUE.aeid') }}
       </span>
       <!--eslint-disable vue-i18n/no-raw-text-->
-      ({{ currentCurrencySymbol + (amountTip * current.currencyRate).toFixed(3) }})
+      ({{ formatCurrency((amountTip * current.currencyRate).toFixed(3)) }})
       <!--eslint-enable vue-i18n/no-raw-text-->
       {{ $t('pages.successTip.to') }}
     </p>
@@ -69,7 +69,7 @@ export default {
   },
   computed: {
     ...mapState(['current']),
-    ...mapGetters(['currentCurrencySymbol']),
+    ...mapGetters(['formatCurrency']),
     amountTip() {
       return (+aettosToAe(this.amount)).toFixed(2);
     },

--- a/src/popup/router/pages/SuccessTip.vue
+++ b/src/popup/router/pages/SuccessTip.vue
@@ -11,9 +11,9 @@
       <span class="secondary-text" data-cy="tip-amount"
         >{{ amountTip }} {{ $t('pages.appVUE.aeid') }}
       </span>
-      <!--eslint-disable-line vue-i18n/no-raw-text-->
-      ({{ (amountTip * current.currencyRate).toFixed(3) }}
-      {{ currentCurrency }})<!--eslint-disable-line vue-i18n/no-raw-text-->
+      <!--eslint-disable vue-i18n/no-raw-text-->
+      ({{ currentCurrencySymbol + (amountTip * current.currencyRate).toFixed(3) }})
+      <!--eslint-enable vue-i18n/no-raw-text-->
       {{ $t('pages.successTip.to') }}
     </p>
     <a class="link-sm text-left block" data-cy="tip-url">{{ tipUrl }}</a>
@@ -69,7 +69,7 @@ export default {
   },
   computed: {
     ...mapState(['current']),
-    ...mapGetters(['currentCurrency']),
+    ...mapGetters(['currentCurrencySymbol']),
     amountTip() {
       return (+aettosToAe(this.amount)).toFixed(2);
     },

--- a/src/popup/router/pages/Tip.vue
+++ b/src/popup/router/pages/Tip.vue
@@ -10,10 +10,9 @@
           <span class="secondary-text" data-cy="tip-amount">
             {{ amount }} {{ $t('pages.appVUE.aeid') }}
           </span>
-          <!--eslint-disable-line vue-i18n/no-raw-text-->
-          ({{ (amount * current.currencyRate).toFixed(3) }}
-          <!--eslint-disable-next-line vue-i18n/no-raw-text-->
-          {{ currentCurrency }})
+          <!--eslint-disable vue-i18n/no-raw-text-->
+          ({{ currentCurrencySymbol + (amount * current.currencyRate).toFixed(3) }})
+          <!--eslint-enable vue-i18n/no-raw-text-->
           {{ $t('pages.tipPage.to') }}
         </template>
       </p>
@@ -114,7 +113,7 @@ export default {
     };
   },
   computed: {
-    ...mapGetters(['account', 'currentCurrency']),
+    ...mapGetters(['account', 'currentCurrencySymbol']),
     ...mapState([
       'tourRunning',
       'tippingAddress',

--- a/src/popup/router/pages/Tip.vue
+++ b/src/popup/router/pages/Tip.vue
@@ -11,7 +11,7 @@
             {{ amount }} {{ $t('pages.appVUE.aeid') }}
           </span>
           <!--eslint-disable vue-i18n/no-raw-text-->
-          ({{ currentCurrencySymbol + (amount * current.currencyRate).toFixed(3) }})
+          ({{ formatCurrency((amount * current.currencyRate).toFixed(3)) }})
           <!--eslint-enable vue-i18n/no-raw-text-->
           {{ $t('pages.tipPage.to') }}
         </template>
@@ -113,7 +113,7 @@ export default {
     };
   },
   computed: {
-    ...mapGetters(['account', 'currentCurrencySymbol']),
+    ...mapGetters(['account', 'formatCurrency']),
     ...mapState([
       'tourRunning',
       'tippingAddress',

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -14,8 +14,14 @@ export default {
   balanceCurrency({ current, balance }) {
     return (current.currencyRate * balance).toFixed(2);
   },
-  currentCurrency({ current }) {
-    return current.currency.toUpperCase();
+  currentCurrencySymbol({ current: { currency } }) {
+    return (
+      {
+        eur: '€',
+        usd: '$',
+        cny: '¥',
+      }[currency] || `${currency.toUpperCase()} `
+    );
   },
   networks({ userNetworks }) {
     return [

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -14,15 +14,8 @@ export default {
   balanceCurrency({ current, balance }) {
     return (current.currencyRate * balance).toFixed(2);
   },
-  currentCurrencySymbol({ current: { currency } }) {
-    return (
-      {
-        eur: '€',
-        usd: '$',
-        cny: '¥',
-      }[currency] || `${currency.toUpperCase()} `
-    );
-  },
+  formatCurrency: ({ current: { currency } }) => value =>
+    new Intl.NumberFormat('en', { style: 'currency', currency }).format(value),
   networks({ userNetworks }) {
     return [
       defaultNetwork,

--- a/tests/e2e/integration/amount-send.js
+++ b/tests/e2e/integration/amount-send.js
@@ -8,11 +8,11 @@ describe('Test cases AmountSend component', () => {
     cy.enterAmountSend(5)
       .get('[data-cy=amount-currency]')
       .invoke('text')
-      .then(text => expect(text).not.to.eq('0.00 USD'))
+      .then(text => expect(text).not.to.eq('$0.00'))
       .enterAmountSend(0)
       .get('[data-cy=amount-currency]')
       .invoke('text')
-      .then(text => expect(text.trim()).to.eq('0.00 USD'));
+      .then(text => expect(text.trim()).to.eq('$0.00'));
   });
 
   it('Validate entered amount', () => {
@@ -33,6 +33,6 @@ describe('Test cases AmountSend component', () => {
       .then(text => expect(text.trim()).to.eq(`${balance.toFixed(2)} AE`))
       .get('[data-cy=balance-currency]', { timeout: 8000 })
       .invoke('text')
-      .then(text => expect(text.trim()).not.to.eq('0.00 USD'));
+      .then(text => expect(text.trim()).not.to.eq('$0.00'));
   });
 });

--- a/tests/e2e/integration/withdraw.js
+++ b/tests/e2e/integration/withdraw.js
@@ -30,7 +30,7 @@ describe('Test cases for Withdraw Page', () => {
       .inputShouldHaveError('[data-cy=input-number]')
       .get('[data-cy=amount-currency]')
       .invoke('text')
-      .then(text => expect(text.trim()).to.eq('0.00 USD'))
+      .then(text => expect(text.trim()).to.eq('$0.00'))
       .enterAmountSend(0)
       .get('[data-cy=input-number]')
       .should('have.class', 'has-error')


### PR DESCRIPTION
inspired by the changes in #466 

#466 introduces currency symbols in several places, having `currentCurrency` getter that is just an uppercased current currency, it is quite easy to introduce currency symbols in the whole application.

I'm proposing to merge this PR firstly and to rebase #466 on the top of it.