### PR TITLE
fix(modal): set empty span on attribute msg undefined

### DIFF
--- a/src/popup/router/components/Modals/Confirm.vue
+++ b/src/popup/router/components/Modals/Confirm.vue
@@ -39,7 +39,7 @@ export default {
   computed: {
     templateRootNode() {
       return new DOMParser()
-        .parseFromString(`<root>${this.$attrs.msg}</root>`, 'text/xml').childNodes[0];
+        .parseFromString(`<root>${this.$attrs.msg || ''}</root>`, 'text/xml').childNodes[0];
     },
   },
   methods: {

--- a/src/popup/router/components/Modals/Help.vue
+++ b/src/popup/router/components/Modals/Help.vue
@@ -19,7 +19,7 @@ export default {
   computed: {
     templateRootNode() {
       return new DOMParser()
-        .parseFromString(`<root>${this.$attrs.msg}</root>`, 'text/xml').childNodes[0];
+        .parseFromString(`<root>${this.$attrs.msg || ''}</root>`, 'text/xml').childNodes[0];
     },
   },
 };


### PR DESCRIPTION
|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/9008074/132454840-8e9c6df3-ef49-4a36-a298-3253016dabd9.png)|![image](https://user-images.githubusercontent.com/9008074/132454927-de7e2fa9-ccb9-49f8-8a08-fd02c6368a65.png)|
