### PR TITLE
permissions.js: Add try/catch for iframe connection popup

### DIFF
--- a/src/store/modules/permissions.js
+++ b/src/store/modules/permissions.js
@@ -78,11 +78,14 @@ export default {
     async requestAddressForHost({ state, commit, dispatch }, { host, address, connectionPopupCb }) {
       if (state[host]?.addresses?.includes(address)) return true;
 
-      if (
-        !(await dispatch('checkPermissions', { host, method: 'connection.open' })) &&
-        !(await connectionPopupCb())
-      )
+      try {
+        if (!(await dispatch('checkPermissions', { host, method: 'connection.open' }))) {
+          const cp = await connectionPopupCb();
+          if (cp !== undefined && !cp) return false;
+        }
+      } catch {
         return false;
+      }
       commit('addAddressToHost', { host, address });
 
       return true;


### PR DESCRIPTION
This fixes missed bug with iframe permissions with checking the result of address request popup. Extension popup returns `true` or `false` depends on user choice, but iframe popup returns `undefined` and it should be handled with try/catch.