### PR TITLE
feat(cordova): add cordova-clipboard to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6960,8 +6960,7 @@
     "cordova-clipboard": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/cordova-clipboard/-/cordova-clipboard-1.3.0.tgz",
-      "integrity": "sha512-IGk4LZm/DJ0Xk/jgakHm4wa+A/lrRP3QfzMAHDG7oWLJS4ISOpfI32Wez4ndnENItRslGyBVyJyKD83CxELCAw==",
-      "dev": true
+      "integrity": "sha512-IGk4LZm/DJ0Xk/jgakHm4wa+A/lrRP3QfzMAHDG7oWLJS4ISOpfI32Wez4ndnENItRslGyBVyJyKD83CxELCAw=="
     },
     "cordova-common": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "cordova-plugin-qrscanner": "^3.0.1",
     "cordova-plugin-splashscreen": "^6.0.0",
     "cordova-plugin-statusbar": "^2.4.3",
+    "cordova-clipboard": "^1.3.0",
     "detect-browser": "^5.2.0",
     "fontsource-ibm-plex-sans": "^3.1.5",
     "lodash-es": "^4.17.21",


### PR DESCRIPTION
While rebasing of #1240 I discovered that `npm i` is removing `cordova-clipboard` from `package-lock.json`. Let's add this plugin to dependencies. Also we can consider moving all cordova plugins to `devDependencies` after they will resolve issues like this: https://github.com/apache/cordova-lib/issues/832