### PR TITLE
fix(bottom-elements): display TabBar and Status at bottommost in mobile

### DIFF
--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -165,7 +165,9 @@ body {
   }
 
   .main {
-    min-height: 600px;
+    @include desktop {
+      min-height: 100%;
+    }
 
     @include mobile {
       padding-bottom: 48px;
@@ -248,12 +250,12 @@ body {
   }
 
   .tab-bar {
-    position: sticky;
+    position: fixed;
+    width: 100%;
     bottom: 0;
 
-    @include mobile {
-      position: fixed;
-      width: 100%;
+    @include desktop {
+      position: sticky;
     }
   }
 

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -245,6 +245,11 @@ body {
   .tab-bar {
     position: sticky;
     bottom: 0;
+
+    @include mobile {
+      position: fixed;
+      width: 100%;
+    }
   }
 
   &.hide-tab-bar .tab-bar {

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -109,12 +109,12 @@ body {
   background-color: $color-black;
 }
 
-@include desktop {
-  html,
-  body {
-    height: 100%;
-  }
+html,
+body {
+  height: 100vh;
+}
 
+@include desktop {
   body {
     display: flex;
     flex-direction: column;
@@ -166,6 +166,11 @@ body {
 
   .main {
     min-height: 600px;
+
+    @include mobile {
+      padding-bottom: 48px;
+      padding-bottom: calc(48px + env(safe-area-inset-bottom));
+    }
   }
 
   &.show-header .main {
@@ -252,8 +257,16 @@ body {
     }
   }
 
-  &.hide-tab-bar .tab-bar {
-    display: none;
+  &.hide-tab-bar {
+    .main {
+      @include mobile {
+        padding-bottom: 0;
+      }
+    }
+
+    .tab-bar {
+      display: none;
+    }
   }
 }
 </style>

--- a/src/popup/router/components/NodeConnectionStatus.vue
+++ b/src/popup/router/components/NodeConnectionStatus.vue
@@ -30,11 +30,17 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-@import '../../../styles/variables';
+@import '../../../styles/mixins';
 
 .connect-error,
 .connect-node {
   position: sticky;
+
+  @include mobile {
+    position: fixed;
+    width: 100%;
+  }
+
   bottom: 48px;
   left: 0;
   right: 0;

--- a/src/popup/router/components/NodeConnectionStatus.vue
+++ b/src/popup/router/components/NodeConnectionStatus.vue
@@ -34,11 +34,11 @@ export default {
 
 .connect-error,
 .connect-node {
-  position: sticky;
+  position: fixed;
+  width: 100%;
 
-  @include mobile {
-    position: fixed;
-    width: 100%;
+  @include desktop {
+    position: sticky;
   }
 
   bottom: 48px;
@@ -47,7 +47,7 @@ export default {
   background: $secondary-color;
   color: $white-color;
   line-height: 2em;
-  padding-bottom: calc(env(safe-area-inset-bottom));
+  padding-bottom: env(safe-area-inset-bottom);
   z-index: 5;
   text-align: center;
   font-size: 14px;

--- a/src/popup/router/components/TabBar.vue
+++ b/src/popup/router/components/TabBar.vue
@@ -36,6 +36,7 @@ export default {
 .tab-bar {
   display: flex;
   background-color: $color-bg-3;
+  padding-bottom: env(safe-area-inset-bottom);
 
   > a {
     height: 48px;

--- a/src/popup/router/components/TransactionFilters.vue
+++ b/src/popup/router/components/TransactionFilters.vue
@@ -37,6 +37,7 @@ export default {
 
 <style lang="scss" scoped>
 @import '../../../styles/typography';
+@import '../../../styles/mixins';
 
 .filters {
   position: sticky;
@@ -52,6 +53,10 @@ export default {
   .filter {
     display: flex;
     align-items: center;
+
+    @include mobile {
+      padding: 0;
+    }
 
     @extend %face-sans-15-medium;
 

--- a/src/popup/router/pages/Popups/AexPopup.scss
+++ b/src/popup/router/pages/Popups/AexPopup.scss
@@ -1,4 +1,5 @@
 .popup-aex2 {
+  padding-top: env(safe-area-inset-top);
   max-height: 600px;
   min-height: 600px;
   margin-bottom: 55px;


### PR DESCRIPTION
Propose to merge this to #957.
This PR fixes this behavior on mobiles with big height screens:
![image](https://user-images.githubusercontent.com/7098449/114020410-ec3db600-98b2-11eb-8e19-4887afe4be47.png)
