### PR TITLE
Fix transactions

### DIFF
--- a/src/popup/router/components/TransactionItem.vue
+++ b/src/popup/router/components/TransactionItem.vue
@@ -105,7 +105,8 @@ export default {
     },
     fiatAmount() {
       const aeToken = this.tokens?.find((t) => t?.isAe);
-      if (!aeToken || this.isErrorTransaction) return 0;
+      if (!aeToken || this.isErrorTransaction
+        || (this.isDex && FUNCTION_TYPE_DEX.pool.includes(this.transaction.tx.function))) return 0;
       return this.getAmountFiat(amountRounded(aeToken.decimals
         ? convertToken(aeToken.amount || 0, -aeToken.decimals) : aeToken.amount));
     },

--- a/src/popup/router/pages/TransactionDetails.vue
+++ b/src/popup/router/pages/TransactionDetails.vue
@@ -228,6 +228,7 @@ export default {
     if (!this.transaction || this.transaction?.incomplete) {
       await this.$watchUntilTruly(() => this.$store.state.middleware);
       this.transaction = await this.$store.state.middleware.getTxByHash(this.hash);
+      this.$store.commit('setTransactionByHash', this.transaction);
     }
   },
   methods: {

--- a/src/popup/router/pages/TransferSend.vue
+++ b/src/popup/router/pages/TransferSend.vue
@@ -312,6 +312,7 @@ export default {
               callerId: this.account.address,
               contractId: this.selectedToken.contractId,
               type: SCHEMA.TX_TYPE.contractCall,
+              function: 'transfer',
             },
           });
         } else if (this.selectedToken) {
@@ -330,6 +331,7 @@ export default {
               callerId: this.account.address,
               contractId: this.selectedToken.contractId,
               type: SCHEMA.TX_TYPE.contractCall,
+              function: 'transfer',
             },
           });
         } else {

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -10,6 +10,10 @@ export default {
   addTransactions(state, payload) {
     Vue.set(state.transactions, 'loaded', uniqBy([...state.transactions.loaded, ...payload], 'hash'));
   },
+  setTransactionByHash(state, transaction) {
+    const index = state.transactions.loaded.findIndex((t) => t.hash === transaction.hash);
+    if (index !== -1) Vue.set(state.transactions.loaded, index, transaction);
+  },
   setTipWithdrawnTransactions(state, payload) {
     Vue.set(state.transactions, 'tipWithdrawnTransactions', payload);
   },

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -8,18 +8,18 @@ export default {
     state.current.network = payload;
   },
   addTransactions(state, payload) {
-    state.transactions.loaded = uniqBy([...state.transactions.loaded, ...payload], 'hash');
+    Vue.set(state.transactions, 'loaded', uniqBy([...state.transactions.loaded, ...payload], 'hash'));
   },
   setTipWithdrawnTransactions(state, payload) {
-    state.transactions.tipWithdrawnTransactions = payload;
+    Vue.set(state.transactions, 'tipWithdrawnTransactions', payload);
   },
   initTransactions(state) {
-    state.transactions.loaded = [];
-    state.transactions.nextPageUrl = '';
-    state.transactions.tipWithdrawnTransactions = [];
+    Vue.set(state.transactions, 'loaded', []);
+    Vue.set(state.transactions, 'nextPageUrl', '');
+    Vue.set(state.transactions, 'tipWithdrawnTransactions', []);
   },
   setTransactionsNextPage(state, pageUrl) {
-    state.transactions.nextPageUrl = pageUrl;
+    Vue.set(state.transactions, 'nextPageUrl', pageUrl);
   },
   addPendingTransaction(state, { transaction, network }) {
     Vue.set(state.transactions.pending, network,

--- a/src/store/plugins/fungibleTokens.js
+++ b/src/store/plugins/fungibleTokens.js
@@ -227,7 +227,10 @@ export default (store) => {
         );
       },
       async getTokensHistory(
-        { state: { transactions }, rootGetters: { activeNetwork, account }, commit }, recent,
+        {
+          state: { transactions },
+          rootGetters: { activeNetwork, account, getDexContracts }, commit,
+        }, recent,
       ) {
         const { address } = account;
         if (transactions[address]?.length && !recent) return transactions[address];
@@ -257,6 +260,7 @@ export default (store) => {
         }
 
         const newTransactions = rawTransactions
+          .filter((tx) => !getDexContracts.router.includes(tx.contract_id))
           .map((tx) => ({
             ...tx,
             tx: {


### PR DESCRIPTION
Since all the dex contract calls contain user address, `txs/backward` will return them and will have more information than `aex9/transfers/to/`. I propose to exclude them from the list which `getTokenHistory` is returning.
![image](https://user-images.githubusercontent.com/9008074/183562043-b808918e-bbf7-4125-a2c1-46b1b4a48b1d.png)
