### PR TITLE
wallet.js: Affect args to make it inserted into function

### DIFF
--- a/src/background/wallet.js
+++ b/src/background/wallet.js
@@ -74,7 +74,7 @@ export default {
           },
           async address(...args) {
             const address = store.state.account.publicKey;
-            const app = args[args.length - 1];
+            const app = args.pop();
             if (
               app instanceof App &&
               !(await store.dispatch('permissions/requestAddressForHost', {

--- a/src/lib/wallet.js
+++ b/src/lib/wallet.js
@@ -173,7 +173,7 @@ export default {
           },
           async address(...args) {
             const address = store.state.account.publicKey;
-            const app = args[args.length - 1];
+            const app = args.pop();
             if (app instanceof App) {
               const { host, hostname, protocol } = app.host;
               if (


### PR DESCRIPTION
This is an interesting bug(?) related to how babel transpile await functions https://github.com/babel/babel/issues/4219.

As I understand, if you spread `...args` in async function it will only be inserted if it is used somehow inside. That's strange, because we had getting last element of args array `args[args.length - 1]`, but transpiler hasn't inserted it, so when I've changed it to `args.pop()` it worked 🤷.

Because of this bug `address` permissions weren't working correctly, so I propose to include it to release if it pass @davidyuk review.