### PR TITLE
Add account on the first init call

### DIFF
--- a/src/lib/rpcWallet.js
+++ b/src/lib/rpcWallet.js
@@ -284,7 +284,7 @@ export default {
         await walletController.getKeypair({ activeAccount: payload.idx, account }),
       ),
     });
-    this.sdk.addAccount(newAccount);
+    this.sdk.addAccount(newAccount, { select: true });
     this.activeAccount = payload.address;
     this.getAccessForAddress(payload.address);
   },
@@ -326,19 +326,19 @@ export default {
     if (!this.nodes[network]) {
       await this.initNodes();
     }
-    if (this.sdk) {
-      try {
-        this.sdk.selectAccount(this.activeAccount);
-      } catch (e) {
-        this[AEX2_METHODS.ADD_ACCOUNT]({ address, idx: 0 });
-      }
-
-      if (this.network !== network) {
-        this.addNewNetwork(network);
-      }
-    } else {
+    if (!this.sdk) {
       this.initNetwork(network);
-      this.initSdk();
+      await this.initSdk();
+    }
+
+    try {
+      this.sdk.selectAccount(this.activeAccount);
+    } catch (e) {
+      this[AEX2_METHODS.ADD_ACCOUNT]({ address, idx: 0 });
+    }
+
+    if (this.network !== network) {
+      await this.addNewNetwork(network);
     }
   },
 };


### PR DESCRIPTION
Without opening the popup, the init function is called only once, and for some reason, it wasn't adding the account in that case. Superhero-ui was detecting the extension but wasn't able to use it because of the lack of an account. This PR is supposed to fix this case.