### PR TITLE
Refactor popup classes into App component

### DIFF
--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -1,17 +1,11 @@
 <template>
-  <div
-    :class="[
-      'ae-main',
-      aeppPopup ? 'ae-main-popup ae-main-wave' : waveBg ? 'ae-main-wave' : '',
-      iframe && ($route.path === '/intro' || $route.path === '/') ? 'iframe' : '',
-    ]"
-  >
-    <Header
-      v-if="!(iframe && $route.path === '/intro')"
-      @toggle-sidebar="showSidebar = !showSidebar"
-    />
+  <div id="app">
+    <Header v-if="showHeader" @toggle-sidebar="showSidebar = !showSidebar" />
 
-    <RouterView />
+    <RouterView
+      :class="{ 'not-rebrand': $route.meta.notRebrand, 'show-header': showHeader }"
+      class="main"
+    />
 
     <transition name="slide">
       <div
@@ -24,8 +18,7 @@
       </div>
     </transition>
 
-    <NodeConnectionStatus v-if="!(iframe && $route.path === '/intro')" />
-    <Tour />
+    <NodeConnectionStatus v-if="showConnectionStatus" />
     <Component
       :is="component"
       v-for="{ component, key, props } in modals"
@@ -44,27 +37,24 @@ import { postMessage } from './utils/connection';
 import Header from './router/components/Header';
 import SidebarMenu from './router/components/SidebarMenu';
 import NodeConnectionStatus from './router/components/NodeConnectionStatus';
