### PR TITLE
Don't display scrollbar on blink and webkit engines

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -13,8 +13,7 @@
 @import './variables';
 
 ::-webkit-scrollbar {
-  width: 1px;
-  background-color: transparent;
+  display: none;
 }
 
 ::-webkit-scrollbar-thumb {


### PR DESCRIPTION
I've decided to move this fix out of notifications PR because it affects other screens.
It fixes issue mentioned by @CedrikNikita in first gif here https://github.com/aeternity/superhero-wallet/pull/716#pullrequestreview-573009116
Because of this issue notifications, activity, names, terms of use, privacy policy (maybe more) screens were moving left a little bit because of 1px width transparent (😆) scrollbar appearance.