### PR TITLE
Run commitlint from first valid commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lint:vue": "eslint --ext .js,.vue src tests",
     "lint:css": "stylelint src/**/*.{css,scss,vue}",
-    "lint:commit": "commitlint --from develop --verbose",
+    "lint:commit": "commitlint --from 151392b0 --verbose",
     "lint": "npm run lint:commit && npm run lint:vue && npm run lint:css",
     "prettier": "prettier \"src/**/*.{js,vue}\" \"tests/**/*.{js,vue}\"",
     "prettier:write": "npm run prettier -- --write",


### PR DESCRIPTION
https://github.com/aeternity/superhero-wallet/pull/775/commits/8cd9d2b100e2b513426cbe97de6c14fb9519dc2e

Start using commit lint from first valid commit.

Moving this commit directly to develop instead the release branch, so CI does not break until we've released 0.5.1.

Thanks @etharner !