### PR TITLE
Scroll to top on route change

### DIFF
--- a/src/popup/router/index.js
+++ b/src/popup/router/index.js
@@ -31,6 +31,7 @@ Vue.component('Loader', LoaderComponent);
 const router = new VueRouter({
   routes,
   mode: process.env.PLATFORM === 'web' ? 'history' : 'hash',
+  scrollBehavior: (to, from, savedPosition) => savedPosition || { x: 0, y: 0 },
 });
 
 const lastRouteKey = 'last-path';


### PR DESCRIPTION
Prevent from new pages being opened in the same scroll position.

Demo of the issue:
![demo](https://user-images.githubusercontent.com/482351/110798691-1899ee80-8283-11eb-8edb-aa68327ef704.gif)
