### PR TITLE
ci: don't use deprecated short sha

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,7 @@ jobs:
           REMOTE_USER: root
           REMOTE_PORT: 2022
           TARGET: ${{ format('/data/{0}/{1}', env.APP_NAME, env.GITHUB_REF_SLUG_URL) }}
-      - uses: unsplash/comment-on-pr@85a56be
+      - uses: unsplash/comment-on-pr@85a56be792d927ac4bfa2f4326607d38e80e6e60
         if: github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
> On February 15th, GitHub Actions will remove support for referencing actions using the shortened version of a git commit SHA. This may cause some workflows in your repository to break. To fix these workflows, you will need to update the action reference to use the full commit SHA.