### PR TITLE
fix(deeplink-api): complete opening a callback url correctly

### DIFF
--- a/src/mixins/deeplinkApi.js
+++ b/src/mixins/deeplinkApi.js
@@ -15,6 +15,7 @@ export default {
         (url, [key, value]) => url.replace(new RegExp(`{${key}}`, 'g'), encodeURIComponent(value)),
         this.$route.query[isSuccess ? 'x-success' : 'x-cancel'],
       );
+      this.$router.push('/account');
       window.open(callbackUrl, '_self');
     },
   },


### PR DESCRIPTION
fixes #1516,
fixes #1517,
fixes #1466 