### PR TITLE
persistState: Explicitly mark that cloneDeep hack is needed for Firefox

### DIFF
--- a/src/store/plugins/persistState.js
+++ b/src/store/plugins/persistState.js
@@ -1,10 +1,10 @@
 import { cloneDeep } from 'lodash-es';
+import { detect } from 'detect-browser';
 
 const KEY = 'state';
 
-const setState = async (state) => {
-  await browser.storage.local.set({ [KEY]: cloneDeep(state) });
-};
+const setState = (state) =>
+  browser.storage.local.set({ [KEY]: detect().name === 'firefox' ? cloneDeep(state) : state });
 
 export const getState = async () => (await browser.storage.local.get(KEY))[KEY];
 


### PR DESCRIPTION
Hack explanation that was missed in https://github.com/aeternity/superhero-wallet/pull/108#discussion_r462054888:

> It's generally not possible to store other types, such as Function, Date, RegExp, Set, Map, ArrayBuffer, and so on. Some of these unsupported types will restore as an empty object, and some cause set() to throw an error.

https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/set

I assume that `cloneDeep` converts reactive vue variables to plain objects that become compatible with Firefox's storage.