### PR TITLE
fix(deeplinks): build redirect route correctly

### DIFF
--- a/src/popup/router/index.js
+++ b/src/popup/router/index.js
@@ -95,7 +95,7 @@ if (process.env.PLATFORM === 'cordova') {
   (async () => {
     await Promise.all([deviceReadyPromise, routerReadyPromise]);
     window.IonicDeeplink.onDeepLink(({ url }) => {
-      const prefix = ['superhero:', APP_LINK_WEB].find((p) => url.startsWith(p));
+      const prefix = ['superhero:', `${APP_LINK_WEB}/`].find((p) => url.startsWith(p));
       if (!prefix) throw new Error(`Unknown url: ${url}`);
       try {
         window.location = `#/${url.slice(prefix.length)}`;


### PR DESCRIPTION
fixes #1271

Double slash in URL causes redirect to `not-found` on iOS and Android.