### PR TITLE
fix(firefox-redirect): exclude redirect.js from popup.html

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -171,6 +171,7 @@ const getConfig = platform => {
                 'other/inject',
                 'phishing/phishing',
                 'popup/cameraPermission',
+                'redirect/redirect',
               ],
             }),
             new HtmlWebpackPlugin({


### PR DESCRIPTION
This closes recently @Liubov-crypto issue in firefox https://github.com/aeternity/superhero-wallet/pull/910#pullrequestreview-617540107
![image](https://user-images.githubusercontent.com/7098449/112267968-fad87a80-8cc1-11eb-9944-111f486efba5.png)

This bug was in the wallet since #49.
The problem is in webpack config for extension-firefox. The chunk `redirect/redirect` hasn't been excluded from html build and therefore **if we weren't lucky** `redirect.js` was inserting **after** `popup.js` and it's `App.vue` was mounted to same `#app` div resulting to wrong page displaying.
As `redirect-chain-names` is using `redirect.html` nor `popup.html` we can exclude corresponding `redirect.js` from `popup.html`
We couldn't catch it cause we usually build extension only once and then hot-reloading it.