### PR TITLE
fix(commitlint): revert run commitlint from first valid commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lint:vue": "eslint --ext .js,.vue src tests",
     "lint:css": "stylelint src/**/*.{css,scss,vue}",
-    "lint:commit": "commitlint --from 151392b0 --verbose",
+    "lint:commit": "commitlint --from develop --verbose",
     "lint": "npm run lint:commit && npm run lint:vue && npm run lint:css",
     "prettier": "prettier \"src/**/*.{js,vue}\" \"tests/**/*.{js,vue}\"",
     "prettier:write": "npm run prettier -- --write",


### PR DESCRIPTION
This reverts commit 404972ea13d4d55f33d2fc402b88ff373012cac9.

I can't get the reasoning for changes made in #791. From my perspective reference to develop is better, because:
- running `lint:commit` I will get a short list of commit messages made by me, without commits already merged
- reference to develop makes it possible to move the setup to another repository without extra adjustments