### PR TITLE
chore: flickity buttons hover and pressed style

### DIFF
--- a/src/popup/router/components/MenuCarousel.vue
+++ b/src/popup/router/components/MenuCarousel.vue
@@ -84,7 +84,7 @@ export default {
 .menu-carousel {
   flex: 1;
   z-index: 1;
-  padding: 24px 18px;
+  padding: 24px;
 
   ::v-deep {
     .flickity-button {
@@ -113,10 +113,13 @@ export default {
         display: none;
       }
 
-      &:hover {
-        background: variables.$color-blue-hover-dark;
+      &:hover,
+      &:active {
+        background:
+          linear-gradient(rgba(variables.$color-blue, 0.15), rgba(variables.$color-blue, 0.15)),
+          linear-gradient(variables.$color-black, variables.$color-black);
 
-        .icon {
+        .flickity-button-icon {
           opacity: 1;
 
           path {
@@ -125,8 +128,8 @@ export default {
         }
       }
 
-      &:active {
-        background-color: rgba(variables.$color-blue-hover-dark, 0.1);
+      &:focus {
+        box-shadow: none;
       }
     }
   }


### PR DESCRIPTION
Fixes #953 

Hover:
<img width="50" src="https://user-images.githubusercontent.com/47859124/118941877-dbc13680-b95a-11eb-9cb0-71b04550be7b.png">

Pressed:
<img width="50" src="https://user-images.githubusercontent.com/47859124/118941945-f09dca00-b95a-11eb-941e-08d5f117bbac.png">