-import Tour from './router/components/Tour';
 
 export default {
   components: {
     Header,
     SidebarMenu,
     NodeConnectionStatus,
-    Tour,
   },
   data: () => ({
     showSidebar: false,
-    iframe: IN_FRAME,
-    aeppPopup: window.RUNNING_IN_POPUP,
   }),
   computed: {
     ...mapGetters(['account', 'isLoggedIn']),
     ...mapState(['isRestored', 'current', 'sdk', 'backedUpSeed', 'notifications']),
-    waveBg() {
-      return ['/intro', '/popup-sign-tx', '/connect', '/import-account', '/receive'].includes(
-        this.$route.path,
-      );
+    showConnectionStatus() {
+      return !(IN_FRAME && this.$route.path === '/intro');
+    },
+    showHeader() {
+      return !window.RUNNING_IN_POPUP && this.showConnectionStatus;
     },
     modals() {
       return this.$store.getters['modals/opened'];
@@ -139,7 +129,7 @@ body {
 <style lang="scss" scoped>
 @import '../styles/typography';
 
-.ae-main {
+#app {
   position: relative;
   margin: 0 auto;
   overflow: visible;
@@ -148,23 +138,19 @@ body {
 
   color: $white-color;
 
-  &.ae-main-popup {
-    background-color: $bg-color;
-    padding-top: 0;
-  }
+  .main {
+    &.not-rebrand {
+      padding: 4px 20px;
+      text-align: center;
+      font-size: 16px;
+      margin: 0 auto;
+      position: relative;
+    }
 
-  &.ae-main-wave {
-    height: 100%;
-    background-position: center bottom;
-    background-repeat: no-repeat;
-    background-image: url('../icons/background-big-wave.png');
-  }
-
-  padding-top: 48px;
-  padding-top: calc(48px + env(safe-area-inset-top));
-
-  &.iframe {
-    padding-top: 0;
+    &.show-header {
+      padding-top: 48px;
+      padding-top: calc(48px + env(safe-area-inset-top));
+    }
   }
 
   .menu-overlay {
@@ -198,12 +184,6 @@ body {
 
   .slide-leave-to .sidebar-menu {
     opacity: 0;
-  }
-}
-
-@media screen and (max-width: 380px) {
-  .ae-main.ae-main-wave {
-    background-position: 100% 100%;
   }
 }
 </style>

--- a/src/popup/router/components/Modals/QrCodeReader.vue
+++ b/src/popup/router/components/Modals/QrCodeReader.vue
@@ -119,10 +119,10 @@ export default {
             this.style = document.createElement('style');
             this.style.type = 'text/css';
             this.style.appendChild(
-              document.createTextNode('html, body, .ae-main { background: transparent }'),
+              document.createTextNode('html, body, #app { background: transparent }'),
             );
             document.head.appendChild(this.style);
-            document.querySelector('.popup').style.display = 'none';
+            document.querySelector('.main').style.display = 'none';
             document.querySelector('.header .content div:not(.title)').style.display = 'none';
             this.headerText = document.querySelector('.header .title').innerText;
             document.querySelector('.header .title').innerText = 'Scan QR';
@@ -134,7 +134,7 @@ export default {
     stopReading() {
       if (process.env.PLATFORM === 'cordova') {
         if (document.head.contains(this.style)) document.head.removeChild(this.style);
-        document.querySelector('.popup').style.display = '';
+        document.querySelector('.main').style.display = '';
         document.querySelector('.header .content div:not(.title)').style.display = '';
         document.querySelector('.header .title').innerText = this.headerText;
         window.QRScanner.destroy();

--- a/src/popup/router/pages/About.vue
+++ b/src/popup/router/pages/About.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup">
+  <div class="about">
     <Logo class="logo" />
     <p>
       {{ $t('pages.about.systemName') }}
@@ -49,12 +49,14 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.version {
-  color: #909090;
-}
+.about {
+  .version {
+    color: #909090;
+  }
 
-.waellet-links a {
-  font-weight: bold;
-  display: block;
+  .waellet-links a {
+    font-weight: bold;
+    display: block;
+  }
 }
 </style>

--- a/src/popup/router/pages/Account.vue
+++ b/src/popup/router/pages/Account.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup popup-no-padding account">
+  <div class="account">
     <div class="plate">
       <i18n
         v-if="!backedUpSeed"
@@ -67,6 +67,7 @@ export default {
 
   .seed-backup-notification {
     font-size: 14px;
+    text-align: center;
     margin-top: 20px;
     line-height: 14px;
     color: $accent-color;

--- a/src/popup/router/pages/Address.vue
+++ b/src/popup/router/pages/Address.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup">
+  <div class="address">
     <div class="section-title">
       {{ $t('pages.tipPage.sendToAddress') }}
     </div>
@@ -30,16 +30,18 @@ export default {
 <style lang="scss" scoped>
 @import '../../../styles/variables';
 
-.url-bar {
-  color: $text-color;
-}
+.address {
+  .url-bar {
+    color: $text-color;
+  }
 
-.section-title {
-  margin-bottom: 8px;
-  margin-top: 16px;
-  font-size: 16px;
-  color: $white-color;
-  font-weight: 400;
-  text-align: left;
+  .section-title {
+    margin-bottom: 8px;
+    margin-top: 16px;
+    font-size: 16px;
+    color: $white-color;
+    font-weight: 400;
+    text-align: left;
+  }
 }
 </style>

--- a/src/popup/router/pages/ClaimTips.vue
+++ b/src/popup/router/pages/ClaimTips.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="claim-tips popup">
+  <div class="claim-tips">
     <p class="primary-title text-left mb-8 f-16">
       {{ $t('pages.claimTips.urlToClaim') }}
     </p>

--- a/src/popup/router/pages/CommentNew.vue
+++ b/src/popup/router/pages/CommentNew.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup">
+  <div class="comment-new">
     <div class="tip-note-preview mt-15">
       {{ text }}
     </div>

--- a/src/popup/router/pages/DonateError.vue
+++ b/src/popup/router/pages/DonateError.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup donate-error">
+  <div class="donate-error">
     <h1>{{ $t('pages.donate-error.error-report') }}</h1>
     <Textarea
       :placeholder="$t('pages.donate-error.error-placeholder')"

--- a/src/popup/router/pages/ImportAccount.vue
+++ b/src/popup/router/pages/ImportAccount.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup">
+  <div class="import-account">
     <p class="regular-text">{{ $t('pages.index.enterSeedPhrase') }}</p>
     <Textarea v-model="mnemonic" :error="error" />
     <Button @click="importAccount" :disabled="!mnemonic || error" data-cy="import">
@@ -50,7 +50,7 @@ export default {
 <style lang="scss" scoped>
 @import '../../../styles/variables';
 
-.regular-text {
+.import-account .regular-text {
   font-size: $base-font-size;
   text-align: left;
   font-weight: normal;

--- a/src/popup/router/pages/Intro.vue
+++ b/src/popup/router/pages/Intro.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="['popup', 'intro', { iframe }]">
+  <div :class="['intro', { iframe }]">
     <div v-show="step === 1">
       <img v-if="iframe" src="../../../icons/iframe/receive.svg" />
       <h2 v-else>

--- a/src/popup/router/pages/Invite.vue
+++ b/src/popup/router/pages/Invite.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="invite popup">
+  <div class="invite">
     <p class="section-title">
       <NewInviteLink class="invite-icon" />
       {{ $t('pages.invite.generate-link') }}
@@ -78,7 +78,7 @@ export default {
 <style lang="scss" scoped>
 @import '../../../styles/variables';
 
-.invite.popup {
+.invite {
   background-color: $black-1;
 
   .section-title {

--- a/src/popup/router/pages/LanguageSettings.vue
+++ b/src/popup/router/pages/LanguageSettings.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup">
+  <div class="language-settings">
     <h4>{{ $t('pages.languageSettings.switchLanguage') }}</h4>
     <hr />
     <small>
@@ -7,7 +7,7 @@
       {{ $t('pages.languageSettings.currentLanguage') }}:
       {{ active.name || 'en' }}
     </small>
-    <div class="language-settings">
+    <div class="settings">
       <div class="dropdown" :class="{ show: dropdown }">
         <Button extend @click="dropdown = !dropdown">
           <ae-icon name="globe" />
@@ -57,91 +57,93 @@ export default {
 <style lang="scss" scoped>
 @import '../../../styles/variables';
 
-h4 {
-  text-align: left;
-  margin: 0;
-}
-
-small {
-  color: #9c9c9c;
-  text-align: left;
-  width: 100%;
-  margin: 0 0 10px;
-  display: block;
-  word-break: break-word;
-}
-
 .language-settings {
-  li {
-    list-style-type: none;
-    color: #717c87;
+  h4 {
+    text-align: left;
     margin: 0;
   }
 
-  .ae-icon {
-    font-size: 1.2rem;
-    margin-right: 10px;
-  }
-
-  button {
-    font-size: 14px;
+  small {
+    color: #9c9c9c;
+    text-align: left;
     width: 100%;
-    color: $button-text-color;
-    margin: 0;
-    padding: 0 1rem;
-    white-space: nowrap;
-    background-color: #505058;
-    border-radius: 4px;
-    text-align: center;
-    display: inline-flex;
-    justify-content: center;
-    align-items: center;
+    margin: 0 0 10px;
+    display: block;
+    word-break: break-word;
   }
 
-  ul {
-    min-width: 250px;
-    box-shadow: none;
-    visibility: hidden;
-    max-height: 0;
-    padding: 0;
-    overflow: hidden;
-    transition: all 0.3s ease-in-out;
-    right: 0;
-
+  .settings {
     li {
-      width: 30%;
+      list-style-type: none;
+      color: #717c87;
+      margin: 0;
+    }
+
+    .ae-icon {
+      font-size: 1.2rem;
+      margin-right: 10px;
+    }
+
+    button {
+      font-size: 14px;
+      width: 100%;
+      color: $button-text-color;
+      margin: 0;
+      padding: 0 1rem;
+      white-space: nowrap;
+      background-color: #505058;
+      border-radius: 4px;
       text-align: center;
-      margin: auto;
-      color: #fff;
-      cursor: pointer;
-
-      div {
-        width: 100%;
-        display: inline-flex;
-        justify-content: center;
-        align-items: center;
-      }
-
-      .active {
-        text-decoration: underline;
-      }
-
-      span {
-        margin-left: auto;
-      }
-    }
-  }
-
-  .dropdown.show {
-    .sub-dropdown {
-      visibility: visible;
-      max-height: 210px;
+      display: inline-flex;
+      justify-content: center;
+      align-items: center;
     }
 
-    .ae-icon-left-more {
-      transform: rotate(90deg);
-      -webkit-transform: rotate(90deg);
-      -ms-transform: rotate(90deg);
+    ul {
+      min-width: 250px;
+      box-shadow: none;
+      visibility: hidden;
+      max-height: 0;
+      padding: 0;
+      overflow: hidden;
+      transition: all 0.3s ease-in-out;
+      right: 0;
+
+      li {
+        width: 30%;
+        text-align: center;
+        margin: auto;
+        color: #fff;
+        cursor: pointer;
+
+        div {
+          width: 100%;
+          display: inline-flex;
+          justify-content: center;
+          align-items: center;
+        }
+
+        .active {
+          text-decoration: underline;
+        }
+
+        span {
+          margin-left: auto;
+        }
+      }
+    }
+
+    .dropdown.show {
+      .sub-dropdown {
+        visibility: visible;
+        max-height: 210px;
+      }
+
+      .ae-icon-left-more {
+        transform: rotate(90deg);
+        -webkit-transform: rotate(90deg);
+        -ms-transform: rotate(90deg);
+      }
     }
   }
 }

--- a/src/popup/router/pages/Names/AuctionBid.vue
+++ b/src/popup/router/pages/Names/AuctionBid.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup">
+  <div class="auction-bid">
     <h4>{{ $t('pages.names.auctions.bid-on') }} {{ name }}</h4>
     <AmountSend :amountError="!+amount" v-model="amount" :errorMsg="amountError" />
     <Button extend @click="bid" :disabled="!!amountError || !+amount">
@@ -99,7 +99,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.details-row {
+.auction-bid .details-row {
   display: flex;
   justify-content: space-between;
   margin: 5px 0;

--- a/src/popup/router/pages/Names/AuctionDetails.vue
+++ b/src/popup/router/pages/Names/AuctionDetails.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup">
+  <div class="auction-details">
     <Loader v-if="bids === null" />
     <p v-else-if="bids.length === 0">{{ $t('pages.names.auctions.not-found') }}</p>
     <template v-else>
@@ -80,7 +80,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.section-title {
+.auction-details .section-title {
   text-align: left;
   margin-top: 15px;
   margin-bottom: 5px;

--- a/src/popup/router/pages/Names/AuctionList.vue
+++ b/src/popup/router/pages/Names/AuctionList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup">
+  <div class="auction-list">
     <NameListHeader />
 
     <Button @click="filter = 'soonest'" :inactive="filter !== 'soonest'" third small>
@@ -12,7 +12,7 @@
       {{ $t('pages.names.auctions.bid') }}
     </Button>
 
-    <ul v-if="activeAuctions.length" class="auctions-list">
+    <ul v-if="activeAuctions.length" class="list">
       <NameRow
         v-for="({ name, expiration, lastBid }, key) in auctions"
         :key="key"
@@ -69,7 +69,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.auctions-list {
+.auction-list .list {
   padding: 0;
   margin-top: 10px;
 }

--- a/src/popup/router/pages/Names/Claim.vue
+++ b/src/popup/router/pages/Names/Claim.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup">
+  <div class="claim">
     <NameListHeader />
     <div class="claim-name-holder">
       <Input
@@ -80,18 +80,20 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.claim-name-holder {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  margin-top: 30px;
+.claim {
+  .claim-name-holder {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-top: 30px;
 
-  .input-group {
-    margin-left: 0;
-  }
+    .input-group {
+      margin-left: 0;
+    }
 
-  .button {
-    margin-right: 0;
+    .button {
+      margin-right: 0;
+    }
   }
 }
 </style>

--- a/src/popup/router/pages/Names/Details.vue
+++ b/src/popup/router/pages/Names/Details.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup">
+  <div class="details">
     <ul v-if="!addPointer" class="name-details">
       <li>
         <span>{{ $t('pages.names.details.name') }}</span> {{ name }}
@@ -137,7 +137,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.name-details {
+.details .name-details {
   padding: 0;
   margin: 0;
 

--- a/src/popup/router/pages/Names/List.vue
+++ b/src/popup/router/pages/Names/List.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup">
+  <div class="list">
     <NameListHeader />
     <ul v-if="owned.length" class="names-list">
       <NameRow
@@ -57,7 +57,7 @@ export default {
 </script>
 
 <style scoped>
-.names-list {
+.list .names-list {
   padding: 0;
 }
 </style>

--- a/src/popup/router/pages/Networks.vue
+++ b/src/popup/router/pages/Networks.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="mode === 'list'" class="popup" data-cy="networks">
+  <div v-if="mode === 'list'" class="networks" data-cy="networks">
     <div v-for="network in networks" :key="network.name" class="network-row">
       <CheckBox
         :value="network === activeNetwork"
@@ -32,7 +32,7 @@
       $t('pages.network.addNetwork')
     }}</Button>
   </div>
-  <div v-else-if="mode === 'add' || mode === 'edit'" class="mt-10 popup network">
+  <div v-else-if="mode === 'add' || mode === 'edit'" class="mt-10 network">
     <Input
       :placeholder="$t('pages.network.networkNamePlaceholder')"
       :label="$t('pages.network.networkNameLabel')"
@@ -198,7 +198,7 @@ export default {
 <style lang="scss" scoped>
 @import '../../../styles/variables';
 
-.network-row {
+.networks .network-row {
   display: flex;
   align-items: center;
   border-top: 1px solid #100c0d;

--- a/src/popup/router/pages/NotificationSettings.vue
+++ b/src/popup/router/pages/NotificationSettings.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup notification-settings">
+  <div class="notification-settings">
     <div class="header">
       {{ $t('pages.notification-settings.header') }}
     </div>
@@ -30,7 +30,7 @@ export default {
 <style lang="scss" scoped>
 @import '../../../styles/variables';
 
-.popup.notification-settings {
+.notification-settings {
   padding: 0;
   font-size: 0.95rem;
 

--- a/src/popup/router/pages/Notifications.vue
+++ b/src/popup/router/pages/Notifications.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup">
+  <div class="notifications">
     <div class="tabs">
       <button :class="{ active: direction === '' }" @click="direction = ''">
         {{ $t('pages.notifications.all') }}
@@ -111,7 +111,7 @@ export default {
 <style lang="scss" scoped>
 @import '../../../styles/variables';
 
-.popup {
+.notifications {
   padding: 0;
 
   .tabs {

--- a/src/popup/router/pages/PermissionsDetails.vue
+++ b/src/popup/router/pages/PermissionsDetails.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup">
+  <div class="permissions-details">
     <p>{{ host }}</p>
     <div class="permission-row">
       <CheckBox :value="address" @input="togglePermission({ host, name: 'address' })" />
@@ -109,7 +109,7 @@ export default {
 <style lang="scss" scoped>
 @import '../../../styles/variables.scss';
 
-.popup {
+.permissions-details {
   font-size: 15px;
   text-align: left;
   color: $text-color;

--- a/src/popup/router/pages/PermissionsSettings.vue
+++ b/src/popup/router/pages/PermissionsSettings.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup">
+  <div class="permissions-settings">
     <Panel v-if="hosts.length">
       <PanelItem
         v-for="host in hosts"

--- a/src/popup/router/pages/Popups/AexPopup.scss
+++ b/src/popup/router/pages/Popups/AexPopup.scss
@@ -1,0 +1,56 @@
+.popup-aex2 {
+  max-height: 600px;
+  min-height: 600px;
+  margin-bottom: 55px;
+  position: relative;
+  // overflow-y:scroll;
+  h2 {
+    word-break: break-word;
+    line-height: 1.8rem;
+    font-size: 1.2rem;
+  }
+
+  p {
+    font-weight: normal;
+    word-break: break-word;
+    font-size: 0.9rem;
+  }
+
+  ul li {
+    border-width: 1px;
+    border-color: #424242;
+  }
+
+  .permission-set {
+    flex-direction: column;
+    text-align: left;
+    cursor: unset;
+
+    h4 {
+      display: block;
+      width: 100%;
+      margin: 0;
+    }
+
+    p {
+      display: block;
+      width: 100%;
+      margin: 0;
+    }
+  }
+
+  ul {
+    padding: 0;
+  }
+
+  .account-name {
+    font-size: 0.8rem;
+    word-break: break-word;
+    white-space: nowrap;
+  }
+
+  .hostname {
+    font-size: 0.65rem;
+    word-break: break-word;
+  }
+}

--- a/src/popup/router/pages/Popups/Connect.vue
+++ b/src/popup/router/pages/Popups/Connect.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup popup-aex2" data-cy="popup-aex2">
+  <div class="connect popup-aex2" data-cy="popup-aex2">
     <div class="flex identicon-container">
       <div class="identicon">
         <img :src="faviconUrl" @error="imageError = true" v-if="!imageError" />
@@ -66,7 +66,7 @@ export default {
 <style lang="scss" scoped>
 @import '../../../../styles/variables';
 
-.identicon-container {
+.connect .identicon-container {
   position: relative;
   margin-top: 2rem;
 
@@ -133,3 +133,4 @@ export default {
   }
 }
 </style>
+<style lang="scss" src="./AexPopup.scss" scoped />

--- a/src/popup/router/pages/Popups/MessageSign.vue
+++ b/src/popup/router/pages/Popups/MessageSign.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup popup-aex2" data-cy="popup-aex2">
+  <div class="message-sign popup-aex2" data-cy="popup-aex2">
     <h2 class="identity">
       <div class="flex flex-align-center flex-justify-content-center">
         <img :src="faviconUrl" @error="imageError = true" v-if="!imageError" />
@@ -48,7 +48,8 @@ export default {
 <style lang="scss" scoped>
 @import '../../../../styles/variables';
 
-.identity img {
+.message-sign .identity img {
   width: 32px;
 }
 </style>
+<style lang="scss" src="./AexPopup.scss" scoped />

--- a/src/popup/router/pages/PrivacyPolicy.vue
+++ b/src/popup/router/pages/PrivacyPolicy.vue
@@ -1,6 +1,6 @@
 <!--eslint-disable vue-i18n/no-raw-text-->
 <template>
-  <div class="popup privacypolicy--content">
+  <div class="privacy-policy">
     <h2>{{ $t('pages.privacyPolicy.heading') }}</h2>
     <p><em>The present Privacy Policy is effective since on 9th April 2020.</em></p>
     <ol>
@@ -374,7 +374,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.privacypolicy--content {
+.privacy-policy {
   text-align: left;
   word-break: break-word;
   font-weight: 100;

--- a/src/popup/router/pages/Receive.vue
+++ b/src/popup/router/pages/Receive.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup popup-no-padding top-up-container" data-cy="top-up-container">
+  <div class="receive" data-cy="top-up-container">
     <p class="primary-title text-left mt-20 f-14 mx-20">
       {{ $t('pages.receive.heading') }}
     </p>
@@ -35,13 +35,15 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-.top-up-container {
+@import '../../../styles/variables.scss';
+
+.receive {
   p.primary-title {
     margin-left: 20px;
   }
 
   ::v-deep .qrcode canvas {
-    border: 5px solid #fff;
+    border: 5px solid $color-white;
   }
 }
 </style>

--- a/src/popup/router/pages/Retip.vue
+++ b/src/popup/router/pages/Retip.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup">
+  <div class="retip">
     <BalanceInfo />
     <div class="section-title">
       {{ $t('pages.tipPage.url') }}
@@ -155,25 +155,27 @@ export default {
 <style lang="scss" scoped>
 @import '../../../styles/variables';
 
-.url-bar {
-  display: flex;
-  align-items: center;
+.retip {
+  .url-bar {
+    display: flex;
+    align-items: center;
 
-  a {
-    color: $text-color;
-    flex-grow: 1;
-    text-decoration: none;
-    width: 90%;
-    margin-left: 10px;
+    a {
+      color: $text-color;
+      flex-grow: 1;
+      text-decoration: none;
+      width: 90%;
+      margin-left: 10px;
+    }
   }
-}
 
-.section-title {
-  margin-bottom: 8px;
-  margin-top: 16px;
-  font-size: 16px;
-  color: $white-color;
-  font-weight: 400;
-  text-align: left;
+  .section-title {
+    margin-bottom: 8px;
+    margin-top: 16px;
+    font-size: 16px;
+    color: $white-color;
+    font-weight: 400;
+    text-align: left;
+  }
 }
 </style>

--- a/src/popup/router/pages/SecuritySettings.vue
+++ b/src/popup/router/pages/SecuritySettings.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup">
+  <div class="security-settings">
     <template v-if="view === 'warning'">
       <h3>{{ $t('pages.securitySettings.seedRecoveryHeading') }}</h3>
       {{ $t('pages.securitySettings.seedRecoverySmall') }}
@@ -117,44 +117,46 @@ export default {
 <style lang="scss" scoped>
 @import '../../../styles/variables';
 
-.mnemonics {
-  margin: 0;
+.security-settings {
+  .mnemonics {
+    margin: 0;
 
-  p {
-    word-spacing: 10px;
+    p {
+      word-spacing: 10px;
+    }
+
+    .ae-button {
+      float: right;
+      margin: 10px 0 30px 0;
+    }
+
+    p,
+    .ae-button.toolbar {
+      color: $bg-color;
+    }
   }
 
-  .ae-button {
-    float: right;
-    margin: 10px 0 30px 0;
+  .ae-icon.ae-icon-check {
+    color: #e911ff;
+    font-size: 100px;
   }
 
-  p,
-  .ae-button.toolbar {
-    color: $bg-color;
-  }
-}
+  .ae-badge {
+    user-select: unset;
+    cursor: pointer;
+    border: 2px solid #edf3f7;
 
-.ae-icon.ae-icon-check {
-  color: #e911ff;
-  font-size: 100px;
-}
+    .ae-icon-close {
+      margin-left: 5px;
+    }
 
-.ae-badge {
-  user-select: unset;
-  cursor: pointer;
-  border: 2px solid #edf3f7;
-
-  .ae-icon-close {
-    margin-left: 5px;
-  }
-
-  &.selected {
-    opacity: 0.4;
-    cursor: unset;
-    background: transparent;
-    border: 2px solid #c1c1c1;
-    color: #fff;
+    &.selected {
+      opacity: 0.4;
+      cursor: unset;
+      background: transparent;
+      border: 2px solid #c1c1c1;
+      color: #fff;
+    }
   }
 }
 </style>

--- a/src/popup/router/pages/Send.vue
+++ b/src/popup/router/pages/Send.vue
@@ -1,10 +1,10 @@
 <template>
-  <div class="popup popup-no-padding">
+  <div class="send">
     <div data-cy="send-container">
       <div v-if="step == 1">
         <AccountInfo />
         <BalanceInfo />
-        <div class="popup withdraw step1">
+        <div class="withdraw step1">
           <p class="primary-title text-left mb-8 f-16">
             {{ $t('pages.tipPage.heading') }}
             <span class="secondary-text">{{
@@ -49,7 +49,7 @@
         </div>
       </div>
       <div v-if="step == 2">
-        <div class="popup withdraw step2">
+        <div class="withdraw step2">
           <h3 class="heading-1 my-15 center">
             <div class="flex flex-align-center flex-justify-content-center">
               <AlertExclamination />
@@ -102,7 +102,7 @@
         </div>
       </div>
       <div v-if="step == 3">
-        <div class="popup withdraw step2">
+        <div class="withdraw step2">
           <h3 class="heading-1 my-15 center">
             <div class="flex flex-align-center flex-justify-content-center">
               <span class="ml-7">{{ $t('pages.send.tx-success') }}</span>
@@ -296,77 +296,79 @@ export default {
 <style lang="scss" scoped>
 @import '../../../styles/variables';
 
-.primary-title-darker {
-  color: $text-color;
-}
-
-.withdraw.step1 {
-  .d-flex {
-    display: flex;
-    padding-bottom: 24px;
-
-    &.error-below {
-      padding-bottom: 0;
-    }
-
-    .textarea {
-      width: 250px;
-      min-height: 60px;
-      margin: 0 20px 0 0;
-      font-size: 11px;
-    }
-  }
-
-  .error {
-    padding-top: 8px;
-    line-height: 16px;
-    color: $color-error;
-    font-size: 12px;
-    text-align: left;
-  }
-
-  small {
-    color: $accent-color;
-    display: block;
-    width: 100%;
-    padding-top: 5px;
-    font-size: 12px;
-  }
-}
-
-.withdraw.step2 {
-  p {
-    display: flex;
-    justify-content: center;
-    line-height: 2rem;
-  }
-
-  p:not(:first-of-type) {
+.send {
+  .primary-title-darker {
     color: $text-color;
   }
 
-  p > svg {
-    margin-right: 10px;
-  }
+  .withdraw.step1 {
+    .d-flex {
+      display: flex;
+      padding-bottom: 24px;
 
-  .info-group {
-    .amount {
-      font-size: 26px;
-      color: $secondary-color;
-    }
+      &.error-below {
+        padding-bottom: 0;
+      }
 
-    .currencyamount {
-      font-size: 18px;
-      display: block;
-
-      span {
-        font-size: 18px;
+      .textarea {
+        width: 250px;
+        min-height: 60px;
+        margin: 0 20px 0 0;
+        font-size: 11px;
       }
     }
+
+    .error {
+      padding-top: 8px;
+      line-height: 16px;
+      color: $color-error;
+      font-size: 12px;
+      text-align: left;
+    }
+
+    small {
+      color: $accent-color;
+      display: block;
+      width: 100%;
+      padding-top: 5px;
+      font-size: 12px;
+    }
   }
 
-  .text-center {
-    text-align: center;
+  .withdraw.step2 {
+    p {
+      display: flex;
+      justify-content: center;
+      line-height: 2rem;
+    }
+
+    p:not(:first-of-type) {
+      color: $text-color;
+    }
+
+    p > svg {
+      margin-right: 10px;
+    }
+
+    .info-group {
+      .amount {
+        font-size: 26px;
+        color: $secondary-color;
+      }
+
+      .currencyamount {
+        font-size: 18px;
+        display: block;
+
+        span {
+          font-size: 18px;
+        }
+      }
+    }
+
+    .text-center {
+      text-align: center;
+    }
   }
 }
 </style>

--- a/src/popup/router/pages/Settings.vue
+++ b/src/popup/router/pages/Settings.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup">
+  <div class="settings">
     <Panel>
       <PanelItem
         to="/settings/language"

--- a/src/popup/router/pages/SignMessage.vue
+++ b/src/popup/router/pages/SignMessage.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- remove when we'll be sure about the wording -->
   <!-- eslint-disable vue-i18n/no-raw-text -->
-  <div class="popup">
+  <div class="sign-message">
     <div class="section-title">Sign message for</div>
 
     <div class="url-bar link-sm text-left">
@@ -44,16 +44,18 @@ export default {
 <style lang="scss" scoped>
 @import '../../../styles/variables';
 
-.url-bar {
-  color: $text-color;
-}
+.sign-message {
+  .url-bar {
+    color: $text-color;
+  }
 
-.section-title {
-  margin-bottom: 8px;
-  margin-top: 16px;
-  font-size: 16px;
-  color: $white-color;
-  font-weight: 400;
-  text-align: left;
+  .section-title {
+    margin-bottom: 8px;
+    margin-top: 16px;
+    font-size: 16px;
+    color: $white-color;
+    font-weight: 400;
+    text-align: left;
+  }
 }
 </style>

--- a/src/popup/router/pages/SuccessTip.vue
+++ b/src/popup/router/pages/SuccessTip.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup" data-cy="success-tip">
+  <div class="success-tip" data-cy="success-tip">
     <h3 class="heading-1 mb-25 mt-15 center">
       <div class="flex flex-align-center flex-justify-content-center">
         <Heart />
@@ -111,19 +111,21 @@ export default {
 <style lang="scss" scoped>
 @import '../../../styles/variables';
 
-.sub-heading {
-  font-size: 14px;
-  font-weight: normal;
-  margin: 8px 0;
-}
+.success-tip {
+  .sub-heading {
+    font-size: 14px;
+    font-weight: normal;
+    margin: 8px 0;
+  }
 
-.note {
-  color: $text-color;
-  font-size: $base-font-size;
-  min-height: 100px;
-  border-radius: 5px;
-  border: 2px solid $border-color;
-  background: $input-bg-color;
-  padding: 15px;
+  .note {
+    color: $text-color;
+    font-size: $base-font-size;
+    min-height: 100px;
+    border-radius: 5px;
+    border: 2px solid $border-color;
+    background: $input-bg-color;
+    padding: 15px;
+  }
 }
 </style>

--- a/src/popup/router/pages/TermsOfService.vue
+++ b/src/popup/router/pages/TermsOfService.vue
@@ -948,52 +948,9 @@ export default {
   },
   data() {
     return {
-      details: [
-        {
-          title: this.$t('pages.termsOfService.section1Title'),
-          open: false,
-        },
-        {
-          title: this.$t('pages.termsOfService.section2Title'),
-          open: false,
-        },
-        {
-          title: this.$t('pages.termsOfService.section3Title'),
-          open: false,
-        },
-        {
-          title: this.$t('pages.termsOfService.section4Title'),
-          open: false,
-        },
-        {
-          title: this.$t('pages.termsOfService.section5Title'),
-          open: false,
-        },
-        {
-          title: this.$t('pages.termsOfService.section6Title'),
-          open: false,
-        },
-        {
-          title: this.$t('pages.termsOfService.section7Title'),
-          open: false,
-        },
-        {
-          title: this.$t('pages.termsOfService.section8Title'),
-          open: false,
-        },
-        {
-          title: this.$t('pages.termsOfService.section9Title'),
-          open: false,
-        },
-        {
-          title: this.$t('pages.termsOfService.section10Title'),
-          open: false,
-        },
-        {
-          title: this.$t('pages.termsOfService.section11Title'),
-          open: false,
-        },
-      ],
+      details: Object.entries(this.$t('pages.termsOfService'))
+        .filter(([k]) => /section[0-9]+Title/.test(k))
+        .map(([, title]) => ({ title, open: false })),
       openUrl,
     };
   },

--- a/src/popup/router/pages/TermsOfService.vue
+++ b/src/popup/router/pages/TermsOfService.vue
@@ -1,6 +1,6 @@
 <!--eslint-disable vue-i18n/no-raw-text-->
 <template>
-  <div class="popup text-left terms">
+  <div class="terms-of-service text-left">
     <!-- header -->
     <h1 class="heading-1 bolder">TERMS OF USE</h1>
     <p class="italic">The present <b>TERMS OF USE</b> are effective since 9th April 2020.</p>
@@ -1008,7 +1008,7 @@ export default {
 <style lang="scss" scoped>
 @import '../../../styles/variables';
 
-.terms {
+.terms-of-service {
   font-weight: 100;
 
   .italic {

--- a/src/popup/router/pages/Tip.vue
+++ b/src/popup/router/pages/Tip.vue
@@ -1,7 +1,7 @@
 <template>
-  <div>
+  <div class="tip">
     <BalanceInfo />
-    <div class="tour__step3 popup">
+    <div class="tour__step3">
       <p class="primary-title text-left mb-8 f-16">
         <template v-if="!confirmMode">
           {{ $t('pages.tipPage.url') }}
@@ -27,7 +27,7 @@
         <Input v-else size="m-0 sm" v-model="url" :placeholder="$t('pages.tipPage.enterUrl')" />
       </div>
     </div>
-    <div class="popup" data-cy="tip-container">
+    <div data-cy="tip-container">
       <template v-if="!confirmMode">
         <AmountSend v-model="amount" />
         <Textarea v-model="note" :placeholder="$t('pages.tipPage.titlePlaceholder')" size="sm" />
@@ -279,70 +279,71 @@ export default {
 <style lang="scss" scoped>
 @import '../../../styles/variables';
 
-.tour__step3 {
-  margin: 0 auto;
-  padding: 12px 20px 5px;
-  margin-top: 22px;
-  min-width: auto;
-
-  &.v-tour__target--highlighted {
-    margin: 10px;
+.tip {
+  .tour__step3 {
+    margin: 0 auto;
+    margin-top: 22px;
     min-width: auto;
-    padding-bottom: 25px;
+
+    &.v-tour__target--highlighted {
+      margin: 10px;
+      min-width: auto;
+      padding-bottom: 25px;
+    }
+
+    p {
+      margin-top: 0;
+
+      &.title-holder {
+        display: flex;
+        align-items: center;
+      }
+    }
   }
 
-  p {
-    margin-top: 0;
+  .url-bar {
+    position: relative;
 
-    &.title-holder {
+    &.url-bar--input {
+      ::v-deep .url-status {
+        position: absolute;
+        left: 10px;
+        top: 48%;
+        transform: translateY(-50%);
+        -ms-transform: translateY(-50%);
+        -webkit-transform: translateY(-50%);
+      }
+
+      ::v-deep input {
+        padding-left: 35px;
+      }
+    }
+
+    &.url-bar--text {
       display: flex;
       align-items: center;
     }
-  }
-}
 
-.url-bar {
-  position: relative;
-
-  &.url-bar--input {
-    ::v-deep .url-status {
-      position: absolute;
-      left: 10px;
-      top: 48%;
-      transform: translateY(-50%);
-      -ms-transform: translateY(-50%);
-      -webkit-transform: translateY(-50%);
-    }
-
-    ::v-deep input {
-      padding-left: 35px;
+    a {
+      color: $text-color;
+      text-decoration: none;
+      margin-left: 10px;
+      width: 90%;
     }
   }
 
-  &.url-bar--text {
-    display: flex;
-    align-items: center;
+  .validation-msg {
+    color: #ff8c2a;
+    font-size: 15px;
+    min-height: 45px;
   }
 
-  a {
-    color: $text-color;
-    text-decoration: none;
-    margin-left: 10px;
-    width: 90%;
-  }
-}
-
-.validation-msg {
-  color: #ff8c2a;
-  font-size: 15px;
-  min-height: 45px;
-}
-
-@media screen and (min-width: 380px) {
-  .tour__step3.v-tour__target--highlighted {
-    margin: 10px auto 0 auto;
-    min-width: auto;
-    padding-bottom: 25px;
+  @media screen and (min-width: 380px) {
+    .tour__step3.v-tour__target--highlighted {
+      margin: 10px auto 0 auto;
+      min-width: auto;
+      padding-bottom: 25px;
+    }
   }
 }
 </style>

--- a/src/popup/router/pages/Transactions.vue
+++ b/src/popup/router/pages/Transactions.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="popup">
+  <div class="transactions">
     <AccountInfo />
     <BalanceInfo />
     <TransactionFilters v-model="displayMode" />
@@ -130,22 +130,20 @@ export default {
 <style lang="scss" scoped>
 @import '../../../styles/variables';
 
-.date {
-  background: $button-color;
-  padding: 0.5rem 1rem;
-  color: $white-color;
-  text-transform: uppercase;
-  font-size: 0.9rem;
-  font-family: monospace;
-}
+.transactions {
+  .date {
+    background: $button-color;
+    padding: 0.5rem 1rem;
+    color: $white-color;
+    text-transform: uppercase;
+    font-size: 0.9rem;
+    font-family: monospace;
+  }
 
-.popup {
-  padding: 0;
-}
-
-.all-transactions {
-  background: $transactions-bg;
-  padding: 0 20px;
-  margin: 0;
+  .all-transactions {
+    background: $transactions-bg;
+    padding: 0 20px;
+    margin: 0;
+  }
 }
 </style>

--- a/src/popup/router/routes/index.js
+++ b/src/popup/router/routes/index.js
@@ -74,6 +74,7 @@ export default [
     props: true,
     meta: {
       notPersist: true,
+      notRebrand: true,
     },
   },
   {
@@ -83,6 +84,7 @@ export default [
     props: true,
     meta: {
       notPersist: true,
+      notRebrand: true,
     },
   },
   {
@@ -90,6 +92,7 @@ export default [
     component: Settings,
     meta: {
       title: 'settings',
+      notRebrand: true,
     },
   },
   {
@@ -97,6 +100,7 @@ export default [
     component: LanguageSettings,
     meta: {
       title: 'language',
+      notRebrand: true,
     },
   },
   {
@@ -105,6 +109,7 @@ export default [
     component: SecuritySettings,
     meta: {
       title: 'security',
+      notRebrand: true,
     },
   },
   {
@@ -113,6 +118,7 @@ export default [
     props: true,
     meta: {
       title: 'networks',
+      notRebrand: true,
     },
   },
   {
@@ -121,6 +127,7 @@ export default [
     name: 'permissions-settings',
     meta: {
       title: 'permissionsSettings',
+      notRebrand: true,
     },
   },
   {
@@ -129,6 +136,7 @@ export default [
     name: 'permissions-details',
     meta: {
       title: 'permissionsDetails',
+      notRebrand: true,
     },
   },
   {
@@ -137,6 +145,7 @@ export default [
     meta: {
       title: 'about',
       ifNotAuth: true,
+      notRebrand: true,
     },
   },
   {
@@ -145,6 +154,7 @@ export default [
     meta: {
       title: 'terms',
       ifNotAuth: true,
+      notRebrand: true,
     },
   },
   {
@@ -152,6 +162,7 @@ export default [
     component: PrivacyPolicy,
     meta: {
       title: 'privacy',
+      notRebrand: true,
     },
   },
   {
@@ -161,6 +172,7 @@ export default [
     props: true,
     meta: {
       title: 'send-tips',
+      notRebrand: true,
     },
   },
   {
@@ -169,6 +181,7 @@ export default [
     meta: {
       title: 'send-tips',
       notPersist: true,
+      notRebrand: true,
     },
   },
   {
@@ -177,6 +190,7 @@ export default [
     component: ClaimTips,
     meta: {
       title: 'claim-tips',
+      notRebrand: true,
     },
   },
   {
@@ -185,6 +199,7 @@ export default [
     meta: {
       title: 'importAccount',
       ifNotAuthOnly: true,
+      notRebrand: true,
     },
   },
   {
@@ -193,6 +208,7 @@ export default [
     meta: {
       ifNotAuthOnly: true,
       notPersist: true,
+      notRebrand: true,
     },
   },
 
@@ -210,6 +226,7 @@ export default [
     component: Send,
     meta: {
       title: 'send',
+      notRebrand: true,
     },
   },
   {
@@ -217,6 +234,7 @@ export default [
     component: Receive,
     meta: {
       title: 'topUp',
+      notRebrand: true,
     },
   },
   {
@@ -227,6 +245,7 @@ export default [
     meta: {
       title: 'send',
       notPersist: true,
+      notRebrand: true,
     },
   },
   {
@@ -245,6 +264,7 @@ export default [
     meta: {
       title: 'notification-settings',
       notPersist: true,
+      notRebrand: true,
     },
   },
   {
@@ -254,6 +274,7 @@ export default [
     name: 'name-list',
     meta: {
       title: 'names',
+      notRebrand: true,
     },
   },
   {
@@ -263,6 +284,7 @@ export default [
     name: 'name-claim',
     meta: {
       title: 'names',
+      notRebrand: true,
     },
   },
   {
@@ -272,6 +294,7 @@ export default [
     name: 'auction-list',
     meta: {
       title: 'names',
+      notRebrand: true,
     },
   },
   {
@@ -282,6 +305,7 @@ export default [
     meta: {
       title: 'names',
       notPersist: true,
+      notRebrand: true,
     },
   },
   {
@@ -292,6 +316,7 @@ export default [
     meta: {
       title: 'bidding',
       notPersist: true,
+      notRebrand: true,
     },
   },
   {
@@ -301,6 +326,7 @@ export default [
     name: 'auction-bid',
     meta: {
       title: 'names',
+      notRebrand: true,
     },
   },
   {
@@ -309,6 +335,7 @@ export default [
     meta: {
       title: 'comment-new',
       notPersist: true,
+      notRebrand: true,
     },
   },
   {
@@ -320,6 +347,7 @@ export default [
       title: 'donate-error',
       notPersist: true,
       ifNotAuth: true,
+      notRebrand: true,
     },
   },
   {
@@ -329,6 +357,7 @@ export default [
     meta: {
       title: 'address',
       notPersist: true,
+      notRebrand: true,
     },
   },
   {
@@ -354,6 +383,7 @@ export default [
     component: NotFound,
     meta: {
       ifNotAuth: true,
+      notRebrand: true,
     },
   },
   {
@@ -363,6 +393,7 @@ export default [
     meta: {
       title: 'sign-message',
       notPersist: true,
+      notRebrand: true,
     },
   },
   {
@@ -371,6 +402,7 @@ export default [
     component: Invite,
     meta: {
       title: 'invite',
+      notRebrand: true,
     },
   },
   {
@@ -381,6 +413,7 @@ export default [
     meta: {
       title: 'invite',
       notPersist: true,
+      notRebrand: true,
     },
   },
   ...webIframePopups,

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -46,10 +46,6 @@ p {
   text-align: left;
 }
 
-.ae-main {
-  padding-bottom: 0;
-}
-
 .ae-button {
   border-radius: 8px;
   height: 52px;
@@ -172,14 +168,6 @@ button {
   color: #717c87;
 }
 
-.popup {
-  padding: 4px 20px;
-  text-align: center;
-  font-size: 16px;
-  margin: 0 auto;
-  position: relative;
-}
-
 .identicon {
   margin-right: 10px;
 }
@@ -192,10 +180,6 @@ button {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.popup-no-padding {
-  padding: 4px 0;
 }
 
 #app {
@@ -293,66 +277,6 @@ button {
   margin-bottom: 30px;
   text-align: left;
   word-break: break-word;
-}
-
-/**
-* POPUP WINDWOS
-*/
-.popup-aex2 {
-  max-height: 600px;
-  min-height: 600px;
-  margin-bottom: 55px;
-  position: relative;
-  // overflow-y:scroll;
-  h2 {
-    word-break: break-word;
-    line-height: 1.8rem;
-    font-size: 1.2rem;
-  }
-
-  p {
-    font-weight: normal;
-    word-break: break-word;
-    font-size: 0.9rem;
-  }
-
-  ul li {
-    border-width: 1px;
-    border-color: #424242;
-  }
-
-  .permission-set {
-    flex-direction: column;
-    text-align: left;
-    cursor: unset;
-
-    h4 {
-      display: block;
-      width: 100%;
-      margin: 0;
-    }
-
-    p {
-      display: block;
-      width: 100%;
-      margin: 0;
-    }
-  }
-
-  ul {
-    padding: 0;
-  }
-
-  .account-name {
-    font-size: 0.8rem;
-    word-break: break-word;
-    white-space: nowrap;
-  }
-
-  .hostname {
-    font-size: 0.65rem;
-    word-break: break-word;
-  }
 }
 
 /**


### PR DESCRIPTION
The idea of this PR came from requested changes for desktop web-wallet. scrolling of Recent Transactions and general rebranding (getting rid of `global.scss` file).
I particularly don't like having some global classes and spread it to every page. Instead of that we can use inheritance of vue components and add classes on top of parent classes, if needed. 

Pros:
1. it helps clear `global.scss` file
2. every page will have root class corresponding to it's name (like we have in components)
2. we can mix old and new designs before we will complete rebranding (so in the end we should get rid of `no-rebrand` prop)
3. we can clear `App,vue` from unnecessary complications (like, moving `Header`, `Loader`, `Node connection status` etc into `Page`) and make css more clear
4. it will probably help to mix modals and popups designs in the future

Cons:
1. for now `no-rebrand` prop looks kinda hacky
2. we should test this PR in every environment to see if everything is ok in terms of layout