### PR TITLE
cordova ios: Fix compilation error by choosing a different swift version

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -38,6 +38,7 @@
         <splash density="port-xxxhdpi" src="resources/android/splash/drawable-port-xxxhdpi-screen.png" />
     </platform>
     <platform name="ios">
+        <preference name="UseSwiftLanguageVersion" value="4.2" />
         <allow-intent href="itms:*" />
         <allow-intent href="itms-apps:*" />
         <preference name="AllowBackForwardNavigationGestures" value="true" />


### PR DESCRIPTION
Before there was used Swift 4 and the error was:

> 'openSettingsURLString' has been renamed to 'UIApplicationOpenSettingsURLString'

in https://github.com/bitpay/cordova-plugin-qrscanner/blob/b62efb64801ba0b830f0aac556935c0978d2fb98/src/ios/QRScanner.swift#L471

I have faced this error trying to build 0.3.3 release using Xcode 12.0.1