### PR TITLE
Improve truncating of a long strings

### DIFF
--- a/src/popup/router/components/AccountInfo.vue
+++ b/src/popup/router/components/AccountInfo.vue
@@ -3,9 +3,11 @@
     <div class="title">
       <div class="account-name" data-cy="account-name">
         <Avatar :address="account.publicKey" :name="account.name" class="avatar" size="small" />
-        <span class="chainname" v-if="activeAccountName.includes('.chain')">{{
-          ellipseStringMid(activeAccountName, 30)
-        }}</span>
+        <TruncateMid
+          v-if="activeAccountName.includes('.chain')"
+          :str="activeAccountName"
+          class="chainname"
+        />
         <router-link class="claim-chainname" to="/names" v-else
           >{{ $t('pages.account.claim-name') }}
         </router-link>
@@ -21,17 +23,16 @@
 
 <script>
 import { mapGetters } from 'vuex';
-import { ellipseStringMid } from '../../utils/helper';
 import Avatar from './Avatar';
+import TruncateMid from './TruncateMid';
 
 export default {
-  components: { Avatar },
+  components: { Avatar, TruncateMid },
   data: () => ({
     copied: false,
   }),
   computed: mapGetters(['account', 'activeAccountName']),
   methods: {
-    ellipseStringMid,
     copy() {
       this.copied = true;
       setTimeout(() => {
@@ -75,8 +76,7 @@ export default {
       }
 
       .chainname {
-        overflow: scroll;
-        scrollbar-width: none;
+        width: 230px;
       }
 
       .avatar {

--- a/src/popup/router/components/FungibleTokens/TokensListItem.vue
+++ b/src/popup/router/components/FungibleTokens/TokensListItem.vue
@@ -13,9 +13,7 @@
     />
     <div class="details">
       <div>
-        <div class="title text-ellipsis" :title="tokenData.name">
-          {{ ellipseStringMid(tokenData.name, 30) }}
-        </div>
+        <TruncateMid :str="tokenData.name" />
         <div>
           <label>{{ $t('pages.fungible-tokens.mcap') }}</label>
           {{
@@ -42,18 +40,17 @@
 
 <script>
 import { mapGetters } from 'vuex';
-import { ellipseStringMid } from '../../../utils/helper';
 import Avatar from '../Avatar';
+import TruncateMid from '../TruncateMid';
 import TokenAmount from '../TokenAmount';
 
 export default {
-  components: { Avatar, TokenAmount },
+  components: { Avatar, TruncateMid, TokenAmount },
   props: {
     tokenData: Object,
     name: String,
   },
   computed: mapGetters(['formatCurrency']),
-  methods: { ellipseStringMid },
 };
 </script>
 
@@ -77,6 +74,10 @@ export default {
   .details {
     margin-left: 7px;
     flex-grow: 1;
+
+    .truncate-mid {
+      max-width: 215px;
+    }
 
     > div {
       display: flex;

--- a/src/popup/router/components/Header.vue
+++ b/src/popup/router/components/Header.vue
@@ -4,9 +4,10 @@
       <Arrow v-if="title && !tourRunning" @click="back" class="back-arrow" data-cy="back-arrow" />
       <Logo :class="$route.path === '/intro' && !isLoggedIn ? 'intro_style' : ''" v-else />
 
-      <div class="title">
-        {{ pageTitle || (title && $t(`pages.titles.${title}`)) || $t('pages.titles.home') }}
-      </div>
+      <TruncateMid
+        :str="pageTitle || (title && $t(`pages.titles.${title}`)) || $t('pages.titles.home')"
+        class="title"
+      />
 
       <div v-if="isLoggedIn">
         <Settings
@@ -37,9 +38,10 @@ import Bell from '../../../icons/bell.svg?vue-component';
 import Hamburger from '../../../icons/hamburger.svg?vue-component';
 import Logo from '../../../icons/logo-small.svg?vue-component';
 import Settings from '../../../icons/settings.svg?vue-component';
+import TruncateMid from './TruncateMid';
 
 export default {
-  components: { Arrow, Bell, Hamburger, Logo, Settings },
+  components: { Arrow, Bell, Hamburger, Logo, Settings, TruncateMid },
   data: () => ({
     aeppPopup: window.RUNNING_IN_POPUP,
   }),
@@ -113,6 +115,8 @@ export default {
 
     .title {
       font-size: 16px;
+      margin: 0 auto;
+      max-width: 185px;
     }
 
     &:not(.isLoggedIn) .title {

--- a/src/popup/router/components/SidebarMenu.vue
+++ b/src/popup/router/components/SidebarMenu.vue
@@ -9,7 +9,7 @@
         <div class="ml-8">
           <div class="f-14">{{ $t('mainAccount') }}</div>
           <div class="f-12" v-if="activeAccountName.includes('.chain')" data-cy="chain-name">
-            {{ activeAccountName }}
+            <TruncateMid :str="activeAccountName" />
           </div>
         </div>
       </div>
@@ -91,9 +91,10 @@ import { mapGetters } from 'vuex';
 import Close from '../../../icons/close.svg?vue-component';
 import Arrow from '../../../icons/arrow-current-color.svg?vue-component';
 import Avatar from './Avatar';
+import TruncateMid from './TruncateMid';
 
 export default {
-  components: { Close, Arrow, Avatar },
+  components: { Close, Arrow, Avatar, TruncateMid },
   computed: mapGetters(['account', 'activeAccountName']),
   data: () => ({ showSettingsDropdown: false }),
   methods: {
@@ -116,7 +117,6 @@ export default {
 
 .sidebar-menu {
   position: fixed;
-  min-width: 200px;
   right: 0;
   top: 0;
   bottom: 0;
@@ -211,6 +211,10 @@ export default {
 
   .account-icon-holder {
     padding: 0.5rem 1rem 20px 1rem;
+
+    .flex .ml-8 {
+      max-width: 110px;
+    }
   }
 }
 </style>

--- a/src/popup/router/components/TruncateMid.vue
+++ b/src/popup/router/components/TruncateMid.vue
@@ -1,0 +1,39 @@
+<template>
+  <span
+    :data-content-start="str.substr(0, str.length / 2)"
+    :data-content-end="str.substr(str.length / 2)"
+    class="truncate-mid"
+  />
+</template>
+
+<script>
+export default {
+  props: {
+    str: { type: String, required: true },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+.truncate-mid {
+  white-space: nowrap;
+
+  &::before,
+  &::after {
+    display: inline-block;
+    max-width: 50%;
+    overflow: hidden;
+    white-space: pre;
+  }
+
+  &::before {
+    content: attr(data-content-start);
+    text-overflow: ellipsis;
+  }
+
+  &::after {
+    content: attr(data-content-end);
+    direction: rtl;
+  }
+}
+</style>

--- a/src/popup/router/pages/FungibleTokens/TokenDetails.vue
+++ b/src/popup/router/pages/FungibleTokens/TokenDetails.vue
@@ -62,7 +62,6 @@
 <script>
 import { pick } from 'lodash-es';
 import { mapGetters, mapState } from 'vuex';
-import { ellipseStringMid } from '../../../utils/helper';
 import TabsMenu from '../../components/TabsMenu';
 import Avatar from '../../components/Avatar';
 import TokenAmount from '../../components/TokenAmount';
@@ -95,10 +94,7 @@ export default {
     return pick(this.$store.state.observables, ['tokenBalance', 'balanceCurrency']);
   },
   created() {
-    this.$store.commit(
-      'setPageTitle',
-      this.fungibleToken ? ellipseStringMid(this.fungibleToken.name, 22) : 'Aeternity',
-    );
+    this.$store.commit('setPageTitle', this.fungibleToken ? this.fungibleToken.name : 'Aeternity');
   },
   computed: {
     ...mapGetters(['tippingSupported', 'formatCurrency']),

--- a/src/popup/router/pages/Names/List.vue
+++ b/src/popup/router/pages/Names/List.vue
@@ -9,7 +9,7 @@
         :name="name"
         :address="owner"
       >
-        <span class="name">{{ ellipseStringMid(name, 30) }}</span>
+        <TruncateMid :str="name" class="name" />
         <Badge v-if="activeAccountName == name" class="active-name">
           {{ $t('pages.names.default') }}
         </Badge>
@@ -36,20 +36,17 @@
 
 <script>
 import { mapState, mapGetters } from 'vuex';
-import { ellipseStringMid } from '../../../utils/helper';
 import NameListHeader from '../../components/NameListHeader';
 import Badge from '../../components/Badge';
 import NameRow from '../../components/NameRow';
+import TruncateMid from '../../components/TruncateMid';
 import CheckBox from '../../components/CheckBox';
 
 export default {
-  components: { NameListHeader, Badge, NameRow, CheckBox },
+  components: { NameListHeader, Badge, NameRow, CheckBox, TruncateMid },
   computed: {
     ...mapGetters(['activeAccountName']),
     ...mapState('names', ['owned']),
-  },
-  methods: {
-    ellipseStringMid,
   },
   created() {
     this.$store.dispatch('names/fetchOwned');

--- a/src/popup/utils/helper.js
+++ b/src/popup/utils/helper.js
@@ -244,13 +244,6 @@ export const isNotFoundError = (error) => error.isAxiosError && error?.response.
 // eslint-disable-next-line no-console
 export const handleUnknownError = (error) => console.warn('Unknown rejection', error);
 
-export const ellipseStringMid = (str, allowedLength) => {
-  if (str.length > allowedLength) {
-    return `${str.substr(0, (allowedLength / 3) * 2)}...${str.substr(-allowedLength / 3)}`;
-  }
-  return str;
-};
-
 export const setBalanceLocalStorage = (balance) => {
   localStorage.rxjs = JSON.stringify({ ...JSON.parse(localStorage.rxjs || '{}'), balance });
 };

--- a/tests/e2e/integration/names.js
+++ b/tests/e2e/integration/names.js
@@ -4,11 +4,7 @@ describe('Test cases for names', () => {
     cy.login({ name })
       .openMenu()
       .get('[data-cy=chain-name]')
-      .should('be.visible')
-      .contains(name)
-
-      .get('[data-cy=account-name]')
-      .should('be.visible')
-      .contains(name);
+      .truncateStringShouldContain('[data-cy=chain-name] .truncate-mid', name)
+      .truncateStringShouldContain('[data-cy=account-name] .truncate-mid', name);
   });
 });

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -301,3 +301,14 @@ Cypress.Commands.add('openTransactions', () => {
     .get('[data-cy=filters]')
     .should('be.visible');
 });
+
+Cypress.Commands.add('truncateStringShouldContain', (elem, string) => {
+  cy.get(elem)
+    .should('be.visible')
+    .then(($els) => {
+      const win = $els[0].ownerDocument.defaultView;
+      const before = win.getComputedStyle($els[0], 'before').getPropertyValue('content');
+      const after = win.getComputedStyle($els[0], 'after').getPropertyValue('content');
+      expect(string).to.eq(`${before.replace(/['"]+/g, '')}${after.replace(/['"]+/g, '')}`);
+    });
+});


### PR DESCRIPTION
Previous aproach wasn't flexible enough:
In the old version there is no difference bwetween wide letters and not wide.
Even if the letters are not wide and the whole string could fit in the screen, it still would be truncated to the amount.

Test names are the same size in old and new versions
![Squueze method](https://user-images.githubusercontent.com/9008074/107723342-9c1bfa80-6d2c-11eb-8625-114eedbbb029.gif)
|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/9008074/107723371-ad650700-6d2c-11eb-9dce-5c7c175a74da.png)|![image](https://user-images.githubusercontent.com/9008074/107723376-afc76100-6d2c-11eb-9664-019023668288.png)|
