### PR TITLE
Fix sdk of wallet in reverse frame

### DIFF
--- a/src/lib/wallet.js
+++ b/src/lib/wallet.js
@@ -88,7 +88,7 @@ async function getKeyPair() {
 let initSdkRunning = false;
 
 if (IN_FRAME) {
-  store.registerModule('sdk', {
+  store.registerModule('sdk-frame-reset', {
     actions: {
       async reset({ sdk }) {
         const { clients } = sdk.getClients();


### PR DESCRIPTION
Fixer error:
> [vuex] state field "sdk" was overridden by a module with the same name at "sdk"

The overlapping of `state.sdk` variable and `sdk` module is completely breaks sdk in iframe mode.