### PR TITLE
Replaced middlewareUrl with explorerUrl

### DIFF
--- a/src/popup/router/components/TransactionItem.vue
+++ b/src/popup/router/components/TransactionItem.vue
@@ -26,7 +26,7 @@
       </span>
       <span
         class="seeTransaction"
-        @click="openUrl(`${activeNetwork.middlewareUrl}/transactions/${transaction.hash}`)"
+        @click="openUrl(`${activeNetwork.explorerUrl}/transactions/${transaction.hash}`)"
       >
         <img src="../../../icons/eye.png" />
       </span>

--- a/src/popup/router/pages/Send.vue
+++ b/src/popup/router/pages/Send.vue
@@ -273,10 +273,10 @@ export default {
       }
     },
     async openTxExplorer(hash) {
-      const { middlewareUrl } = this.activeNetwork;
+      const { explorerUrl } = this.activeNetwork;
       const { endpoint, valid } = await checkHashType(hash);
       if (valid) {
-        const url = `${middlewareUrl}/${endpoint}/${hash}`;
+        const url = `${explorerUrl}/${endpoint}/${hash}`;
         openUrl(url);
       }
     },


### PR DESCRIPTION
Tx preview when clicking the eye icon was leading to the middleware API URL
Instead of the explorer URL (middleware UI) specified in the constants file

Fixes #504