### PR TITLE
fix(global): revert scrollbar width until rebranding

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -13,7 +13,8 @@
 @import './variables';
 
 ::-webkit-scrollbar {
-  display: none;
+  width: 1px;
+  background-color: transparent;
 }
 
 ::-webkit-scrollbar-thumb {


### PR DESCRIPTION
I propose to revert 7755be64 because it 
1) prevents scrolling in extension in Chrome
2) we have new scrollbar designs