### PR TITLE
Remove superhero-button click listener

### DIFF
--- a/src/content-scripts/inject.js
+++ b/src/content-scripts/inject.js
@@ -112,20 +112,6 @@ const runContentScript = () => {
     }
   });
 
-  const setSuperheroButtonClickListener = () =>
-    document.addEventListener('click', event => {
-      if (!event.target.closest('.superhero-button')) return;
-      const link = event.target.closest('a');
-      if (!link) return;
-
-      event.preventDefault();
-      browser.runtime.sendMessage({
-        from: 'content',
-        type: 'openTipPopup',
-        url: link.dataset.url,
-      });
-    });
-
   /**
    * Aex-2 Aepp communication
    */
@@ -151,7 +137,6 @@ const runContentScript = () => {
       });
       const bridge = ContentScriptBridge({ pageConnection, extConnection });
       bridge.run();
-      setSuperheroButtonClickListener();
     }
   }, 10);
 };


### PR DESCRIPTION
The idea is to use deeplinks instead, it may have a worse UI but this is much flexible. This would break the existing superhero-button installations, so I'm not sure when it the best time to merge it.