### PR TITLE
names: Handle the default name responce correctly

### DIFF
--- a/src/store/plugins/names.js
+++ b/src/store/plugins/names.js
@@ -106,7 +106,9 @@ export default (store) => {
         }
         const { preferredChainName: defaultNameBackend } = await fetchJson(
           `${activeNetwork.backendUrl}/profile/${account.publicKey}`,
-        ).catch(() => {});
+        ).catch(() => {
+          return {};
+        });
         if (!claimed.includes(defaultNameBackend)) {
           await dispatch('setDefault', { address: account.publicKey, name: claimed[0] });
           return;


### PR DESCRIPTION
fixes this issue
```
Uncaught (in promise) TypeError: Cannot read property 'preferredChainName' of undefined
    at _callee$ (names.js?2510:107)
    at tryCatch (vue-tour.umd.js?1415:1940)
    at Generator.invoke [as _invoke] (vue-tour.umd.js?1415:2166)
    at Generator.prototype.<computed> [as next] (vue-tour.umd.js?1415:1992)
    at asyncGeneratorStep (names.js:61)
    at _next (names.js:63)
```
![image](https://user-images.githubusercontent.com/9008074/106716397-1f14c500-664a-11eb-8571-c7c4012bc5b5.png)
