### PR TITLE
UserAvatar: Don't collapse the image

### DIFF
--- a/src/popup/router/components/UserAvatar.vue
+++ b/src/popup/router/components/UserAvatar.vue
@@ -45,6 +45,7 @@ $lg-size: 64px;
   border-radius: 50%;
   overflow: hidden;
   display: inline-block;
+  object-fit: cover;
 
   &.lg {
     height: $lg-size;


### PR DESCRIPTION
| Before | After |
|---|---|
| <img width="220" alt="Screenshot 2020-10-28 at 09 27 46" src="https://user-images.githubusercontent.com/9007851/97400294-f02adc80-18ff-11eb-802e-b7274dce9702.png"> | <img width="220" alt="Screenshot 2020-10-28 at 09 27 51" src="https://user-images.githubusercontent.com/9007851/97400305-f456fa00-18ff-11eb-87cb-d1fb9ace8508.png"> |

