### PR TITLE
Fallback to empty string if sender is null

### DIFF
--- a/src/popup/router/pages/Notifications.vue
+++ b/src/popup/router/pages/Notifications.vue
@@ -21,7 +21,7 @@
     <NotificationItem
       v-for="notification in filteredNotifications"
       :key="notification.id"
-      :address="notification.sender"
+      :address="notification.sender || ''"
       :name="
         notification.wallet ? notification.title : notification.chainName || 'Fellow Superhero'
       "


### PR DESCRIPTION
Fixes error:

> Invalid prop: type check failed for prop "address". Expected String with value "null", got Null 
found in
---> <UserAvatar> at popup/router/components/UserAvatar.vue
       <NotificationItem> at popup/router/components/NotificationItem.vue
         <Notifications> at popup/router/pages/Notifications.vue
           <AeMain> at src/components/aeMain/aeMain.vue
             <App> at popup/App.vue
               <Root>

When looking at "claimed your retip" notification with has `sender` equal to `null`.

depends on https://github.com/aeternity/superhero-avatars/pull/2