### PR TITLE
Update SDK to 8.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
       }
     },
     "@aeternity/aepp-sdk": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@aeternity/aepp-sdk/-/aepp-sdk-8.0.0.tgz",
-      "integrity": "sha512-sHtS1wQnjQ5i1sTXBJUACAQCMoLliqxqG6pOdGzjXCu6Pz4al9qzTAqJzhDcvsLi3rTdB1RgWZnDQqLx1KvHjQ==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@aeternity/aepp-sdk/-/aepp-sdk-8.1.0.tgz",
+      "integrity": "sha512-/b58OLKpWEZYJhgA+0mvsRqirOccwd7ohd6FByKVRIo3RwQHz7QXiD2xgRpEXjFYeDC+/lxgAvz+mPJzOB7M/g==",
       "requires": {
         "@aeternity/bip39": "^0.1.0",
         "@aeternity/json-bigint": "^0.3.1",
@@ -6601,9 +6601,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.12.1",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.12.1.tgz",
-      "integrity": "sha512-1cch+qads4JnDSWsvc7d6nzlKAippwjUlf6vykkTLW53VSV+NkE6muGBToAjEA8pG90cSfcud3JgVmW2ds5TaQ=="
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.13.1.tgz",
+      "integrity": "sha512-wVlh0IAi2t1iOEh16y4u1TRk6ubd4KvLE8dlMi+3QUI6SfKphQUh7tAwihGGSQ8affxEXpVIPpOdf9kjR4v4Pw=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -17332,9 +17332,9 @@
       }
     },
     "swagger-client": {
-      "version": "3.13.2",
-      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.13.2.tgz",
-      "integrity": "sha512-kamtyXtmbZiA2C5YTVqJYgoPJgzqtM5RbeP23Rt/YPYjMArTKZ2fjx1UTsI0aSbws0GluU5pVHiGp8YMciSUfw==",
+      "version": "3.13.5",
+      "resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.13.5.tgz",
+      "integrity": "sha512-n4+yS0+jvx7PNq95TulWhjN+v9Cz6GRkdloF3LL0JV2eQ8E8a3a+0/XEppsYGIzb7i2/h7ZMcM5hIxIr7Gr1RA==",
       "requires": {
         "@babel/runtime-corejs3": "^7.11.2",
         "btoa": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "dependencies": {
     "@aeternity/aepp-components-3": "3.0.0-alpha.9",
-    "@aeternity/aepp-sdk": "^8.0.0",
+    "@aeternity/aepp-sdk": "^8.1.0",
     "@aeternity/bip39": "^0.1.0",
     "@aeternity/hd-wallet": "^0.2.0",
     "@zxing/library": "^0.18.3",


### PR DESCRIPTION
Update to SDK 8.1.0 is needed because that version increases the compiler version validity check. As there is a compiler 6.0.0 release planned for Iris this PR should be included in order to ensure Iris compatibiity.