### PR TITLE
chore(tx): return empty tx list if getTxByAccount returns error

### DIFF
--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -39,7 +39,9 @@ export default {
     if (!state.middleware) return [];
     const { address } = getters.account;
     let txs = await Promise.all([
-      state.middleware.getTxByAccount(address, limit, page).then(({ data }) => data),
+      state.middleware.getTxByAccount(address, limit, page)
+        .then(({ data }) => data)
+        .catch(() => []),
       dispatch('fetchPendingTransactions'),
       fetchJson(
         `${getters.activeNetwork.backendUrl}/cache/events/?address=${address}&event=TipWithdrawn${


### PR DESCRIPTION
I suggest to return empty list if `Random access restricted` error will be returned from mdw until fix on our or their side.
This PR prevents this error spamming in many cases:
![image](https://user-images.githubusercontent.com/7098449/114818379-0c173180-9dff-11eb-8793-033823f35668.png)
