### PR TITLE
Fix spend transaction with fungible tokens

### DIFF
--- a/src/popup/router/components/InputAmount.vue
+++ b/src/popup/router/components/InputAmount.vue
@@ -58,7 +58,7 @@ export default {
   },
   computed: {
     ...mapState(['sdk']),
-    ...mapGetters(['formatCurrency']),
+    ...mapGetters(['formatCurrency', 'account']),
     ...mapGetters('fungibleTokens', ['selectedToken']),
     hasError() {
       return this.$validator.errors.has('amount');

--- a/src/popup/router/components/Modals/SpendSuccess.vue
+++ b/src/popup/router/components/Modals/SpendSuccess.vue
@@ -46,8 +46,8 @@ export default {
   },
   methods: {
     getSymbol() {
-      return this.transaction.contractId
-        ? this.availableTokens[this.transaction.contractId].symbol
+      return this.transaction.tx.contractId
+        ? this.availableTokens[this.transaction.tx.contractId].symbol
         : 'AE';
     },
   },

--- a/src/popup/utils/constants.js
+++ b/src/popup/utils/constants.js
@@ -37,6 +37,7 @@ export const calculateFee = (type, params) => {
       ctVersion: { abiVersion: SCHEMA.ABI_VERSIONS.SOPHIA, vmVersion: SCHEMA.VM_VERSIONS.SOPHIA },
       abiVersion: SCHEMA.ABI_VERSIONS.SOPHIA,
       callData: STUB_CALLDATA,
+      gas: 0,
       ...params,
     },
     ...type === 'nameClaimTx' ? { vsn: SCHEMA.VSN_2 } : {},


### PR DESCRIPTION
fixes #1472,
also fixes issues that appearing when user opens Transfer page with fungible token chosen
`
Uncaught (in promise) InvalidTxParamsError: Transaction build error. {"gas":"Field is required"}
`
`
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'address')
`