### PR TITLE
hotfix: Open deeplink callbacks in current tab even in iframe use case

### DIFF
--- a/src/popup/router/components/ClaimTipButton.vue
+++ b/src/popup/router/components/ClaimTipButton.vue
@@ -20,7 +20,7 @@ export default {
   },
   methods: {
     openHowToClaimURL() {
-      openUrl(`${AGGREGATOR_URL}create-profile`);
+      openUrl(`${AGGREGATOR_URL}create-profile`, true);
     },
   },
 };

--- a/src/popup/router/components/TransactionItem.vue
+++ b/src/popup/router/components/TransactionItem.vue
@@ -14,7 +14,7 @@
       <span class="time" data-cy="time">{{ transaction.time | formatDate }}</span>
     </div>
     <div class="holder tx-info">
-      <span v-if="tipUrl" class="url" @click="tipUrl && openUrl(tipUrl)">{{ tipUrl }}</span>
+      <span v-if="tipUrl" class="url" @click="tipUrl && openUrl(tipUrl, true)">{{ tipUrl }}</span>
       <span v-else-if="topup" class="address">
         {{ transaction.tx.senderId }}
       </span>
@@ -26,7 +26,7 @@
       </span>
       <span
         class="seeTransaction"
-        @click="openUrl(`${activeNetwork.explorerUrl}/transactions/${transaction.hash}`)"
+        @click="openUrl(`${activeNetwork.explorerUrl}/transactions/${transaction.hash}`, true)"
       >
         <img src="../../../icons/eye.png" />
       </span>

--- a/src/popup/router/pages/Send.vue
+++ b/src/popup/router/pages/Send.vue
@@ -275,7 +275,7 @@ export default {
       const { endpoint, valid } = await checkHashType(hash);
       if (valid) {
         const url = `${explorerUrl}/${endpoint}/${hash}`;
-        openUrl(url);
+        openUrl(url, true);
       }
     },
   },

--- a/src/popup/router/pages/SuccessTip.vue
+++ b/src/popup/router/pages/SuccessTip.vue
@@ -91,7 +91,7 @@ export default {
   },
   methods: {
     redirectOnFeed() {
-      openUrl(AGGREGATOR_URL);
+      openUrl(AGGREGATOR_URL, true);
     },
   },
 };

--- a/src/popup/utils/openUrl.js
+++ b/src/popup/utils/openUrl.js
@@ -12,7 +12,7 @@ export default (url, newTab) => {
       });
       break;
     case 'web':
-      if (newTab || window.parent) {
+      if (newTab) {
         window.open(url);
       } else {
         window.location = url;


### PR DESCRIPTION
reverts #495 

The thing is that window.parent is always truthy:

> If a window does not have a parent, its parent property is a reference to itself.

https://developer.mozilla.org/en-US/docs/Web/API/Window/parent

Would be better to use IN_FRAME the next time. Forcing openUrl to use a new tab in the web version of wallet breaks deeplink flow. To address #493 I'm proposing explicitly specify that the explorer and ui should be opened in a new tab, but keeping the ability to open deeplink in the same tab that is used in Meet.

closes https://github.com/aeternity/jitsi-meet/issues/259