### PR TITLE
Fix sufficient balance check

### DIFF
--- a/src/popup/router/pages/Retip.vue
+++ b/src/popup/router/pages/Retip.vue
@@ -84,7 +84,7 @@ export default {
         if (
           this.selectedToken
             ? +this.selectedToken.convertedBalance < +this.amount || this.balance < fee
-            : this.balance < fee + +this.amount
+            : this.balance < +fee + +this.amount
         ) {
           return { error: true, msg: this.$t('pages.tipPage.insufficientBalance') };
         }

--- a/src/popup/router/pages/Tip.vue
+++ b/src/popup/router/pages/Tip.vue
@@ -143,7 +143,7 @@ export default {
         if (
           this.selectedToken
             ? +this.selectedToken.convertedBalance < +this.amount || this.balance < fee
-            : this.balance < fee + +this.amount
+            : this.balance < +fee + +this.amount
         ) {
           return { error: true, msg: this.$t('pages.tipPage.insufficientBalance') };
         }


### PR DESCRIPTION
fixes #773

Notes: 
* The transaction fee is a `BigNumber` and is coerced to a `String` which is then concatenated with the amount which is also converted to a `String`.
* Ex: Fee is `0.00045962`, amount is `5555` and the sum is `0.000459625555`. When it is checked against the account holdings for sufficiency the result is incorrect.