### PR TITLE
[Proposition] Large mobile screens fixes

### DIFF
--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -113,6 +113,7 @@ export default {
   --screen-padding-x: 16px;
   --screen-bg-color: #{variables.$color-bg-3};
   --header-height: 0;
+  --gap: 12px;
 
   @extend %face-sans-16-regular;
 

--- a/src/popup/router/components/Header.vue
+++ b/src/popup/router/components/Header.vue
@@ -172,7 +172,7 @@ export default {
   height: calc(var(--header-height) + env(safe-area-inset-top));
   background-color: var(--screen-bg-color);
   display: flex;
-  padding: env(safe-area-inset-top) 8px 8px 8px;
+  padding: env(safe-area-inset-top) 8px 0 8px;
   align-items: center;
   justify-content: space-between;
   width: 100%;

--- a/src/popup/router/components/Modal.vue
+++ b/src/popup/router/components/Modal.vue
@@ -125,6 +125,7 @@ export default {
   min-width: variables.$extension-width;
   background-color: rgba(variables.$color-black, 0.7);
   display: flex;
+  will-change: backdrop-filter;
 
   &.blur-bg {
     backdrop-filter: blur(5px);
@@ -141,6 +142,7 @@ export default {
     box-shadow:
       0 0 0 1px variables.$color-border,
       2px 4px 12px rgba(variables.$color-black, 0.22);
+    will-change: transform;
 
     @include mixins.desktop {
       width: calc(#{variables.$extension-width} - 32px);

--- a/src/popup/router/components/dashboard/Card.vue
+++ b/src/popup/router/components/dashboard/Card.vue
@@ -64,7 +64,7 @@ export default {
   width: 100%;
   background-color: variables.$color-bg-6;
   min-height: 116px;
-  border-radius: 10px;
+  border-radius: variables.$border-radius-interactive;
   padding: 16px;
   gap: 8px;
   background-repeat: no-repeat;

--- a/src/popup/router/components/dashboard/CardRow.vue
+++ b/src/popup/router/components/dashboard/CardRow.vue
@@ -13,9 +13,9 @@ export default {
 <style lang="scss" scoped>
   .card-row {
     display: flex;
-    padding: 0 16px;
-    gap: 12px;
-    margin-bottom: 12px;
+    padding: 0 var(--screen-padding-x);
+    gap: var(--gap);
+    margin-bottom: var(--gap);
     width: 100%;
 
     &:last-child {

--- a/src/popup/router/pages/AccountDetails.vue
+++ b/src/popup/router/pages/AccountDetails.vue
@@ -39,9 +39,11 @@
         />
       </div>
 
-      <div class="search-bar-wrapper">
+      <div
+        v-if="searchTermPlaceholder"
+        class="search-bar-wrapper"
+      >
         <SearchBar
-          v-if="searchTermPlaceholder"
           v-model="searchTerm"
           :placeholder="searchTermPlaceholder"
         />
@@ -174,6 +176,7 @@ export default {
   --screen-bg-color: #{variables.$color-bg-modal};
 
   border-radius: variables.$border-radius-app;
+  min-height: 100%;
   font-weight: 500;
   color: variables.$color-white;
   background-color: var(--screen-bg-color);
@@ -220,35 +223,34 @@ export default {
   }
 
   .buttons {
-    padding: 20px var(--screen-padding-x) 12px;
+    margin-top: 20px;
+    padding: 0 var(--screen-padding-x);
     width: 100%;
     display: inline-flex;
     justify-content: space-between;
-    gap: 16px;
+    gap: var(--gap);
   }
 
   .header {
     position: sticky;
     z-index: 2;
     top: calc(env(safe-area-inset-top) + 62px);
-    padding-left: var(--screen-padding-x);
-    padding-right: var(--screen-padding-x);
+    padding: var(--gap) var(--screen-padding-x);
     background-color: var(--screen-bg-color);
   }
 
   .tabs {
-    gap: 16px;
-    padding-left: 4px;
-    padding-right: 4px;
-    border-radius: 14px;
-    background-color: var(--screen-bg-color);
+    gap: var(--gap);
+    padding: 4px;
+    border-radius: variables.$border-radius-interactive;
+    background-color: variables.$color-black;
 
     @include mixins.flex(flex-start, center, row);
 
     .button-plain {
       padding: 4px 10px;
       gap: 4px;
-      border-radius: 10px;
+      border-radius: variables.$border-radius-interactive - 3px;
 
       @extend %face-sans-14-medium;
 
@@ -265,7 +267,7 @@ export default {
     position: sticky;
     top: calc(env(safe-area-inset-top) + 104px);
     z-index: 1;
-    margin-top: 8px;
+    margin-top: var(--gap);
   }
 
   .tabs-content {

--- a/src/popup/router/pages/AccountDetailsNames.vue
+++ b/src/popup/router/pages/AccountDetailsNames.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="account-details-names">
     <div class="tabs">
       <ButtonPlain
         :to="{ name: 'account-details-names' }"
@@ -35,15 +35,15 @@ export default {
   },
 };
 </script>
-<style lang="scss" scoped>
-  @use '../../../styles/variables';
-  @use '../../../styles/mixins';
-  @use '../../../styles/typography';
 
+<style lang="scss" scoped>
+@use '../../../styles/variables';
+@use '../../../styles/mixins';
+@use '../../../styles/typography';
+
+.account-details-names {
   .tabs {
-    gap: 16px;
-    padding-left: 4px;
-    padding-right: 4px;
+    gap: var(--gap);
     border-radius: 14px;
     padding-top: 2px;
     background-color: var(--screen-bg-color);
@@ -68,4 +68,5 @@ export default {
       }
     }
   }
+}
 </style>

--- a/src/popup/router/pages/Index.vue
+++ b/src/popup/router/pages/Index.vue
@@ -61,7 +61,7 @@
       <ButtonSubheader
         v-show="termsAgreed"
         data-cy="generate-wallet"
-        :subheader=" $t('pages.index.getStartedWithWallet')"
+        :subheader="$t('pages.index.getStartedWithWallet')"
         :header="$t('pages.index.generateWallet')"
         @click="createWallet"
       >
@@ -70,7 +70,7 @@
       <ButtonSubheader
         v-show="termsAgreed"
         data-cy="import-wallet"
-        :subheader=" $t('pages.index.enterSeed') "
+        :subheader="$t('pages.index.enterSeed')"
         :header="$t('pages.index.importWallet')"
         @click="importWallet"
       >

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -10,6 +10,7 @@
     display: none;
   }
 
+  -webkit-tap-highlight-color: transparent;
   -ms-overflow-style: none;
   scrollbar-width: none;
 }


### PR DESCRIPTION
**List of changes/fixes:**
1. Changed the app height from 600px to 100% of the screen to allow the app to stretch on mobile screens with atypical aspect ratio.
2. Removed border radius from the app - it was visible on android mobile devices.
3. Center the app header elements vertically. Previously bottom padding was forcing the header content to be too high.
4. Making the account details page to be 100% height of the app.
5. Repaired the missing dark background color behind the account details tabs ("Assets", "Transactions", "Names").
6. Unify gaps between buttons on home page and the account details with the use of global CSS variable `--gap`.
7. Align the items in account details to have the same left and right padding.
8. Performance tweaks to modal opening transition - added `will-change` property.
9. Removed tap highlight color from android devices.