### PR TITLE
[SW-302]: Vue 3 compatible way of passing content to component slots

### DIFF
--- a/src/popup/components/AuctionOverview.vue
+++ b/src/popup/components/AuctionOverview.vue
@@ -1,10 +1,11 @@
 <template>
   <div class="auction-overview">
     <DetailsItem :label="$t('pages.auctionBid.current-highest-bid')">
-      <TokenAmount
-        slot="value"
-        :amount="+getHighestBid(name).nameFee"
-      />
+      <template #value>
+        <TokenAmount
+          :amount="+getHighestBid(name).nameFee"
+        />
+      </template>
     </DetailsItem>
     <DetailsItem
       class="end-height"

--- a/src/popup/components/InputAmountV2.vue
+++ b/src/popup/components/InputAmountV2.vue
@@ -9,11 +9,12 @@
     :message="$attrs['message'] || errors.first('amount')"
     @input="$emit('input', $event)"
   >
-    <slot
-      v-for="slot in Object.keys($slots)"
-      :slot="slot"
-      :name="slot"
-    />
+    <template
+      v-for="(index, name) in $slots"
+      #[name]
+    >
+      <slot :name="name" />
+    </template>
     <template #after="{ focused }">
       <SelectAsset
         v-bind="$attrs"

--- a/src/popup/components/Modals/Confirm.vue
+++ b/src/popup/components/Modals/Confirm.vue
@@ -3,12 +3,12 @@
     v-bind="{ ...$attrs, resolve }"
     :close="cancel"
   >
-    <TemplateRenderer
-      v-if="!$slots.msg"
-      slot="msg"
-      :str="$attrs.msg"
-    />
-    <template slot="footer">
+    <template #msg>
+      <TemplateRenderer
+        :str="msg"
+      />
+    </template>
+    <template #footer>
       <BtnMain
         variant="secondary"
         @click="cancel"
