### PR TITLE
fix(status): set bottom to 0 if tab bar is hidden

### DIFF
--- a/src/popup/router/components/NodeConnectionStatus.vue
+++ b/src/popup/router/components/NodeConnectionStatus.vue
@@ -3,7 +3,10 @@
     v-if="nodeStatus && account.address && isLoggedIn"
     :data-cy="nodeStatus !== 'error' ? 'connect-node' : ''"
     class="node-connection-status"
-    :class="`connect-${nodeStatus === 'error' ? 'error' : 'node'}`"
+    :class="[
+      `connect-${nodeStatus === 'error' ? 'error' : 'node'}`,
+      { 'hide-tab-bar': $route.meta.hideTabBar }
+    ]"
   >
     {{ statuses[nodeStatus] }}
   </div>
@@ -53,6 +56,10 @@ export default {
   line-height: 2em;
   text-align: center;
   font-size: 14px;
+
+  &.hide-tab-bar {
+    bottom: env(safe-area-inset-bottom);
+  }
 }
 
 .connect-error {


### PR DESCRIPTION
Fixes this issue on screens which have tab bar hidden (details, bidding):
![image](https://user-images.githubusercontent.com/7098449/131285803-896571ad-5146-4dff-a0be-101082265073.png)
