### PR TITLE
fix(tx-list): show loader only when fetching

### DIFF
--- a/src/popup/router/components/TransactionList.vue
+++ b/src/popup/router/components/TransactionList.vue
@@ -63,7 +63,7 @@ export default {
   },
   data() {
     return {
-      loading: true,
+      loading: false,
       transactions: [],
       page: 1,
       displayMode: { latestFirst: true, type: 'all' },


### PR DESCRIPTION
Transaction list shows loader while not fetching because of a guard clause: https://github.com/aeternity/superhero-wallet/blob/00f6f24ac66d9b8a5ed6c185fff95ed657f18709/src/popup/router/components/TransactionList.vue#L148