### PR TITLE
fix(dropdown-width): make dropdown list width constant

### DIFF
--- a/src/popup/router/components/BalanceInfo.vue
+++ b/src/popup/router/components/BalanceInfo.vue
@@ -122,7 +122,6 @@ export default {
   color: variables.$color-white;
 
   .balance-wrapper {
-    flex-grow: 1;
     margin: 0 auto;
 
     .balance-dropdown {
@@ -134,12 +133,16 @@ export default {
 
       .dropdown {
         position: absolute;
-        left: 0;
 
         ::v-deep {
           .custom > button,
           .custom > button:active:not(:disabled) {
             opacity: 0;
+          }
+
+          .custom .list {
+            width: 250px;
+            margin-left: -80px;
           }
 
           .custom > button,


### PR DESCRIPTION
This fixes behavior when you click somewhere on the card in the line with dropdown and it appears.