### PR TITLE
refactor: disable vue-i18n/no-raw-text rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,6 +52,6 @@ module.exports = {
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
     'vue-i18n/no-dynamic-keys': 'error',
     'vue-i18n/no-unused-keys': 'error',
-    'vue-i18n/no-raw-text': 'error',
+    'vue-i18n/no-raw-text': 'off',
   }
 }

--- a/src/popup/router/components/BalanceInfo.vue
+++ b/src/popup/router/components/BalanceInfo.vue
@@ -26,7 +26,6 @@
           :selected="current.currency"
           is-custom
         />
-        <!--eslint-disable-next-line vue-i18n/no-raw-text-->
         <span class="approx-sign">~</span>
         <span class="display-value text-ellipsis">{{ formatCurrency(balanceCurrency) }}</span>
         <ExpandedAngleArrow class="expand-arrow" />

--- a/src/popup/router/components/Modals/ClaimSuccess.vue
+++ b/src/popup/router/components/Modals/ClaimSuccess.vue
@@ -1,4 +1,3 @@
-<!--eslint-disable vue-i18n/no-raw-text-->
 <template>
   <Modal @close="resolve" close>
     <CheckIcon /> <br />

--- a/src/popup/router/components/Modals/ErrorLog.vue
+++ b/src/popup/router/components/Modals/ErrorLog.vue
@@ -4,7 +4,6 @@
       {{ $t('modals.error-log.title') }}
     </template>
 
-    <!--eslint-disable-next-line vue-i18n/no-raw-text-->
     <div class="error-msg">{{ message }}...</div>
     <div>
       <span>{{ $t('modals.error-log.sub-title') }}</span>

--- a/src/popup/router/components/ThreeDotsMenu.vue
+++ b/src/popup/router/components/ThreeDotsMenu.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="three-dots" :class="{ active: showMenu }" @click="showMenu = !showMenu">
-    <!--eslint-disable-line vue-i18n/no-raw-text-->
     •••
     <SmallModal v-if="showMenu" @close="showMenu = false">
       <slot />

--- a/src/popup/router/components/Tour.vue
+++ b/src/popup/router/components/Tour.vue
@@ -21,7 +21,6 @@
             <template>
               <div slot="header" class="step-header">
                 {{ $t(`onboarding.step_${step.step}.title`) }}
-                <!--eslint-disable-next-line vue-i18n/no-raw-text-->
                 <span class="step-info"> ({{ step.step }}/{{ steps.length }}) </span>
               </div>
               <div

--- a/src/popup/router/pages/About.vue
+++ b/src/popup/router/pages/About.vue
@@ -9,7 +9,7 @@
           "
         >
           {{ commitHash.slice(0, 7) }}</a
-        ><!--eslint-disable-line vue-i18n/no-raw-text-->
+        >
         / {{ extensionVersion }}
       </span>
     </p>

--- a/src/popup/router/pages/LanguageSettings.vue
+++ b/src/popup/router/pages/LanguageSettings.vue
@@ -3,7 +3,6 @@
     <h4>{{ $t('pages.languageSettings.switchLanguage') }}</h4>
     <hr />
     <small>
-      <!--eslint-disable-next-line vue-i18n/no-raw-text-->
       {{ $t('pages.languageSettings.currentLanguage') }}:
       {{ active.name || 'en' }}
     </small>

--- a/src/popup/router/pages/Popups/Connect.vue
+++ b/src/popup/router/pages/Popups/Connect.vue
@@ -17,7 +17,6 @@
     </div>
 
     <h2>
-      <!--eslint-disable-next-line vue-i18n/no-raw-text-->
       <span class="secondary-text" data-cy="aepp">{{ app.host }} ({{ app.name }}) </span>
       {{ $t('pages.connectConfirm.websiteRequestconnect') }}
       <Avatar class="send-account-icon" :address="account.address" :name="account.name" />

--- a/src/popup/router/pages/Popups/MessageSign.vue
+++ b/src/popup/router/pages/Popups/MessageSign.vue
@@ -5,7 +5,6 @@
         <img :src="faviconUrl" @error="imageError = true" v-if="!imageError" />
         <div>
           <span class="secondary-text" data-cy="host">
-            <!--eslint-disable-next-line vue-i18n/no-raw-text-->
             {{ app.host }} {{ app.name ? `(${app.name})` : '' }}
           </span>
           {{ $t('pages.popupMessageSign.heading') }}

--- a/src/popup/router/pages/PrivacyPolicy.vue
+++ b/src/popup/router/pages/PrivacyPolicy.vue
@@ -1,4 +1,3 @@
-<!--eslint-disable vue-i18n/no-raw-text-->
 <template>
   <div class="privacy-policy">
     <h2>{{ $t('pages.privacyPolicy.heading') }}</h2>

--- a/src/popup/router/pages/SecuritySettings.vue
+++ b/src/popup/router/pages/SecuritySettings.vue
@@ -46,7 +46,6 @@
           <ae-badge class="selected">{{ $t('pages.seedPhrase.first') }}</ae-badge>
           <ae-badge class="selected">{{ $t('pages.seedPhrase.second') }}</ae-badge>
           <ae-badge class="selected">{{ $t('pages.seedPhrase.third') }}</ae-badge>
-          <!--eslint-disable-next-line vue-i18n/no-raw-text-->
           <ae-badge class="selected">...</ae-badge>
         </template>
         <ae-badge

--- a/src/popup/router/pages/Send.vue
+++ b/src/popup/router/pages/Send.vue
@@ -76,7 +76,6 @@
                 {{ selectedToken ? selectedToken.symbol : $t('ae') }}</span
               >
               <span v-if="!selectedToken" class="currencyamount">
-                <!--eslint-disable-line vue-i18n/no-raw-text-->
                 ~
                 <span>
                   {{ formatCurrency((form.amount * currentCurrencyRate).toFixed(3)) }}

--- a/src/popup/router/pages/SignMessage.vue
+++ b/src/popup/router/pages/SignMessage.vue
@@ -1,6 +1,4 @@
 <template>
-  <!-- remove when we'll be sure about the wording -->
-  <!-- eslint-disable vue-i18n/no-raw-text -->
   <div class="sign-message">
     <div class="section-title">Sign message for</div>
 

--- a/src/popup/router/pages/TermsOfService.vue
+++ b/src/popup/router/pages/TermsOfService.vue
@@ -1,4 +1,3 @@
-<!--eslint-disable vue-i18n/no-raw-text-->
 <template>
   <div class="terms-of-service text-left">
     <!-- header -->

--- a/tests/aepp/App.vue
+++ b/tests/aepp/App.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable vue-i18n/no-raw-text -->
 <template>
   <div>
     <p data-cy="wallet-found" v-if="wallet.found">Wallet found</p>


### PR DESCRIPTION
I think this rule is too strict, it shouldn't make developers
- write `<!--eslint-disable-next-line vue-i18n/no-raw-text-->` to add a tilda
- write `{{ '~' }}` to add a tilda
- write `{{ $t('AE') }}` and `"AE": "AE"` in locale file to add "AE"