### PR TITLE
Align node status bar in collapsed iframe

### DIFF
--- a/src/popup/router/components/NodeConnectionStatus.vue
+++ b/src/popup/router/components/NodeConnectionStatus.vue
@@ -62,4 +62,12 @@ export default {
 .connect-node {
   background: variables.$color-bg-3;
 }
+
+@include mixins.collapsed {
+  .node-connection-status,
+  .connect-error,
+  .connect-node {
+    bottom: 0;
+  }
+}
 </style>

--- a/src/popup/router/components/TabBar.vue
+++ b/src/popup/router/components/TabBar.vue
@@ -127,4 +127,10 @@ export default {
     }
   }
 }
+
+@include mixins.collapsed {
+  .tab-bar {
+    display: none;
+  }
+}
 </style>

--- a/src/styles/mixins.scss
+++ b/src/styles/mixins.scss
@@ -11,3 +11,9 @@
     @content;
   }
 }
+
+@mixin collapsed {
+  @media screen and (max-height: 250px) {
+    @content;
+  }
+}


### PR DESCRIPTION
fixes #1120 

<img width="352" alt="Screenshot 2021-07-22 at 19 07 10" src="https://user-images.githubusercontent.com/47859124/126672230-1502780f-91eb-4ffe-a2e9-2d6ba6d1088f.png">

+ TabBar hidden in collapsed view as in my opinion collapsed view should be just for info reference, not complicated navigating