### PR TITLE
fix(transaction-list): do not send request after component being destroyed

### DIFF
--- a/src/popup/router/components/TransactionList.vue
+++ b/src/popup/router/components/TransactionList.vue
@@ -67,6 +67,7 @@ export default {
       loading: false,
       transactions: [],
       page: 1,
+      isDestroyed: false,
       displayMode: { rotated: true, filter: 'all', sort: 'date' },
       filters: {
         all: {}, sent: {}, received: {}, tips: {}, date: { rotated: true },
@@ -136,11 +137,13 @@ export default {
       document.querySelector('#app').removeEventListener('scroll', this.checkLoadMore);
       window.removeEventListener('scroll', this.checkLoadMore);
       clearInterval(polling);
+      this.isDestroyed = true;
     });
     this.$watch(({ displayMode }) => displayMode, this.checkLoadMore);
   },
   methods: {
     checkLoadMore() {
+      if (this.isDestroyed) return;
       const isDesktop = document.documentElement.clientWidth > 480 || process.env.IS_EXTENSION;
       const { scrollHeight, scrollTop, clientHeight } = isDesktop
         ? document.querySelector('#app') : document.documentElement;


### PR DESCRIPTION
The problem here is that after the component being destroyed it is waiting while the code will stop working and then garbage collector will clean it, but we have two functions that are calling each other in an infinite loop. In result we have a several request being send to the mdw to get the transactions on other pages. There is a flag `_isDestroyed` which can do the same trick as i did in the PR, but since this is a private method, on the side of vue they might brake it without any documentation.

![LoadOnOtherPage](https://user-images.githubusercontent.com/9008074/139821133-a5dceca6-85bd-4fba-99bb-a67b24cd8b1b.gif)
