### PR TITLE
Always use window.open on links inside iframe web wallet

### DIFF
--- a/src/popup/utils/openUrl.js
+++ b/src/popup/utils/openUrl.js
@@ -12,7 +12,7 @@ export default (url, newTab) => {
       });
       break;
     case 'web':
-      if (newTab) {
+      if (newTab || window.parent) {
         window.open(url);
       } else {
         window.location = url;


### PR DESCRIPTION
This quick fix potentially closes #493 as we won't open any links inside iframe web-wallet.