@@ -39,6 +39,7 @@ export default {
   props: {
     resolve: { type: Function, required: true },
     reject: { type: Function, required: true },
+    msg: { type: String, default: '' },
   },
   methods: {
     cancel() {

--- a/src/popup/components/Modals/ConfirmTransactionSign.vue
+++ b/src/popup/components/Modals/ConfirmTransactionSign.vue
@@ -25,10 +25,11 @@
       :label="$t('modals.confirm-transaction-sign.nameFee')"
       class="name-fee"
     >
-      <TokenAmount
-        slot="value"
-        :amount="getNameFee(transaction)"
-      />
+      <template #value>
+        <TokenAmount
+          :amount="getNameFee(transaction)"
+        />
+      </template>
     </DetailsItem>
 
     <div class="details">
@@ -36,33 +37,36 @@
         v-if="isSwap"
         :label="$t(`pages.signTransaction.${swapDirection}`)"
       >
-        <TokenAmount
-          slot="value"
-          :amount="+convertToken(getSwapTokenAmountData.amount, -getSwapTokenAmountData.decimals)"
-          :symbol="getSwapTokenAmountData.isAe ? 'AE' : getSwapTokenAmountData.symbol"
-          :aex9="isTxAex9(transaction)"
-          :hide-fiat="!getSwapTokenAmountData.isAe"
-          data-cy="total"
-        />
+        <template #value>
+          <TokenAmount
+            :amount="+convertToken(getSwapTokenAmountData.amount, -getSwapTokenAmountData.decimals)"
+            :symbol="getSwapTokenAmountData.isAe ? 'AE' : getSwapTokenAmountData.symbol"
+            :aex9="isTxAex9(transaction)"
+            :hide-fiat="!getSwapTokenAmountData.isAe"
+            data-cy="total"
+          />
+        </template>
       </DetailsItem>
       <DetailsItem :label="$t('pages.signTransaction.fee')">
-        <TokenAmount
-          slot="value"
-          :amount="getTxFee(transaction)"
-          data-cy="fee"
-        />
+        <template #value>
+          <TokenAmount
+            :amount="getTxFee(transaction)"
+            data-cy="fee"
+          />
+        </template>
       </DetailsItem>
       <DetailsItem
         v-if="!isDex"
         :label="$t('pages.signTransaction.total')"
       >
-        <TokenAmount
-          slot="value"
-          :amount="getTxAmountTotal(transaction)"
-          :symbol="getTxSymbol(transaction)"
-          :aex9="isTxAex9(transaction)"
-          data-cy="total"
-        />
+        <template #value>
+          <TokenAmount
+            :amount="getTxAmountTotal(transaction)"
+            :symbol="getTxSymbol(transaction)"
+            :aex9="isTxAex9(transaction)"
+            data-cy="total"
+          />
+        </template>
       </DetailsItem>
     </div>
 
@@ -89,9 +93,8 @@
         />
       </div>
     </transition>
-    <template
-      slot="footer"
-    >
+
+    <template #footer>
       <BtnMain
         third
         variant="secondary"

--- a/src/popup/components/Modals/ErrorLog.vue
+++ b/src/popup/components/Modals/ErrorLog.vue
@@ -15,7 +15,7 @@
       {{ $t('modals.error-log.content') }}
     </div>
 
-    <template slot="footer">
+    <template #footer>
       <BtnMain
         variant="secondary"
         @click="cancel"

--- a/src/popup/components/Modals/Help.vue
+++ b/src/popup/components/Modals/Help.vue
@@ -1,13 +1,14 @@
 <template>
   <Default
-    :icon="$attrs.icon || 'info'"
+    :icon="icon || 'info'"
     v-bind="$attrs"
   >
-    <TemplateRenderer
-      slot="msg"
-      :str="$attrs.msg"
-      :option="$attrs.option"
-    />
+    <template #msg>
+      <TemplateRenderer
+        :str="msg"
+        :option="option"
+      />
+    </template>
   </Default>
 </template>
 
@@ -16,6 +17,14 @@ import Default from './Default.vue';
 import TemplateRenderer from '../TemplateRenderer.vue';
 
 export default {
-  components: { Default, TemplateRenderer },
+  components: {
+    Default,
+    TemplateRenderer,
+  },
+  props: {
+    msg: { type: String, default: '' },
+    option: { type: Object, default: null },
+    icon: { type: String, default: null },
+  },
 };
 </script>

--- a/src/popup/components/Modals/ShareQr.vue
+++ b/src/popup/components/Modals/ShareQr.vue
@@ -12,11 +12,13 @@
         level="Q"
       />
     </div>
+
     <TemplateRenderer
       :class="!msgStr.includes('.chain') && 'address'"
       :str="msgStr"
     />
-    <template slot="footer">
+
+    <template #footer>
       <BtnMain
         variant="secondary"
         @click="resolve"

--- a/src/popup/components/NameItem.vue
+++ b/src/popup/components/NameItem.vue
@@ -105,20 +105,22 @@
         v-if="Object.entries(nameEntry.pointers || {}).length"
         :label="$t('pages.names.list.pointers')"
       >
-        <BtnHelp
-          slot="label"
-          :title="$t('modals.name-pointers-help.title')"
-          :msg="$t('modals.name-pointers-help.msg')"
-        />
-        <div
-          v-for="(nameEntryPointer, key, idx) in nameEntry.pointers"
-          slot="value"
-          :key="key"
-          class="pointers"
-        >
-          <span>{{ `#${idx + 1}` }}</span>
-          {{ nameEntryPointer }}
-        </div>
+        <template #label>
+          <BtnHelp
+            :title="$t('modals.name-pointers-help.title')"
+            :msg="$t('modals.name-pointers-help.msg')"
+          />
+        </template>
+        <template #value>
+          <div
+            v-for="(nameEntryPointer, key, idx) in nameEntry.pointers"
+            :key="key"
+            class="pointers"
+          >
+            <span>{{ `#${idx + 1}` }}</span>
+            {{ nameEntryPointer }}
+          </div>
+        </template>
       </DetailsItem>
     </div>
   </div>

--- a/src/popup/components/NotificationItem.vue
+++ b/src/popup/components/NotificationItem.vue
@@ -24,7 +24,7 @@
         </span>
       </div>
       <ActionsMenu @click.native.stop>
-        <template slot="display">
+        <template #display>
           •••
         </template>
         <div

--- a/src/popup/components/TransactionDetailsPoolTokenRow.vue
+++ b/src/popup/components/TransactionDetailsPoolTokenRow.vue
@@ -3,24 +3,26 @@
     :label="label"
     class="pool-token-row"
   >
-    <div slot="value">
-      <TokenAmount
-        v-if="!hideAmount"
-        :amount="+convertToken(token.amount, -token.decimals)"
-        hide-fiat
-        no-symbol
-      />
-      <div class="token-info">
-        <Tokens
-          v-if="token"
-          :tokens="token.isPool ? [tokens[0], tokens[1]] : [token]"
+    <template #value>
+      <div>
+        <TokenAmount
+          v-if="!hideAmount"
+          :amount="+convertToken(token.amount, -token.decimals)"
+          hide-fiat
+          no-symbol
         />
-        <AddressShortening
-          v-if="token.contractId"
-          :address="token.contractId"
-        />
+        <div class="token-info">
+          <Tokens
+            v-if="token"
+            :tokens="token.isPool ? [tokens[0], tokens[1]] : [token]"
+          />
+          <AddressShortening
+            v-if="token.contractId"
+            :address="token.contractId"
+          />
+        </div>
       </div>
-    </div>
+    </template>
   </DetailsItem>
 </template>
 

--- a/src/popup/components/TransferReviewTip.vue
+++ b/src/popup/components/TransferReviewTip.vue
@@ -38,7 +38,6 @@
     <span class="token-amount-wrapper">
       {{ $t('pages.send.sending') }}
       <TokenAmount
-        slot="value"
         :amount="+transferData.amount"
         :symbol="tokenSymbol"
         :hide-fiat="!!selectedToken"

--- a/src/popup/components/TransferSendForm.vue
+++ b/src/popup/components/TransferSendForm.vue
@@ -65,12 +65,13 @@
     <DetailsItem
       :label="$t('pages.signTransaction.fee')"
     >
-      <TokenAmount
-        slot="value"
-        :amount="+fee.toFixed()"
-        symbol="AE"
-        data-cy="review-fee"
-      />
+      <template #value>
+        <TokenAmount
+          :amount="+fee.toFixed()"
+          symbol="AE"
+          data-cy="review-fee"
+        />
+      </template>
     </DetailsItem>
   </div>
 </template>

--- a/src/popup/pages/Names/AuctionBid.vue
+++ b/src/popup/pages/Names/AuctionBid.vue
@@ -10,17 +10,19 @@
       />
       <div class="tx-details">
         <DetailsItem :label="$t('tx-fee')">
-          <TokenAmount
-            slot="value"
-            :amount="+txFee"
-            hide-fiat
-          />
+          <template #value>
+            <TokenAmount
+              :amount="+txFee"
+              hide-fiat
+            />
+          </template>
         </DetailsItem>
         <DetailsItem :label="$t('total')">
-          <TokenAmount
-            slot="value"
-            :amount="+amountTotal"
-          />
+          <template #value>
+            <TokenAmount
+              :amount="+amountTotal"
+            />
+          </template>
         </DetailsItem>
       </div>
       <BtnMain

--- a/src/popup/pages/Popups/Connect.vue
+++ b/src/popup/pages/Popups/Connect.vue
@@ -33,7 +33,7 @@
       </span>
     </div>
 
-    <template slot="footer">
+    <template #footer>
       <BtnMain
         variant="secondary"
         data-cy="deny"

--- a/src/popup/pages/Popups/MessageSign.vue
+++ b/src/popup/pages/Popups/MessageSign.vue
@@ -31,7 +31,7 @@
       </template>
     </DetailsItem>
 
-    <template slot="footer">
+    <template #footer>
       <BtnMain
         variant="secondary"
         data-cy="deny"

--- a/src/popup/pages/TransactionDetails.vue
+++ b/src/popup/pages/TransactionDetails.vue
@@ -67,12 +67,13 @@
             data-cy="hash"
             small
           >
-            <CopyAddress
-              slot="value"
-              class="copy-hash"
-              :value="hash"
-              :custom-text="$t('hashCopied')"
-            />
+            <template #value>
+              <CopyAddress
+                class="copy-hash"
+                :value="hash"
+                :custom-text="$t('hashCopied')"
+              />
+            </template>
           </DetailsItem>
           <div class="span-3-columns">
             <DetailsItem
@@ -112,24 +113,26 @@
             :label="$t('pages.transactionDetails.amount')"
             data-cy="amount"
           >
-            <TokenAmount
-              slot="value"
-              :amount="getTxAmountTotal(transaction)"
-              :symbol="getTxSymbol(transaction)"
-              :hide-fiat="getTxSymbol(transaction) !== 'AE'"
-            />
+            <template #value>
+              <TokenAmount
+                :amount="getTxAmountTotal(transaction)"
+                :symbol="getTxSymbol(transaction)"
+                :hide-fiat="getTxSymbol(transaction) !== 'AE'"
+              />
+            </template>
           </DetailsItem>
           <DetailsItem
             v-if="transaction.tx.gasPrice"
             :label="$t('pages.transactionDetails.gasPrice')"
             data-cy="gas-price"
           >
-            <TokenAmount
-              slot="value"
-              :amount="+aettosToAe(transaction.tx.gasPrice)"
-              symbol="AE"
-              hide-fiat
-            />
+            <template #value>
+              <TokenAmount
+                :amount="+aettosToAe(transaction.tx.gasPrice)"
+                symbol="AE"
+                hide-fiat
+              />
+            </template>
           </DetailsItem>
           <DetailsItem
             v-if="transaction.tx.gasUsed"
@@ -142,11 +145,12 @@
             :label="$t('pages.transactionDetails.fee')"
             data-cy="fee"
           >
-            <TokenAmount
-              slot="value"
-              :amount="+aettosToAe(transaction.tx.fee)"
-              symbol="AE"
-            />
+            <template #value>
+              <TokenAmount
+                :amount="+aettosToAe(transaction.tx.fee)"
+                symbol="AE"
+              />
+            </template>
           </DetailsItem>
         </div>
         <div class="explorer">


### PR DESCRIPTION
Tech enabler for the further migration to Vue 3.
`slot="xxx"` is not working in Vue 3 and should be replaced with `<template #xxx>...</template>`.