### PR TITLE
style(dropdown): make dropdown wider and always on top

### DIFF
--- a/src/popup/router/components/BalanceInfo.vue
+++ b/src/popup/router/components/BalanceInfo.vue
@@ -122,16 +122,19 @@ export default {
   color: variables.$color-white;
 
   .balance-wrapper {
+    flex-grow: 1;
     margin: 0 auto;
 
     .balance-dropdown {
+      width: 100%;
+      text-align: center;
       margin-top: 6px;
       margin-left: auto;
       position: relative;
-      width: max-content;
 
       .dropdown {
         position: absolute;
+        left: 0;
 
         ::v-deep {
           .custom > button,

--- a/src/popup/router/components/Dropdown.vue
+++ b/src/popup/router/components/Dropdown.vue
@@ -96,6 +96,7 @@ export default {
   min-width: 6rem;
   width: 100%;
   margin-bottom: 22px;
+  z-index: 10;
 
   .display {
     text-align: center;
@@ -196,7 +197,6 @@ export default {
     max-height: 165px;
     overflow-y: scroll;
     position: relative;
-    z-index: 10;
   }
 
   .list-item:hover {


### PR DESCRIPTION
Of course we should make refactoring and redesigning of dropdown (started in #1144) but this changes looks the most reasonable right now.

Before:
![31212](https://user-images.githubusercontent.com/7098449/124803662-bafd8080-df9c-11eb-9a19-d30bb4120547.gif)

After:
![312](https://user-images.githubusercontent.com/7098449/124803677-bfc23480-df9c-11eb-9cdc-f716aefa2e52.gif)
