### PR TITLE
Tip shared URL on iOS/Android

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6620,6 +6620,52 @@
       "resolved": "https://registry.npmjs.org/cordova-plugin-inappbrowser/-/cordova-plugin-inappbrowser-4.1.0.tgz",
       "integrity": "sha512-jPvcwDx2/L5ZbVG69NT2xmlG1E+MljRxkdsFpgj/5aoaF4oPqxg44J/bYxJNWgQtGnRSRWoqCRmU7FgmmMNMxA=="
     },
+    "cordova-plugin-openwith": {
+      "version": "git+https://github.com/aeternity/cordova-plugin-openwith.git#f60c21ef8b69db0b11d684584c3c900f5ddeb535",
+      "from": "git+https://github.com/aeternity/cordova-plugin-openwith.git",
+      "dev": true,
+      "requires": {
+        "file-system": "^2.2.2",
+        "path": "^0.12.7",
+        "plist": "^2.1.0",
+        "xcode": "2.0.0"
+      },
+      "dependencies": {
+        "base64-js": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.0.tgz",
+          "integrity": "sha1-o5mS1yNYSBGYK+XikLtqU9hnAPE=",
+          "dev": true
+        },
+        "plist": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/plist/-/plist-2.1.0.tgz",
+          "integrity": "sha1-V8zbeggh3yGDEhejytVOPhRqECU=",
+          "dev": true,
+          "requires": {
+            "base64-js": "1.2.0",
+            "xmlbuilder": "8.2.2",
+            "xmldom": "0.1.x"
+          }
+        },
+        "xcode": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/xcode/-/xcode-2.0.0.tgz",
+          "integrity": "sha512-5xF6RCjAdDEiEsbbZaS/gBRt3jZ/177otZcpoLCjGN/u1LrfgH7/Sgeeavpr/jELpyDqN2im3AKosl2G2W8hfw==",
+          "dev": true,
+          "requires": {
+            "simple-plist": "^1.0.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "xmlbuilder": {
+          "version": "8.2.2",
+          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+          "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
+          "dev": true
+        }
+      }
+    },
     "cordova-plugin-qrscanner": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/cordova-plugin-qrscanner/-/cordova-plugin-qrscanner-3.0.1.tgz",
@@ -9126,6 +9172,25 @@
             "ajv-keywords": "^3.5.2"
           }
         }
+      }
+    },
+    "file-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/file-match/-/file-match-1.0.2.tgz",
+      "integrity": "sha1-ycrSZdLIrfOoFHWw30dYWQafrvc=",
+      "dev": true,
+      "requires": {
+        "utils-extend": "^1.0.6"
+      }
+    },
+    "file-system": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/file-system/-/file-system-2.2.2.tgz",
+      "integrity": "sha1-fWWDPjojR9zZVqgTxncVPtPt2Yc=",
+      "dev": true,
+      "requires": {
+        "file-match": "^1.0.1",
+        "utils-extend": "^1.0.4"
       }
     },
     "file-uri-to-path": {
@@ -20055,6 +20120,12 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/utila/-/utila-0.4.0.tgz",
       "integrity": "sha1-ihagXURWV6Oupe7MWxKk+lN5dyw=",
+      "dev": true
+    },
+    "utils-extend": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/utils-extend/-/utils-extend-1.0.8.tgz",
+      "integrity": "sha1-zP17ZFQPjpDuIe7Fd2nQZRyril8=",
       "dev": true
     },
     "utils-merge": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "clean-webpack-plugin": "^3.0.0",
     "copy-webpack-plugin": "^6.4.1",
     "cordova": "^10.0.0",
+    "cordova-plugin-openwith": "git+https://github.com/aeternity/cordova-plugin-openwith.git",
     "cordova-plugin-whitelist": "^1.3.4",
     "cordova-res": "^0.15.2",
     "core-js": "^3.8.2",
@@ -131,7 +132,12 @@
         "URL_SCHEME": "superhero",
         "DEEPLINK_HOST": "wallet.superhero.com"
       },
-      "cordova-plugin-qrscanner": {}
+      "cordova-plugin-qrscanner": {},
+      "cordova-plugin-openwith": {
+        "IOS_URL_SCHEME": "hf938wofijfjhsdlsf23",
+        "IOS_BUNDLE_IDENTIFIER": "com.superhero.cordova",
+        "DISPLAY_NAME": "Superhero"
+      }
     },
     "platforms": [
       "android",

--- a/src/popup/locales/en.json
+++ b/src/popup/locales/en.json
@@ -168,7 +168,11 @@
       "cameraNotAllowed": "ERROR: you need to grant camera access permisson"
     },
     "cancel": "Cancel",
-    "confirm": "Confirm"
+    "confirm": "Confirm",
+    "mobile-share-error": {
+      "title": "Only URLs can be tipped at the moment!",
+      "msg": "More options are currently being developed - coming to you soon!"
+    }
   },
   "transaction": {
     "type": {

--- a/src/popup/router/index.js
+++ b/src/popup/router/index.js
@@ -7,6 +7,7 @@ import 'vue-tour/dist/vue-tour.css';
 import routes from './routes';
 import '@aeternity/aepp-components-3/dist/aepp.components.css';
 import LoaderComponent from './components/Loader';
+import { i18n } from '../../store/plugins/languages';
 
 import * as helper from '../utils/helper';
 import store from '../../store';
@@ -104,6 +105,16 @@ if (process.env.PLATFORM === 'cordova') {
         window.location = `#/${url.slice(prefix.length)}`;
       } catch (error) {
         if (error.name !== 'NavigationDuplicated') throw error;
+      }
+    });
+
+    window.cordova.openwith.init();
+    window.cordova.openwith.addHandler((intent) => {
+      const url = intent.items.find(({ type }) => type.includes('url'))?.data;
+      if (url) {
+        router.push({ name: 'tip', params: { tipUrl: url } });
+      } else {
+        store.dispatch('modals/open', { name: 'default', ...i18n.t('modals.mobile-share-error') });
       }
     });
   })();

--- a/src/popup/router/pages/Tip.vue
+++ b/src/popup/router/pages/Tip.vue
@@ -87,6 +87,7 @@ export default {
     TokenAmount,
     BalanceInfo,
   },
+  props: { tipUrl: String },
   data() {
     return {
       url: null,
@@ -188,6 +189,7 @@ export default {
         await browser.storage.local.remove('last-path');
       }
     }
+    if (this.$props.tipUrl) this.url = this.$props.tipUrl;
   },
   methods: {
     async persistTipDetails() {

--- a/src/popup/router/routes/index.js
+++ b/src/popup/router/routes/index.js
@@ -168,6 +168,7 @@ export default [
     path: '/tip',
     name: 'tip',
     component: Tip,
+    props: true,
     meta: {
       title: 'send-tips',
     },


### PR DESCRIPTION
fixes #260

change log:
* forked a patched fork of `cordova-plugin-openwith` and adjusted hardcoded config to support only text sharing
* added URL prop to Tip page
* route to Tip page with URL prefilled on share intent

dev notes:
* run `cordova prepare` to init the new plugin for iOS/Android

screenshots:
<img src="https://user-images.githubusercontent.com/482351/107229849-fc5a2600-6a26-11eb-9a61-43f0eb2a94ba.png" alt="" title="" width="340" />

<img src="https://user-images.githubusercontent.com/482351/107229851-fe23e980-6a26-11eb-8036-1706b259a719.png" alt="" title="" width="340" />
