### PR TITLE
Revert "popup: Remove extra wrapper around unwatch"

### DIFF
--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -17,7 +17,7 @@ Vue.prototype.$watchUntilTruly = function watchUntilTruly(getter) {
       (value) => {
         if (!value) return;
         resolve();
-        defer(unwatch);
+        defer(() => unwatch());
       },
       { immediate: true },
     );


### PR DESCRIPTION
This reverts commit d06afa2c4c1d00bda9f9ed2d21a7ecc763578bb6.

This fixes the error on "Send Tip" screen:

> logger.js?45e3:15 callback for immediate watcher "function () {
                return _this.sdk;
              }"
logger.js?45e3:16 TypeError: Expected a function
    at baseDelay (_baseDelay.js?5a79:16)
    at eval (defer.js?d7ab:23)
    at apply (_apply.js?9943:15)
    at eval (_overRest.js?6c13:32)
    at VueComponent._this.$watch.immediate (popup.js?4eca:22)
    at VueComponent.Vue.$watch (vue.runtime.esm.js?e832:4949)
    at eval (popup.js?4eca:16)
    at new Promise (<anonymous>)
    at VueComponent.watchUntilTruly [as $watchUntilTruly] (popup.js?4eca:14)
    at _callee$ (Tip.vue?fe7f:175)

The wrapping function is necessary because, in the case of the immediate, watcher is called in sync, earlier than `unwatch` value is evaluated. `defer` function gets `undefined` instead of the unwatch function and throws the exception. Wrapping it with an arrow function will access a correct `unwatch` value from the closure.

For the reference, the `defer` is needed because the removing handler running in sync breaks the internal Vue's handlers array and the next handler may be omitted that may look a super unobvious bug.