### PR TITLE
refactor: prefer 'mounted' hook instead of 'created'

### DIFF
--- a/src/phishing/App.vue
+++ b/src/phishing/App.vue
@@ -35,7 +35,7 @@ export default {
       hostname: null,
     };
   },
-  created() {
+  mounted() {
     const uri = window.location.href.split('#');
     if (typeof uri[1] !== 'undefined') {
       const url = uri[1].split('&');

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -85,7 +85,7 @@ export default {
       if (val) this.init();
     },
   },
-  async created() {
+  async mounted() {
     await this.$watchUntilTruly(() => this.isRestored);
 
     this.$store.dispatch('getCurrencies');

--- a/src/popup/router/components/RecentTransactions.vue
+++ b/src/popup/router/components/RecentTransactions.vue
@@ -42,7 +42,7 @@ export default {
       icons: { AnimatedSpinner },
     };
   },
-  created() {
+  mounted() {
     if (this.transactions.latest.length) this.loading = false;
     this.polling = setInterval(() => this.updateTransactions(), 5000);
     this.$once('hook:beforeDestroy', () => clearInterval(this.polling));

--- a/src/popup/router/pages/ClaimTips.vue
+++ b/src/popup/router/pages/ClaimTips.vue
@@ -36,7 +36,7 @@ export default {
       return toURL(this.url).toString();
     },
   },
-  async created() {
+  async mounted() {
     if (process.env.IS_EXTENSION) {
       const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
       if (tab && validateTipUrl(tab.url)) {

--- a/src/popup/router/pages/CommentNew.vue
+++ b/src/popup/router/pages/CommentNew.vue
@@ -29,7 +29,7 @@ export default {
     ...mapState(['sdk']),
     ...mapGetters(['tippingSupported']),
   },
-  async created() {
+  async mounted() {
     this.loading = true;
     this.id = this.$route.query.id;
     if (this.$route.query.parentId) this.parentId = +this.$route.query.parentId;

--- a/src/popup/router/pages/FungibleTokens/TokenDetails.vue
+++ b/src/popup/router/pages/FungibleTokens/TokenDetails.vue
@@ -93,7 +93,7 @@ export default {
   subscriptions() {
     return pick(this.$store.state.observables, ['tokenBalance', 'balanceCurrency']);
   },
-  created() {
+  mounted() {
     this.$store.commit('setPageTitle', this.fungibleToken ? this.fungibleToken.name : 'Aeternity');
   },
   computed: {

--- a/src/popup/router/pages/Names/AuctionBid.vue
+++ b/src/popup/router/pages/Names/AuctionBid.vue
@@ -61,7 +61,7 @@ export default {
     },
   },
   filters: { blocksToRelativeTime },
-  async created() {
+  async mounted() {
     this.loading = true;
     await this.$watchUntilTruly(() => this.$store.state.middleware);
     const res = await this.$store.dispatch('names/fetchAuctionEntry', this.name);

--- a/src/popup/router/pages/Names/AuctionList.vue
+++ b/src/popup/router/pages/Names/AuctionList.vue
@@ -61,7 +61,7 @@ export default {
     },
   },
   filters: { blocksToRelativeTime },
-  async created() {
+  async mounted() {
     await this.$watchUntilTruly(() => this.$store.state.sdk);
     this.activeAuctions = await this.$store.dispatch('names/fetchAuctions');
   },

--- a/src/popup/router/pages/Names/Details.vue
+++ b/src/popup/router/pages/Names/Details.vue
@@ -87,7 +87,7 @@ export default {
       immediate: true,
     },
   },
-  async created() {
+  async mounted() {
     await this.$watchUntilTruly(() => this.sdk);
     this.$store.dispatch('names/fetchOwned');
   },

--- a/src/popup/router/pages/Names/List.vue
+++ b/src/popup/router/pages/Names/List.vue
@@ -48,7 +48,7 @@ export default {
     ...mapGetters(['activeAccountName']),
     ...mapState('names', ['owned']),
   },
-  created() {
+  mounted() {
     this.$store.dispatch('names/fetchOwned');
     const id = setInterval(() => this.$store.dispatch('names/fetchOwned'), 10000);
     this.$once('hook:destroyed', () => clearInterval(id));

--- a/src/popup/router/pages/PermissionsDetails.vue
+++ b/src/popup/router/pages/PermissionsDetails.vue
@@ -70,7 +70,7 @@ export default {
   subscriptions() {
     return pick(this.$store.state.observables, ['tokenBalance']);
   },
-  created() {
+  mounted() {
     if (!this.$store.state.permissions[this.host]) this.$router.replace({ name: 'not-found' });
   },
   computed: {

--- a/src/popup/router/pages/Popups/AskAccounts.vue
+++ b/src/popup/router/pages/Popups/AskAccounts.vue
@@ -33,7 +33,7 @@ export default {
       data: {},
     };
   },
-  async created() {
+  async mounted() {
     this.data = await getPopupProps();
   },
   methods: {

--- a/src/popup/router/pages/Popups/Connect.vue
+++ b/src/popup/router/pages/Popups/Connect.vue
@@ -67,7 +67,7 @@ export default {
       imageError: false,
     };
   },
-  async created() {
+  async mounted() {
     this.data =
       process.env.PLATFORM === 'web' && IN_POPUP
         ? {

--- a/src/popup/router/pages/Popups/MessageSign.vue
+++ b/src/popup/router/pages/Popups/MessageSign.vue
@@ -50,7 +50,7 @@ export default {
       imageError: false,
     };
   },
-  async created() {
+  async mounted() {
     this.data =
       process.env.PLATFORM === 'web' && IN_POPUP
         ? {

--- a/src/popup/router/pages/Popups/SignTx.vue
+++ b/src/popup/router/pages/Popups/SignTx.vue
@@ -45,7 +45,7 @@ export default {
       },
     };
   },
-  async created() {
+  async mounted() {
     this.props = await getPopupProps();
     this.unpackedTx = TxBuilder.unpackTx(this.props.action.params.tx);
     if (this.txObject.amount >= 0) this.tx.amount = +aettosToAe(this.txObject.amount);

--- a/src/popup/router/pages/Retip.vue
+++ b/src/popup/router/pages/Retip.vue
@@ -98,7 +98,7 @@ export default {
         : this.tippingV1;
     },
   },
-  async created() {
+  async mounted() {
     this.loading = true;
     await this.$watchUntilTruly(() => this.tippingV1);
     const tipId = this.$route.query.id;

--- a/src/popup/router/pages/Send.vue
+++ b/src/popup/router/pages/Send.vue
@@ -186,7 +186,7 @@ export default {
       return checkAddress(this.form.address) || chekAensName(this.form.address);
     },
   },
-  created() {
+  async mounted() {
     if (this.redirectstep && this.successtx) {
       this.step = 3;
       this.setTxDetails(this.successtx);
@@ -194,8 +194,6 @@ export default {
     if (typeof this.address !== 'undefined') {
       this.form.address = this.address;
     }
-  },
-  async mounted() {
     this.fetchFee();
   },
   methods: {

--- a/src/popup/router/pages/SuccessTip.vue
+++ b/src/popup/router/pages/SuccessTip.vue
@@ -90,7 +90,7 @@ export default {
       return this.$t('pages.successTip.notifyMessage', this.formatReceivedTokensForLocale);
     },
   },
-  async created() {
+  async mounted() {
     if (process.env.IS_EXTENSION) {
       const { addresses, tab } = await this.$store.dispatch('getWebPageAddresses');
       if (addresses.length) {

--- a/src/popup/router/pages/Tip.vue
+++ b/src/popup/router/pages/Tip.vue
@@ -178,7 +178,7 @@ export default {
       },
     },
   },
-  async created() {
+  async mounted() {
     await this.persistTipDetails();
     if (process.env.IS_EXTENSION) {
       const [{ url }] = await browser.tabs.query({ active: true, currentWindow: true });

--- a/src/redirect/App.vue
+++ b/src/redirect/App.vue
@@ -22,7 +22,7 @@ export default {
       error: null,
     };
   },
-  created() {
+  mounted() {
     const url = new URL(window.location.href);
     const error = url.searchParams.get('error');
     if (error) this.error = error;

--- a/tests/aepp/App.vue
+++ b/tests/aepp/App.vue
@@ -66,7 +66,7 @@ contract Example =
       contractAddress: 'ct_ym8eXWR2YfQZcMaXA8GFid9aarfCozGkeMcRHYVCVoBdVMzio',
     };
   },
-  async created() {
+  async mounted() {
     this.initClient();
     setInterval(async () => {
       if (this.client && !this.wallet.found) {

--- a/tests/e2e/integration/amount-send.js
+++ b/tests/e2e/integration/amount-send.js
@@ -2,6 +2,9 @@ describe('Test cases AmountSend component', () => {
   it('Calculates currency on enter amount, validates entered amount, shows correct balance', () => {
     cy.login()
       .openWithdraw()
+      .get('[data-cy=balance-currency]')
+      .invoke('text')
+      .then((text) => expect(text).not.to.eq('$0.00'))
       .enterAmountSend(5)
       .get('[data-cy=amount-currency]')
       .invoke('text')


### PR DESCRIPTION
I think by default we should use `mounted` because:
- in `mounted` hook the component's DOM is available making a wider range of operations available
- `mounted` is not executed in SSR context, it is not related to this repository, but it seems to be a good habit to don't use `created` by default because of that