### PR TITLE
Bump to 0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.5.2](https://github.com/aeternity/superhero-wallet/compare/v0.5.1...v0.5.2) (2021-02-08)
+
+
+### Features
+
+* **changelog:**  add sections ([ff062cf](https://github.com/aeternity/superhero-wallet/commit/ff062cf7fd52c4e5155b6ce9e6d9b6df58c11a3f))
+* **mobile:** tip shared url ([865302b](https://github.com/aeternity/superhero-wallet/commit/865302bc54632d4aea77208931d1d801e736e3a8))
+
+
+### Maintenance
+
+* **lint:** setup pre-commit hook ([686ee0c](https://github.com/aeternity/superhero-wallet/commit/686ee0cdd1772b31d9df961020810a5b4059abef))
+
 ### [0.5.1](https://github.com/aeternity/superhero-wallet/compare/v0.5.0...v0.5.1) (2021-01-22)
 
 

--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<widget id="com.superhero.cordova" version="0.5.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="com.superhero.cordova" version="0.5.2" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Superhero</name>
     <description>Superhero wallet</description>
     <author email="dev@cordova.apache.org" href="http://cordova.io">

--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="utf-8"?>
-<widget id="com.superhero.cordova" version="0.5.2" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<?xml version='1.0' encoding='utf-8'?>
+<widget id="com.superhero.cordova" version="0.5.4" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Superhero</name>
     <description>Superhero wallet</description>
     <author email="dev@cordova.apache.org" href="http://cordova.io">

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "superhero-wallet",
-  "version": "0.5.2",
+  "version": "0.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6621,7 +6621,7 @@
       "integrity": "sha512-jPvcwDx2/L5ZbVG69NT2xmlG1E+MljRxkdsFpgj/5aoaF4oPqxg44J/bYxJNWgQtGnRSRWoqCRmU7FgmmMNMxA=="
     },
     "cordova-plugin-openwith": {
-      "version": "git+https://github.com/aeternity/cordova-plugin-openwith.git#f60c21ef8b69db0b11d684584c3c900f5ddeb535",
+      "version": "git+https://github.com/aeternity/cordova-plugin-openwith.git#2901de37137f08cea7dc76c4ac077fe47a318dae",
       "from": "git+https://github.com/aeternity/cordova-plugin-openwith.git",
       "dev": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "superhero-wallet",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superhero-wallet",
-  "version": "0.5.2",
+  "version": "0.5.4",
   "description": "Superhero wallet",
   "author": "Superhero",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superhero-wallet",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Superhero wallet",
   "author": "Superhero",
   "license": "MIT",


### PR DESCRIPTION
This was required because of some faulty builds in Apple's TestFlight. It does not allow replacing builds, so we needed to bump up the version number.