### PR TITLE
Increase auto extend name blocks interval

### DIFF
--- a/src/popup/utils/constants.js
+++ b/src/popup/utils/constants.js
@@ -101,7 +101,7 @@ export const LIMIT_KEY = 'limit';
 export const AENS_DOMAIN = '.chain';
 export const MAX_AUCTION_NAME_LENGTH = 12 + AENS_DOMAIN.length;
 export const MIN_NAME_LENGTH = 14;
-export const AUTO_EXTEND_NAME_BLOCKS_INTERVAL = 100;
+export const AUTO_EXTEND_NAME_BLOCKS_INTERVAL = 17000;
 
 export const BUG_REPORT_URL = 'https://thesuperherowallet.typeform.com/to/vh8Ffu';
 


### PR DESCRIPTION
The current name extend interval is 100 blocks. This means that the wallet will ask to extend names every 5 hours (100 blocks * 3 minutes/block / 60 minutes/hour). This seems to be super frequent, assuming that name is extended for 104 days (50k blocks). We need to find a balance between annoying users with frequent notifications and making less probable the loosing of names by users that open wallet several times in a year. 

Here are my assumptions about when the wallet should remind the user to extend name depending on his activity:

| Average wallet opening interval | Need to remind to extend name after (104 days - opening interval) |
|---|---|
| 1 day | 103 days |
| 1 week | 97 days |
| 1 month | 74 days |
| 2 months | 44 days |
| 3 months | 14 days |
| 4 months | AENS shouldn't be used |

Because of the lack of analytics, we don't know the average wallet opening interval between our users. I'm proposing to set this interval to 34 days (17k blocks, 1/3 of max name ttl) which is much less annoying and probably suitable for most of our users.
