### PR TITLE
ImportAccount: Show only Loading component on loading

### DIFF
--- a/src/popup/router/pages/ImportAccount.vue
+++ b/src/popup/router/pages/ImportAccount.vue
@@ -1,16 +1,18 @@
 <template>
   <div class="popup">
-    <p class="regular-text">{{ $t('pages.index.enterSeedPhrase') }}</p>
-    <Textarea v-model="mnemonic" :error="errorMsg ? true : false" />
-    <Button
-      @click="importAccount"
-      :disabled="mnemonic && !disabled ? false : true"
-      data-cy="import"
-    >
-      {{ $t('pages.index.importAccount') }}
-    </Button>
-    <div v-if="errorMsg" class="error-msg" v-html="errorMsg"></div>
     <Loader v-if="loading" type="none" />
+    <template v-else>
+      <p class="regular-text">{{ $t('pages.index.enterSeedPhrase') }}</p>
+      <Textarea v-model="mnemonic" :error="errorMsg ? true : false" />
+      <Button
+        @click="importAccount"
+        :disabled="mnemonic && !disabled ? false : true"
+        data-cy="import"
+      >
+        {{ $t('pages.index.importAccount') }}
+      </Button>
+      <div v-if="errorMsg" class="error-msg" v-html="errorMsg"></div>
+    </template>
   </div>
 </template>
 


### PR DESCRIPTION
I propose to change behaviour of loading in the ImportAccount page
|Before|After|
|---|---|
|![impot](https://user-images.githubusercontent.com/9008074/101346431-3ea2a200-38d4-11eb-8733-b8ec1609990e.gif)|![import2](https://user-images.githubusercontent.com/9008074/101346571-7873a880-38d4-11eb-92dc-9f82be9c9f29.png)|