### PR TITLE
fix(mobile-share): allow tip url to be passed in TipsSend

### DIFF
--- a/src/popup/router/routes/index.js
+++ b/src/popup/router/routes/index.js
@@ -198,6 +198,7 @@ export default [
       path: '',
       name: 'tips-send',
       component: TipsSend,
+      props: true,
       meta: {
         title: 'tips',
         notRebrand: true,


### PR DESCRIPTION
fixes #1140