### PR TITLE
Fix Avatar component

### DIFF
--- a/src/popup/router/components/Avatar.vue
+++ b/src/popup/router/components/Avatar.vue
@@ -46,7 +46,8 @@ $lg-size: 64px;
   border-radius: 50%;
   overflow: hidden;
   display: inline-block;
-  object-fit: scale-down;
+  object-fit: cover;
+  flex-shrink: 0;
 
   &.lg {
     height: $lg-size;


### PR DESCRIPTION
| Before | After |
|---|---|
| Not rounded corners | Normal |
| <img width="305" alt="Screenshot 2020-11-22 at 22 44 00" src="https://user-images.githubusercontent.com/9007851/99915357-44b15400-2d14-11eb-8da0-3c4843724d1b.png">| <img width="305" alt="Screenshot 2020-11-22 at 22 43 55" src="https://user-images.githubusercontent.com/9007851/99915360-467b1780-2d14-11eb-9b10-96bb67f45e83.png">  |
| Shrinked | Normal |
| <img width="338" alt="Screenshot 2020-11-22 at 22 41 27" src="https://user-images.githubusercontent.com/9007851/99915381-627eb900-2d14-11eb-9a2c-9809a0f241d7.png"> | <img width="338" alt="Screenshot 2020-11-22 at 22 41 32" src="https://user-images.githubusercontent.com/9007851/99915361-4713ae00-2d14-11eb-9840-5bc54221f09f.png"> |

Stan has changed Avatar's `object-fit` to `scale-down` for an [unknown reason](https://github.com/aeternity/superhero-wallet/commit/646f37321d1ef2e67b4fe45b04fd9cf348431bc8#diff-68c702f9f374859bd82baf6c6278fed4f219edbc1a17150ac08f7516f1d6c098R49). I'm guessing that Avatar was looking broken because of shrinking in a TokenListItem's flexbox. To fix this is more reasonable to disallow shrinking that I'm proposing to do in this PR.

related PRs: #572, #519 



