### PR TITLE
Added testcases for Tokens & TotalAmount Component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ tests/e2e/screenshots
 .DS_Store
 /tests/e2e/videos/
 /tests/e2e/screenshots/
+/coverage
 
 # local env files
 .env.local

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,4 +17,5 @@ module.exports = {
   setupFiles: [
     '<rootDir>/config/jest/setEnvVars.js',
   ],
+  collectCoverage: true,
 };

--- a/tests/unit/TokenAmount.spec.js
+++ b/tests/unit/TokenAmount.spec.js
@@ -1,0 +1,32 @@
+import {shallowMount} from '@vue/test-utils'
+import TokenAmount from '../../src/popup/components/TokenAmount.vue'
+
+let wrapper;
+
+describe('TokenAmount',()=>{
+    beforeEach(()=>{
+        wrapper = shallowMount(TokenAmount,{
+            propsData:{
+                amount:111,
+                hideFiat:true,
+                direction:'sent',
+                large:false,
+                noSymbol:true,
+                highPrecision:false
+            },
+            mocks:{
+                $store:{
+                    state:{},
+                    getters:{}
+                }
+            }
+        })
+    })
+
+    it('should match the snapshot',()=>{
+        expect(wrapper.vm).toMatchSnapshot()
+    })
+})
+
+
+

--- a/tests/unit/Tokens.spec.js
+++ b/tests/unit/Tokens.spec.js
@@ -1,0 +1,35 @@
+import {shallowMount} from '@vue/test-utils'
+import Tokens from '../../src/popup/components/Tokens.vue'
+
+let wrapper;
+
+describe('Tokens',()=>{
+    beforeEach(()=>{
+        wrapper = shallowMount(Tokens,{
+            propsData:{
+                tokens:[{symbol:'test123'},{symbol:'test456'}],
+                vertical:true
+            }
+        })
+    })
+
+    it('should match the snapshot',()=>{
+        expect(wrapper.vm).toMatchSnapshot()
+    })
+
+    it('should test getAvailableCharLength',async ()=>{
+        const getAvailableCharLength = jest.spyOn(wrapper.vm,'getAvailableCharLength')
+        let length = wrapper.vm.getAvailableCharLength()
+        expect(getAvailableCharLength).toHaveBeenCalled()
+        expect(length).toEqual(5)
+        await wrapper.setProps({symbolLength:11,
+            doubleSymbolLength:5,
+            tokens:[{symbol:'test'},{symbol:'test456'}],
+            vertical:true})
+        length = wrapper.vm.getAvailableCharLength()
+        expect(length).toEqual(7)
+    })
+})
+
+
+

--- a/tests/unit/__snapshots__/TokenAmount.spec.js.snap
+++ b/tests/unit/__snapshots__/TokenAmount.spec.js.snap
@@ -1,0 +1,21091 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should match the snapshot 1`] = `
+VueComponent {
+  "$attrs": Object {},
+  "$children": Array [],
+  "$createElement": [Function],
+  "$el": <span
+    class="token-amount sent"
+  >
+    
+  111
+  
+    <!---->
+     
+    <!---->
+  </span>,
+  "$emit": [Function],
+  "$listeners": Object {},
+  "$options": Object {
+    "_componentTag": undefined,
+    "_parentListeners": Object {},
+    "_parentVnode": VNode {
+      "asyncFactory": undefined,
+      "asyncMeta": undefined,
+      "children": undefined,
+      "componentInstance": [Circular],
+      "componentOptions": Object {
+        "Ctor": [Function],
+        "children": undefined,
+        "listeners": Object {},
+        "propsData": Object {
+          "amount": 111,
+          "direction": "sent",
+          "hideFiat": true,
+          "highPrecision": false,
+          "large": false,
+          "noSymbol": true,
+        },
+        "tag": undefined,
+      },
+      "context": VueComponent {
+        "$attrs": Object {},
+        "$children": Array [
+          [Circular],
+        ],
+        "$createElement": [Function],
+        "$el": <span
+          class="token-amount sent"
+        >
+          
+  111
+  
+          <!---->
+           
+          <!---->
+        </span>,
+        "$emit": [Function],
+        "$listeners": Object {},
+        "$options": Object {
+          "$_doNotStubChildren": true,
+          "$_isWrapperParent": true,
+          "_Ctor": Object {
+            "1": [Function],
+          },
+          "_base": [Function],
+          "_isFunctionalContainer": undefined,
+          "beforeCreate": Array [
+            [Function],
+            [Function],
+            [Function],
+          ],
+          "components": Object {
+            "transition": Object {
+              "$_doNotStubChildren": true,
+              "$_vueTestUtils_original": Object {
+                "_Ctor": Object {
+                  "1": [Function],
+                },
+                "abstract": true,
+                "name": "transition",
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "mode": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+              },
+              "abstract": true,
+              "attrs": undefined,
+              "class": undefined,
+              "domProps": undefined,
+              "functional": undefined,
+              "key": undefined,
+              "model": undefined,
+              "name": "transition",
+              "nativeOn": undefined,
+              "normalizedStyle": undefined,
+              "on": undefined,
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "mode": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+              "staticClass": undefined,
+              "staticStyle": undefined,
+              "style": undefined,
+            },
+            "transition-group": Object {
+              "$_doNotStubChildren": true,
+              "$_vueTestUtils_original": Object {
+                "_Ctor": Object {
+                  "1": [Function],
+                },
+                "beforeMount": [Function],
+                "methods": Object {
+                  "hasMove": [Function],
+                },
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "moveClass": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "tag": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+                "updated": [Function],
+              },
+              "abstract": undefined,
+              "attrs": undefined,
+              "class": undefined,
+              "domProps": undefined,
+              "functional": undefined,
+              "key": undefined,
+              "model": undefined,
+              "name": undefined,
+              "nativeOn": undefined,
+              "normalizedStyle": undefined,
+              "on": undefined,
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "moveClass": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "tag": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+              "staticClass": undefined,
+              "staticStyle": undefined,
+              "style": undefined,
+            },
+          },
+          "data": [Function],
+          "directives": Object {},
+          "filters": Object {},
+          "methods": undefined,
+          "mocks": Object {
+            "$store": Object {
+              "getters": Object {},
+              "state": Object {},
+            },
+          },
+          "provide": [Function],
+          "render": [Function],
+          "shouldProxy": true,
+          "stubs": Object {
+            "transition": true,
+            "transition-group": true,
+          },
+        },
+        "$parent": undefined,
+        "$refs": Object {},
+        "$root": [Circular],
+        "$scopedSlots": Object {},
+        "$slots": Object {},
+        "$vnode": undefined,
+        "__emitted": Object {},
+        "__emittedByOrder": Array [],
+        "_c": [Function],
+        "_data": Object {
+          "vueTestUtils_childProps": Object {
+            "amount": 111,
+            "direction": "sent",
+            "hideFiat": true,
+            "highPrecision": false,
+            "large": false,
+            "noSymbol": true,
+          },
+        },
+        "_directInactive": false,
+        "_events": Object {},
+        "_hasHookEvent": false,
+        "_inactive": null,
+        "_isBeingDestroyed": false,
+        "_isDestroyed": false,
+        "_isMounted": true,
+        "_isVue": true,
+        "_provided": Object {},
+        "_renderProxy": VueComponent {
+          "$attrs": Object {},
+          "$children": Array [
+            [Circular],
+          ],
+          "$createElement": [Function],
+          "$el": <span
+            class="token-amount sent"
+          >
+            
+  111
+  
+            <!---->
+             
+            <!---->
+          </span>,
+          "$emit": [Function],
+          "$listeners": Object {},
+          "$options": Object {
+            "$_doNotStubChildren": true,
+            "$_isWrapperParent": true,
+            "_Ctor": Object {
+              "1": [Function],
+            },
+            "_base": [Function],
+            "_isFunctionalContainer": undefined,
+            "beforeCreate": Array [
+              [Function],
+              [Function],
+              [Function],
+            ],
+            "components": Object {
+              "transition": Object {
+                "$_doNotStubChildren": true,
+                "$_vueTestUtils_original": Object {
+                  "_Ctor": Object {
+                    "1": [Function],
+                  },
+                  "abstract": true,
+                  "name": "transition",
+                  "props": Object {
+                    "appear": Object {
+                      "type": [Function],
+                    },
+                    "appearActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "appearClass": Object {
+                      "type": [Function],
+                    },
+                    "appearToClass": Object {
+                      "type": [Function],
+                    },
+                    "css": Object {
+                      "type": [Function],
+                    },
+                    "duration": Object {
+                      "type": Array [
+                        [Function],
+                        [Function],
+                        [Function],
+                      ],
+                    },
+                    "enterActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "enterClass": Object {
+                      "type": [Function],
+                    },
+                    "enterToClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveToClass": Object {
+                      "type": [Function],
+                    },
+                    "mode": Object {
+                      "type": [Function],
+                    },
+                    "name": Object {
+                      "type": [Function],
+                    },
+                    "type": Object {
+                      "type": [Function],
+                    },
+                  },
+                  "render": [Function],
+                },
+                "abstract": true,
+                "attrs": undefined,
+                "class": undefined,
+                "domProps": undefined,
+                "functional": undefined,
+                "key": undefined,
+                "model": undefined,
+                "name": "transition",
+                "nativeOn": undefined,
+                "normalizedStyle": undefined,
+                "on": undefined,
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "mode": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+                "staticClass": undefined,
+                "staticStyle": undefined,
+                "style": undefined,
+              },
+              "transition-group": Object {
+                "$_doNotStubChildren": true,
+                "$_vueTestUtils_original": Object {
+                  "_Ctor": Object {
+                    "1": [Function],
+                  },
+                  "beforeMount": [Function],
+                  "methods": Object {
+                    "hasMove": [Function],
+                  },
+                  "props": Object {
+                    "appear": Object {
+                      "type": [Function],
+                    },
+                    "appearActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "appearClass": Object {
+                      "type": [Function],
+                    },
+                    "appearToClass": Object {
+                      "type": [Function],
+                    },
+                    "css": Object {
+                      "type": [Function],
+                    },
+                    "duration": Object {
+                      "type": Array [
+                        [Function],
+                        [Function],
+                        [Function],
+                      ],
+                    },
+                    "enterActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "enterClass": Object {
+                      "type": [Function],
+                    },
+                    "enterToClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveToClass": Object {
+                      "type": [Function],
+                    },
+                    "moveClass": Object {
+                      "type": [Function],
+                    },
+                    "name": Object {
+                      "type": [Function],
+                    },
+                    "tag": Object {
+                      "type": [Function],
+                    },
+                    "type": Object {
+                      "type": [Function],
+                    },
+                  },
+                  "render": [Function],
+                  "updated": [Function],
+                },
+                "abstract": undefined,
+                "attrs": undefined,
+                "class": undefined,
+                "domProps": undefined,
+                "functional": undefined,
+                "key": undefined,
+                "model": undefined,
+                "name": undefined,
+                "nativeOn": undefined,
+                "normalizedStyle": undefined,
+                "on": undefined,
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "moveClass": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "tag": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+                "staticClass": undefined,
+                "staticStyle": undefined,
+                "style": undefined,
+              },
+            },
+            "data": [Function],
+            "directives": Object {},
+            "filters": Object {},
+            "methods": undefined,
+            "mocks": Object {
+              "$store": Object {
+                "getters": Object {},
+                "state": Object {},
+              },
+            },
+            "provide": [Function],
+            "render": [Function],
+            "shouldProxy": true,
+            "stubs": Object {
+              "transition": true,
+              "transition-group": true,
+            },
+          },
+          "$parent": undefined,
+          "$refs": Object {},
+          "$root": [Circular],
+          "$scopedSlots": Object {},
+          "$slots": Object {},
+          "$vnode": undefined,
+          "__emitted": Object {},
+          "__emittedByOrder": Array [],
+          "_c": [Function],
+          "_data": Object {
+            "vueTestUtils_childProps": Object {
+              "amount": 111,
+              "direction": "sent",
+              "hideFiat": true,
+              "highPrecision": false,
+              "large": false,
+              "noSymbol": true,
+            },
+          },
+          "_directInactive": false,
+          "_events": Object {},
+          "_hasHookEvent": false,
+          "_inactive": null,
+          "_isBeingDestroyed": false,
+          "_isDestroyed": false,
+          "_isMounted": true,
+          "_isVue": true,
+          "_provided": Object {},
+          "_renderProxy": [Circular],
+          "_self": [Circular],
+          "_staticTrees": null,
+          "_uid": 0,
+          "_vnode": [Circular],
+          "_watcher": Watcher {
+            "active": true,
+            "before": [Function],
+            "cb": [Function],
+            "deep": false,
+            "depIds": Set {
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+            },
+            "deps": Array [
+              Dep {
+                "id": 9,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 10,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 11,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 12,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 13,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 14,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 15,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 16,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+            ],
+            "dirty": false,
+            "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+            "getter": [Function],
+            "id": 1,
+            "lazy": false,
+            "newDepIds": Set {},
+            "newDeps": Array [],
+            "sync": false,
+            "user": false,
+            "value": undefined,
+            "vm": [Circular],
+          },
+          "_watchers": Array [
+            Watcher {
+              "active": true,
+              "before": [Function],
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15,
+                16,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 9,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 10,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 11,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 12,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 13,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 14,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 15,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 16,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+              "getter": [Function],
+              "id": 1,
+              "lazy": false,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": undefined,
+              "vm": [Circular],
+            },
+          ],
+          "vueTestUtils_childProps": Object {
+            "amount": 111,
+            "direction": "sent",
+            "hideFiat": true,
+            "highPrecision": false,
+            "large": false,
+            "noSymbol": true,
+          },
+        },
+        "_self": [Circular],
+        "_staticTrees": null,
+        "_uid": 0,
+        "_vnode": [Circular],
+        "_watcher": Watcher {
+          "active": true,
+          "before": [Function],
+          "cb": [Function],
+          "deep": false,
+          "depIds": Set {
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+          },
+          "deps": Array [
+            Dep {
+              "id": 9,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 10,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 11,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 12,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 13,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 14,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 15,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 16,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+          ],
+          "dirty": false,
+          "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+          "getter": [Function],
+          "id": 1,
+          "lazy": false,
+          "newDepIds": Set {},
+          "newDeps": Array [],
+          "sync": false,
+          "user": false,
+          "value": undefined,
+          "vm": [Circular],
+        },
+        "_watchers": Array [
+          Watcher {
+            "active": true,
+            "before": [Function],
+            "cb": [Function],
+            "deep": false,
+            "depIds": Set {
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+            },
+            "deps": Array [
+              Dep {
+                "id": 9,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 10,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 11,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 12,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 13,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 14,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 15,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 16,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+            ],
+            "dirty": false,
+            "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+            "getter": [Function],
+            "id": 1,
+            "lazy": false,
+            "newDepIds": Set {},
+            "newDeps": Array [],
+            "sync": false,
+            "user": false,
+            "value": undefined,
+            "vm": [Circular],
+          },
+        ],
+        "vueTestUtils_childProps": Object {
+          "amount": 111,
+          "direction": "sent",
+          "hideFiat": true,
+          "highPrecision": false,
+          "large": false,
+          "noSymbol": true,
+        },
+      },
+      "data": Object {
+        "attrs": Object {},
+        "hook": Object {
+          "destroy": [Function],
+          "init": [Function],
+          "insert": [Function],
+          "prepatch": [Function],
+        },
+        "on": undefined,
+        "pendingInsert": null,
+        "scopedSlots": Object {
+          "_normalized": Object {},
+        },
+      },
+      "elm": <span
+        class="token-amount sent"
+      >
+        
+  111
+  
+        <!---->
+         
+        <!---->
+      </span>,
+      "fnContext": undefined,
+      "fnOptions": undefined,
+      "fnScopeId": undefined,
+      "isAsyncPlaceholder": false,
+      "isCloned": false,
+      "isComment": false,
+      "isOnce": false,
+      "isRootInsert": true,
+      "isStatic": false,
+      "key": undefined,
+      "ns": undefined,
+      "parent": undefined,
+      "raw": false,
+      "tag": "vue-component-5",
+      "text": undefined,
+    },
+    "_propKeys": Array [
+      "amount",
+      "symbol",
+      "aex9",
+      "fiatBelow",
+      "hideFiat",
+      "direction",
+      "large",
+      "noSymbol",
+      "highPrecision",
+    ],
+    "_renderChildren": undefined,
+    "parent": VueComponent {
+      "$attrs": Object {},
+      "$children": Array [
+        [Circular],
+      ],
+      "$createElement": [Function],
+      "$el": <span
+        class="token-amount sent"
+      >
+        
+  111
+  
+        <!---->
+         
+        <!---->
+      </span>,
+      "$emit": [Function],
+      "$listeners": Object {},
+      "$options": Object {
+        "$_doNotStubChildren": true,
+        "$_isWrapperParent": true,
+        "_Ctor": Object {
+          "1": [Function],
+        },
+        "_base": [Function],
+        "_isFunctionalContainer": undefined,
+        "beforeCreate": Array [
+          [Function],
+          [Function],
+          [Function],
+        ],
+        "components": Object {
+          "transition": Object {
+            "$_doNotStubChildren": true,
+            "$_vueTestUtils_original": Object {
+              "_Ctor": Object {
+                "1": [Function],
+              },
+              "abstract": true,
+              "name": "transition",
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "mode": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+            },
+            "abstract": true,
+            "attrs": undefined,
+            "class": undefined,
+            "domProps": undefined,
+            "functional": undefined,
+            "key": undefined,
+            "model": undefined,
+            "name": "transition",
+            "nativeOn": undefined,
+            "normalizedStyle": undefined,
+            "on": undefined,
+            "props": Object {
+              "appear": Object {
+                "type": [Function],
+              },
+              "appearActiveClass": Object {
+                "type": [Function],
+              },
+              "appearClass": Object {
+                "type": [Function],
+              },
+              "appearToClass": Object {
+                "type": [Function],
+              },
+              "css": Object {
+                "type": [Function],
+              },
+              "duration": Object {
+                "type": Array [
+                  [Function],
+                  [Function],
+                  [Function],
+                ],
+              },
+              "enterActiveClass": Object {
+                "type": [Function],
+              },
+              "enterClass": Object {
+                "type": [Function],
+              },
+              "enterToClass": Object {
+                "type": [Function],
+              },
+              "leaveActiveClass": Object {
+                "type": [Function],
+              },
+              "leaveClass": Object {
+                "type": [Function],
+              },
+              "leaveToClass": Object {
+                "type": [Function],
+              },
+              "mode": Object {
+                "type": [Function],
+              },
+              "name": Object {
+                "type": [Function],
+              },
+              "type": Object {
+                "type": [Function],
+              },
+            },
+            "render": [Function],
+            "staticClass": undefined,
+            "staticStyle": undefined,
+            "style": undefined,
+          },
+          "transition-group": Object {
+            "$_doNotStubChildren": true,
+            "$_vueTestUtils_original": Object {
+              "_Ctor": Object {
+                "1": [Function],
+              },
+              "beforeMount": [Function],
+              "methods": Object {
+                "hasMove": [Function],
+              },
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "moveClass": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "tag": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+              "updated": [Function],
+            },
+            "abstract": undefined,
+            "attrs": undefined,
+            "class": undefined,
+            "domProps": undefined,
+            "functional": undefined,
+            "key": undefined,
+            "model": undefined,
+            "name": undefined,
+            "nativeOn": undefined,
+            "normalizedStyle": undefined,
+            "on": undefined,
+            "props": Object {
+              "appear": Object {
+                "type": [Function],
+              },
+              "appearActiveClass": Object {
+                "type": [Function],
+              },
+              "appearClass": Object {
+                "type": [Function],
+              },
+              "appearToClass": Object {
+                "type": [Function],
+              },
+              "css": Object {
+                "type": [Function],
+              },
+              "duration": Object {
+                "type": Array [
+                  [Function],
+                  [Function],
+                  [Function],
+                ],
+              },
+              "enterActiveClass": Object {
+                "type": [Function],
+              },
+              "enterClass": Object {
+                "type": [Function],
+              },
+              "enterToClass": Object {
+                "type": [Function],
+              },
+              "leaveActiveClass": Object {
+                "type": [Function],
+              },
+              "leaveClass": Object {
+                "type": [Function],
+              },
+              "leaveToClass": Object {
+                "type": [Function],
+              },
+              "moveClass": Object {
+                "type": [Function],
+              },
+              "name": Object {
+                "type": [Function],
+              },
+              "tag": Object {
+                "type": [Function],
+              },
+              "type": Object {
+                "type": [Function],
+              },
+            },
+            "render": [Function],
+            "staticClass": undefined,
+            "staticStyle": undefined,
+            "style": undefined,
+          },
+        },
+        "data": [Function],
+        "directives": Object {},
+        "filters": Object {},
+        "methods": undefined,
+        "mocks": Object {
+          "$store": Object {
+            "getters": Object {},
+            "state": Object {},
+          },
+        },
+        "provide": [Function],
+        "render": [Function],
+        "shouldProxy": true,
+        "stubs": Object {
+          "transition": true,
+          "transition-group": true,
+        },
+      },
+      "$parent": undefined,
+      "$refs": Object {},
+      "$root": [Circular],
+      "$scopedSlots": Object {},
+      "$slots": Object {},
+      "$vnode": undefined,
+      "__emitted": Object {},
+      "__emittedByOrder": Array [],
+      "_c": [Function],
+      "_data": Object {
+        "vueTestUtils_childProps": Object {
+          "amount": 111,
+          "direction": "sent",
+          "hideFiat": true,
+          "highPrecision": false,
+          "large": false,
+          "noSymbol": true,
+        },
+      },
+      "_directInactive": false,
+      "_events": Object {},
+      "_hasHookEvent": false,
+      "_inactive": null,
+      "_isBeingDestroyed": false,
+      "_isDestroyed": false,
+      "_isMounted": true,
+      "_isVue": true,
+      "_provided": Object {},
+      "_renderProxy": VueComponent {
+        "$attrs": Object {},
+        "$children": Array [
+          [Circular],
+        ],
+        "$createElement": [Function],
+        "$el": <span
+          class="token-amount sent"
+        >
+          
+  111
+  
+          <!---->
+           
+          <!---->
+        </span>,
+        "$emit": [Function],
+        "$listeners": Object {},
+        "$options": Object {
+          "$_doNotStubChildren": true,
+          "$_isWrapperParent": true,
+          "_Ctor": Object {
+            "1": [Function],
+          },
+          "_base": [Function],
+          "_isFunctionalContainer": undefined,
+          "beforeCreate": Array [
+            [Function],
+            [Function],
+            [Function],
+          ],
+          "components": Object {
+            "transition": Object {
+              "$_doNotStubChildren": true,
+              "$_vueTestUtils_original": Object {
+                "_Ctor": Object {
+                  "1": [Function],
+                },
+                "abstract": true,
+                "name": "transition",
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "mode": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+              },
+              "abstract": true,
+              "attrs": undefined,
+              "class": undefined,
+              "domProps": undefined,
+              "functional": undefined,
+              "key": undefined,
+              "model": undefined,
+              "name": "transition",
+              "nativeOn": undefined,
+              "normalizedStyle": undefined,
+              "on": undefined,
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "mode": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+              "staticClass": undefined,
+              "staticStyle": undefined,
+              "style": undefined,
+            },
+            "transition-group": Object {
+              "$_doNotStubChildren": true,
+              "$_vueTestUtils_original": Object {
+                "_Ctor": Object {
+                  "1": [Function],
+                },
+                "beforeMount": [Function],
+                "methods": Object {
+                  "hasMove": [Function],
+                },
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "moveClass": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "tag": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+                "updated": [Function],
+              },
+              "abstract": undefined,
+              "attrs": undefined,
+              "class": undefined,
+              "domProps": undefined,
+              "functional": undefined,
+              "key": undefined,
+              "model": undefined,
+              "name": undefined,
+              "nativeOn": undefined,
+              "normalizedStyle": undefined,
+              "on": undefined,
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "moveClass": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "tag": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+              "staticClass": undefined,
+              "staticStyle": undefined,
+              "style": undefined,
+            },
+          },
+          "data": [Function],
+          "directives": Object {},
+          "filters": Object {},
+          "methods": undefined,
+          "mocks": Object {
+            "$store": Object {
+              "getters": Object {},
+              "state": Object {},
+            },
+          },
+          "provide": [Function],
+          "render": [Function],
+          "shouldProxy": true,
+          "stubs": Object {
+            "transition": true,
+            "transition-group": true,
+          },
+        },
+        "$parent": undefined,
+        "$refs": Object {},
+        "$root": [Circular],
+        "$scopedSlots": Object {},
+        "$slots": Object {},
+        "$vnode": undefined,
+        "__emitted": Object {},
+        "__emittedByOrder": Array [],
+        "_c": [Function],
+        "_data": Object {
+          "vueTestUtils_childProps": Object {
+            "amount": 111,
+            "direction": "sent",
+            "hideFiat": true,
+            "highPrecision": false,
+            "large": false,
+            "noSymbol": true,
+          },
+        },
+        "_directInactive": false,
+        "_events": Object {},
+        "_hasHookEvent": false,
+        "_inactive": null,
+        "_isBeingDestroyed": false,
+        "_isDestroyed": false,
+        "_isMounted": true,
+        "_isVue": true,
+        "_provided": Object {},
+        "_renderProxy": [Circular],
+        "_self": [Circular],
+        "_staticTrees": null,
+        "_uid": 0,
+        "_vnode": VNode {
+          "asyncFactory": undefined,
+          "asyncMeta": undefined,
+          "children": undefined,
+          "componentInstance": [Circular],
+          "componentOptions": Object {
+            "Ctor": [Function],
+            "children": undefined,
+            "listeners": Object {},
+            "propsData": Object {
+              "amount": 111,
+              "direction": "sent",
+              "hideFiat": true,
+              "highPrecision": false,
+              "large": false,
+              "noSymbol": true,
+            },
+            "tag": undefined,
+          },
+          "context": [Circular],
+          "data": Object {
+            "attrs": Object {},
+            "hook": Object {
+              "destroy": [Function],
+              "init": [Function],
+              "insert": [Function],
+              "prepatch": [Function],
+            },
+            "on": undefined,
+            "pendingInsert": null,
+            "scopedSlots": Object {
+              "_normalized": Object {},
+            },
+          },
+          "elm": <span
+            class="token-amount sent"
+          >
+            
+  111
+  
+            <!---->
+             
+            <!---->
+          </span>,
+          "fnContext": undefined,
+          "fnOptions": undefined,
+          "fnScopeId": undefined,
+          "isAsyncPlaceholder": false,
+          "isCloned": false,
+          "isComment": false,
+          "isOnce": false,
+          "isRootInsert": true,
+          "isStatic": false,
+          "key": undefined,
+          "ns": undefined,
+          "parent": undefined,
+          "raw": false,
+          "tag": "vue-component-5",
+          "text": undefined,
+        },
+        "_watcher": Watcher {
+          "active": true,
+          "before": [Function],
+          "cb": [Function],
+          "deep": false,
+          "depIds": Set {
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+          },
+          "deps": Array [
+            Dep {
+              "id": 9,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 10,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 11,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 12,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 13,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 14,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 15,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 16,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+          ],
+          "dirty": false,
+          "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+          "getter": [Function],
+          "id": 1,
+          "lazy": false,
+          "newDepIds": Set {},
+          "newDeps": Array [],
+          "sync": false,
+          "user": false,
+          "value": undefined,
+          "vm": [Circular],
+        },
+        "_watchers": Array [
+          Watcher {
+            "active": true,
+            "before": [Function],
+            "cb": [Function],
+            "deep": false,
+            "depIds": Set {
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+            },
+            "deps": Array [
+              Dep {
+                "id": 9,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 10,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 11,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 12,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 13,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 14,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 15,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 16,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+            ],
+            "dirty": false,
+            "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+            "getter": [Function],
+            "id": 1,
+            "lazy": false,
+            "newDepIds": Set {},
+            "newDeps": Array [],
+            "sync": false,
+            "user": false,
+            "value": undefined,
+            "vm": [Circular],
+          },
+        ],
+        "vueTestUtils_childProps": Object {
+          "amount": 111,
+          "direction": "sent",
+          "hideFiat": true,
+          "highPrecision": false,
+          "large": false,
+          "noSymbol": true,
+        },
+      },
+      "_self": [Circular],
+      "_staticTrees": null,
+      "_uid": 0,
+      "_vnode": VNode {
+        "asyncFactory": undefined,
+        "asyncMeta": undefined,
+        "children": undefined,
+        "componentInstance": [Circular],
+        "componentOptions": Object {
+          "Ctor": [Function],
+          "children": undefined,
+          "listeners": Object {},
+          "propsData": Object {
+            "amount": 111,
+            "direction": "sent",
+            "hideFiat": true,
+            "highPrecision": false,
+            "large": false,
+            "noSymbol": true,
+          },
+          "tag": undefined,
+        },
+        "context": [Circular],
+        "data": Object {
+          "attrs": Object {},
+          "hook": Object {
+            "destroy": [Function],
+            "init": [Function],
+            "insert": [Function],
+            "prepatch": [Function],
+          },
+          "on": undefined,
+          "pendingInsert": null,
+          "scopedSlots": Object {
+            "_normalized": Object {},
+          },
+        },
+        "elm": <span
+          class="token-amount sent"
+        >
+          
+  111
+  
+          <!---->
+           
+          <!---->
+        </span>,
+        "fnContext": undefined,
+        "fnOptions": undefined,
+        "fnScopeId": undefined,
+        "isAsyncPlaceholder": false,
+        "isCloned": false,
+        "isComment": false,
+        "isOnce": false,
+        "isRootInsert": true,
+        "isStatic": false,
+        "key": undefined,
+        "ns": undefined,
+        "parent": undefined,
+        "raw": false,
+        "tag": "vue-component-5",
+        "text": undefined,
+      },
+      "_watcher": Watcher {
+        "active": true,
+        "before": [Function],
+        "cb": [Function],
+        "deep": false,
+        "depIds": Set {
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+        },
+        "deps": Array [
+          Dep {
+            "id": 9,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 10,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 11,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 12,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 13,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 14,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 15,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 16,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+        ],
+        "dirty": false,
+        "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+        "getter": [Function],
+        "id": 1,
+        "lazy": false,
+        "newDepIds": Set {},
+        "newDeps": Array [],
+        "sync": false,
+        "user": false,
+        "value": undefined,
+        "vm": [Circular],
+      },
+      "_watchers": Array [
+        Watcher {
+          "active": true,
+          "before": [Function],
+          "cb": [Function],
+          "deep": false,
+          "depIds": Set {
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+          },
+          "deps": Array [
+            Dep {
+              "id": 9,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 10,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 11,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 12,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 13,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 14,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 15,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 16,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+          ],
+          "dirty": false,
+          "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+          "getter": [Function],
+          "id": 1,
+          "lazy": false,
+          "newDepIds": Set {},
+          "newDeps": Array [],
+          "sync": false,
+          "user": false,
+          "value": undefined,
+          "vm": [Circular],
+        },
+      ],
+      "vueTestUtils_childProps": Object {
+        "amount": 111,
+        "direction": "sent",
+        "hideFiat": true,
+        "highPrecision": false,
+        "large": false,
+        "noSymbol": true,
+      },
+    },
+    "propsData": Object {
+      "amount": 111,
+      "direction": "sent",
+      "hideFiat": true,
+      "highPrecision": false,
+      "large": false,
+      "noSymbol": true,
+    },
+  },
+  "$parent": VueComponent {
+    "$attrs": Object {},
+    "$children": Array [
+      [Circular],
+    ],
+    "$createElement": [Function],
+    "$el": <span
+      class="token-amount sent"
+    >
+      
+  111
+  
+      <!---->
+       
+      <!---->
+    </span>,
+    "$emit": [Function],
+    "$listeners": Object {},
+    "$options": Object {
+      "$_doNotStubChildren": true,
+      "$_isWrapperParent": true,
+      "_Ctor": Object {
+        "1": [Function],
+      },
+      "_base": [Function],
+      "_isFunctionalContainer": undefined,
+      "beforeCreate": Array [
+        [Function],
+        [Function],
+        [Function],
+      ],
+      "components": Object {
+        "transition": Object {
+          "$_doNotStubChildren": true,
+          "$_vueTestUtils_original": Object {
+            "_Ctor": Object {
+              "1": [Function],
+            },
+            "abstract": true,
+            "name": "transition",
+            "props": Object {
+              "appear": Object {
+                "type": [Function],
+              },
+              "appearActiveClass": Object {
+                "type": [Function],
+              },
+              "appearClass": Object {
+                "type": [Function],
+              },
+              "appearToClass": Object {
+                "type": [Function],
+              },
+              "css": Object {
+                "type": [Function],
+              },
+              "duration": Object {
+                "type": Array [
+                  [Function],
+                  [Function],
+                  [Function],
+                ],
+              },
+              "enterActiveClass": Object {
+                "type": [Function],
+              },
+              "enterClass": Object {
+                "type": [Function],
+              },
+              "enterToClass": Object {
+                "type": [Function],
+              },
+              "leaveActiveClass": Object {
+                "type": [Function],
+              },
+              "leaveClass": Object {
+                "type": [Function],
+              },
+              "leaveToClass": Object {
+                "type": [Function],
+              },
+              "mode": Object {
+                "type": [Function],
+              },
+              "name": Object {
+                "type": [Function],
+              },
+              "type": Object {
+                "type": [Function],
+              },
+            },
+            "render": [Function],
+          },
+          "abstract": true,
+          "attrs": undefined,
+          "class": undefined,
+          "domProps": undefined,
+          "functional": undefined,
+          "key": undefined,
+          "model": undefined,
+          "name": "transition",
+          "nativeOn": undefined,
+          "normalizedStyle": undefined,
+          "on": undefined,
+          "props": Object {
+            "appear": Object {
+              "type": [Function],
+            },
+            "appearActiveClass": Object {
+              "type": [Function],
+            },
+            "appearClass": Object {
+              "type": [Function],
+            },
+            "appearToClass": Object {
+              "type": [Function],
+            },
+            "css": Object {
+              "type": [Function],
+            },
+            "duration": Object {
+              "type": Array [
+                [Function],
+                [Function],
+                [Function],
+              ],
+            },
+            "enterActiveClass": Object {
+              "type": [Function],
+            },
+            "enterClass": Object {
+              "type": [Function],
+            },
+            "enterToClass": Object {
+              "type": [Function],
+            },
+            "leaveActiveClass": Object {
+              "type": [Function],
+            },
+            "leaveClass": Object {
+              "type": [Function],
+            },
+            "leaveToClass": Object {
+              "type": [Function],
+            },
+            "mode": Object {
+              "type": [Function],
+            },
+            "name": Object {
+              "type": [Function],
+            },
+            "type": Object {
+              "type": [Function],
+            },
+          },
+          "render": [Function],
+          "staticClass": undefined,
+          "staticStyle": undefined,
+          "style": undefined,
+        },
+        "transition-group": Object {
+          "$_doNotStubChildren": true,
+          "$_vueTestUtils_original": Object {
+            "_Ctor": Object {
+              "1": [Function],
+            },
+            "beforeMount": [Function],
+            "methods": Object {
+              "hasMove": [Function],
+            },
+            "props": Object {
+              "appear": Object {
+                "type": [Function],
+              },
+              "appearActiveClass": Object {
+                "type": [Function],
+              },
+              "appearClass": Object {
+                "type": [Function],
+              },
+              "appearToClass": Object {
+                "type": [Function],
+              },
+              "css": Object {
+                "type": [Function],
+              },
+              "duration": Object {
+                "type": Array [
+                  [Function],
+                  [Function],
+                  [Function],
+                ],
+              },
+              "enterActiveClass": Object {
+                "type": [Function],
+              },
+              "enterClass": Object {
+                "type": [Function],
+              },
+              "enterToClass": Object {
+                "type": [Function],
+              },
+              "leaveActiveClass": Object {
+                "type": [Function],
+              },
+              "leaveClass": Object {
+                "type": [Function],
+              },
+              "leaveToClass": Object {
+                "type": [Function],
+              },
+              "moveClass": Object {
+                "type": [Function],
+              },
+              "name": Object {
+                "type": [Function],
+              },
+              "tag": Object {
+                "type": [Function],
+              },
+              "type": Object {
+                "type": [Function],
+              },
+            },
+            "render": [Function],
+            "updated": [Function],
+          },
+          "abstract": undefined,
+          "attrs": undefined,
+          "class": undefined,
+          "domProps": undefined,
+          "functional": undefined,
+          "key": undefined,
+          "model": undefined,
+          "name": undefined,
+          "nativeOn": undefined,
+          "normalizedStyle": undefined,
+          "on": undefined,
+          "props": Object {
+            "appear": Object {
+              "type": [Function],
+            },
+            "appearActiveClass": Object {
+              "type": [Function],
+            },
+            "appearClass": Object {
+              "type": [Function],
+            },
+            "appearToClass": Object {
+              "type": [Function],
+            },
+            "css": Object {
+              "type": [Function],
+            },
+            "duration": Object {
+              "type": Array [
+                [Function],
+                [Function],
+                [Function],
+              ],
+            },
+            "enterActiveClass": Object {
+              "type": [Function],
+            },
+            "enterClass": Object {
+              "type": [Function],
+            },
+            "enterToClass": Object {
+              "type": [Function],
+            },
+            "leaveActiveClass": Object {
+              "type": [Function],
+            },
+            "leaveClass": Object {
+              "type": [Function],
+            },
+            "leaveToClass": Object {
+              "type": [Function],
+            },
+            "moveClass": Object {
+              "type": [Function],
+            },
+            "name": Object {
+              "type": [Function],
+            },
+            "tag": Object {
+              "type": [Function],
+            },
+            "type": Object {
+              "type": [Function],
+            },
+          },
+          "render": [Function],
+          "staticClass": undefined,
+          "staticStyle": undefined,
+          "style": undefined,
+        },
+      },
+      "data": [Function],
+      "directives": Object {},
+      "filters": Object {},
+      "methods": undefined,
+      "mocks": Object {
+        "$store": Object {
+          "getters": Object {},
+          "state": Object {},
+        },
+      },
+      "provide": [Function],
+      "render": [Function],
+      "shouldProxy": true,
+      "stubs": Object {
+        "transition": true,
+        "transition-group": true,
+      },
+    },
+    "$parent": undefined,
+    "$refs": Object {},
+    "$root": [Circular],
+    "$scopedSlots": Object {},
+    "$slots": Object {},
+    "$vnode": undefined,
+    "__emitted": Object {},
+    "__emittedByOrder": Array [],
+    "_c": [Function],
+    "_data": Object {
+      "vueTestUtils_childProps": Object {
+        "amount": 111,
+        "direction": "sent",
+        "hideFiat": true,
+        "highPrecision": false,
+        "large": false,
+        "noSymbol": true,
+      },
+    },
+    "_directInactive": false,
+    "_events": Object {},
+    "_hasHookEvent": false,
+    "_inactive": null,
+    "_isBeingDestroyed": false,
+    "_isDestroyed": false,
+    "_isMounted": true,
+    "_isVue": true,
+    "_provided": Object {},
+    "_renderProxy": VueComponent {
+      "$attrs": Object {},
+      "$children": Array [
+        [Circular],
+      ],
+      "$createElement": [Function],
+      "$el": <span
+        class="token-amount sent"
+      >
+        
+  111
+  
+        <!---->
+         
+        <!---->
+      </span>,
+      "$emit": [Function],
+      "$listeners": Object {},
+      "$options": Object {
+        "$_doNotStubChildren": true,
+        "$_isWrapperParent": true,
+        "_Ctor": Object {
+          "1": [Function],
+        },
+        "_base": [Function],
+        "_isFunctionalContainer": undefined,
+        "beforeCreate": Array [
+          [Function],
+          [Function],
+          [Function],
+        ],
+        "components": Object {
+          "transition": Object {
+            "$_doNotStubChildren": true,
+            "$_vueTestUtils_original": Object {
+              "_Ctor": Object {
+                "1": [Function],
+              },
+              "abstract": true,
+              "name": "transition",
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "mode": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+            },
+            "abstract": true,
+            "attrs": undefined,
+            "class": undefined,
+            "domProps": undefined,
+            "functional": undefined,
+            "key": undefined,
+            "model": undefined,
+            "name": "transition",
+            "nativeOn": undefined,
+            "normalizedStyle": undefined,
+            "on": undefined,
+            "props": Object {
+              "appear": Object {
+                "type": [Function],
+              },
+              "appearActiveClass": Object {
+                "type": [Function],
+              },
+              "appearClass": Object {
+                "type": [Function],
+              },
+              "appearToClass": Object {
+                "type": [Function],
+              },
+              "css": Object {
+                "type": [Function],
+              },
+              "duration": Object {
+                "type": Array [
+                  [Function],
+                  [Function],
+                  [Function],
+                ],
+              },
+              "enterActiveClass": Object {
+                "type": [Function],
+              },
+              "enterClass": Object {
+                "type": [Function],
+              },
+              "enterToClass": Object {
+                "type": [Function],
+              },
+              "leaveActiveClass": Object {
+                "type": [Function],
+              },
+              "leaveClass": Object {
+                "type": [Function],
+              },
+              "leaveToClass": Object {
+                "type": [Function],
+              },
+              "mode": Object {
+                "type": [Function],
+              },
+              "name": Object {
+                "type": [Function],
+              },
+              "type": Object {
+                "type": [Function],
+              },
+            },
+            "render": [Function],
+            "staticClass": undefined,
+            "staticStyle": undefined,
+            "style": undefined,
+          },
+          "transition-group": Object {
+            "$_doNotStubChildren": true,
+            "$_vueTestUtils_original": Object {
+              "_Ctor": Object {
+                "1": [Function],
+              },
+              "beforeMount": [Function],
+              "methods": Object {
+                "hasMove": [Function],
+              },
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "moveClass": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "tag": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+              "updated": [Function],
+            },
+            "abstract": undefined,
+            "attrs": undefined,
+            "class": undefined,
+            "domProps": undefined,
+            "functional": undefined,
+            "key": undefined,
+            "model": undefined,
+            "name": undefined,
+            "nativeOn": undefined,
+            "normalizedStyle": undefined,
+            "on": undefined,
+            "props": Object {
+              "appear": Object {
+                "type": [Function],
+              },
+              "appearActiveClass": Object {
+                "type": [Function],
+              },
+              "appearClass": Object {
+                "type": [Function],
+              },
+              "appearToClass": Object {
+                "type": [Function],
+              },
+              "css": Object {
+                "type": [Function],
+              },
+              "duration": Object {
+                "type": Array [
+                  [Function],
+                  [Function],
+                  [Function],
+                ],
+              },
+              "enterActiveClass": Object {
+                "type": [Function],
+              },
+              "enterClass": Object {
+                "type": [Function],
+              },
+              "enterToClass": Object {
+                "type": [Function],
+              },
+              "leaveActiveClass": Object {
+                "type": [Function],
+              },
+              "leaveClass": Object {
+                "type": [Function],
+              },
+              "leaveToClass": Object {
+                "type": [Function],
+              },
+              "moveClass": Object {
+                "type": [Function],
+              },
+              "name": Object {
+                "type": [Function],
+              },
+              "tag": Object {
+                "type": [Function],
+              },
+              "type": Object {
+                "type": [Function],
+              },
+            },
+            "render": [Function],
+            "staticClass": undefined,
+            "staticStyle": undefined,
+            "style": undefined,
+          },
+        },
+        "data": [Function],
+        "directives": Object {},
+        "filters": Object {},
+        "methods": undefined,
+        "mocks": Object {
+          "$store": Object {
+            "getters": Object {},
+            "state": Object {},
+          },
+        },
+        "provide": [Function],
+        "render": [Function],
+        "shouldProxy": true,
+        "stubs": Object {
+          "transition": true,
+          "transition-group": true,
+        },
+      },
+      "$parent": undefined,
+      "$refs": Object {},
+      "$root": [Circular],
+      "$scopedSlots": Object {},
+      "$slots": Object {},
+      "$vnode": undefined,
+      "__emitted": Object {},
+      "__emittedByOrder": Array [],
+      "_c": [Function],
+      "_data": Object {
+        "vueTestUtils_childProps": Object {
+          "amount": 111,
+          "direction": "sent",
+          "hideFiat": true,
+          "highPrecision": false,
+          "large": false,
+          "noSymbol": true,
+        },
+      },
+      "_directInactive": false,
+      "_events": Object {},
+      "_hasHookEvent": false,
+      "_inactive": null,
+      "_isBeingDestroyed": false,
+      "_isDestroyed": false,
+      "_isMounted": true,
+      "_isVue": true,
+      "_provided": Object {},
+      "_renderProxy": [Circular],
+      "_self": [Circular],
+      "_staticTrees": null,
+      "_uid": 0,
+      "_vnode": VNode {
+        "asyncFactory": undefined,
+        "asyncMeta": undefined,
+        "children": undefined,
+        "componentInstance": [Circular],
+        "componentOptions": Object {
+          "Ctor": [Function],
+          "children": undefined,
+          "listeners": Object {},
+          "propsData": Object {
+            "amount": 111,
+            "direction": "sent",
+            "hideFiat": true,
+            "highPrecision": false,
+            "large": false,
+            "noSymbol": true,
+          },
+          "tag": undefined,
+        },
+        "context": [Circular],
+        "data": Object {
+          "attrs": Object {},
+          "hook": Object {
+            "destroy": [Function],
+            "init": [Function],
+            "insert": [Function],
+            "prepatch": [Function],
+          },
+          "on": undefined,
+          "pendingInsert": null,
+          "scopedSlots": Object {
+            "_normalized": Object {},
+          },
+        },
+        "elm": <span
+          class="token-amount sent"
+        >
+          
+  111
+  
+          <!---->
+           
+          <!---->
+        </span>,
+        "fnContext": undefined,
+        "fnOptions": undefined,
+        "fnScopeId": undefined,
+        "isAsyncPlaceholder": false,
+        "isCloned": false,
+        "isComment": false,
+        "isOnce": false,
+        "isRootInsert": true,
+        "isStatic": false,
+        "key": undefined,
+        "ns": undefined,
+        "parent": undefined,
+        "raw": false,
+        "tag": "vue-component-5",
+        "text": undefined,
+      },
+      "_watcher": Watcher {
+        "active": true,
+        "before": [Function],
+        "cb": [Function],
+        "deep": false,
+        "depIds": Set {
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+        },
+        "deps": Array [
+          Dep {
+            "id": 9,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 10,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 11,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 12,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 13,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 14,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 15,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 16,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+        ],
+        "dirty": false,
+        "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+        "getter": [Function],
+        "id": 1,
+        "lazy": false,
+        "newDepIds": Set {},
+        "newDeps": Array [],
+        "sync": false,
+        "user": false,
+        "value": undefined,
+        "vm": [Circular],
+      },
+      "_watchers": Array [
+        Watcher {
+          "active": true,
+          "before": [Function],
+          "cb": [Function],
+          "deep": false,
+          "depIds": Set {
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+          },
+          "deps": Array [
+            Dep {
+              "id": 9,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 10,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 11,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 12,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 13,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 14,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 15,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 16,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+          ],
+          "dirty": false,
+          "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+          "getter": [Function],
+          "id": 1,
+          "lazy": false,
+          "newDepIds": Set {},
+          "newDeps": Array [],
+          "sync": false,
+          "user": false,
+          "value": undefined,
+          "vm": [Circular],
+        },
+      ],
+      "vueTestUtils_childProps": Object {
+        "amount": 111,
+        "direction": "sent",
+        "hideFiat": true,
+        "highPrecision": false,
+        "large": false,
+        "noSymbol": true,
+      },
+    },
+    "_self": [Circular],
+    "_staticTrees": null,
+    "_uid": 0,
+    "_vnode": VNode {
+      "asyncFactory": undefined,
+      "asyncMeta": undefined,
+      "children": undefined,
+      "componentInstance": [Circular],
+      "componentOptions": Object {
+        "Ctor": [Function],
+        "children": undefined,
+        "listeners": Object {},
+        "propsData": Object {
+          "amount": 111,
+          "direction": "sent",
+          "hideFiat": true,
+          "highPrecision": false,
+          "large": false,
+          "noSymbol": true,
+        },
+        "tag": undefined,
+      },
+      "context": [Circular],
+      "data": Object {
+        "attrs": Object {},
+        "hook": Object {
+          "destroy": [Function],
+          "init": [Function],
+          "insert": [Function],
+          "prepatch": [Function],
+        },
+        "on": undefined,
+        "pendingInsert": null,
+        "scopedSlots": Object {
+          "_normalized": Object {},
+        },
+      },
+      "elm": <span
+        class="token-amount sent"
+      >
+        
+  111
+  
+        <!---->
+         
+        <!---->
+      </span>,
+      "fnContext": undefined,
+      "fnOptions": undefined,
+      "fnScopeId": undefined,
+      "isAsyncPlaceholder": false,
+      "isCloned": false,
+      "isComment": false,
+      "isOnce": false,
+      "isRootInsert": true,
+      "isStatic": false,
+      "key": undefined,
+      "ns": undefined,
+      "parent": undefined,
+      "raw": false,
+      "tag": "vue-component-5",
+      "text": undefined,
+    },
+    "_watcher": Watcher {
+      "active": true,
+      "before": [Function],
+      "cb": [Function],
+      "deep": false,
+      "depIds": Set {
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+      },
+      "deps": Array [
+        Dep {
+          "id": 9,
+          "subs": Array [
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 10,
+          "subs": Array [
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 11,
+          "subs": Array [
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 12,
+          "subs": Array [
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 13,
+          "subs": Array [
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 14,
+          "subs": Array [
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 15,
+          "subs": Array [
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 16,
+          "subs": Array [
+            [Circular],
+          ],
+        },
+      ],
+      "dirty": false,
+      "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+      "getter": [Function],
+      "id": 1,
+      "lazy": false,
+      "newDepIds": Set {},
+      "newDeps": Array [],
+      "sync": false,
+      "user": false,
+      "value": undefined,
+      "vm": [Circular],
+    },
+    "_watchers": Array [
+      Watcher {
+        "active": true,
+        "before": [Function],
+        "cb": [Function],
+        "deep": false,
+        "depIds": Set {
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+        },
+        "deps": Array [
+          Dep {
+            "id": 9,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 10,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 11,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 12,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 13,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 14,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 15,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 16,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+        ],
+        "dirty": false,
+        "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+        "getter": [Function],
+        "id": 1,
+        "lazy": false,
+        "newDepIds": Set {},
+        "newDeps": Array [],
+        "sync": false,
+        "user": false,
+        "value": undefined,
+        "vm": [Circular],
+      },
+    ],
+    "vueTestUtils_childProps": Object {
+      "amount": 111,
+      "direction": "sent",
+      "hideFiat": true,
+      "highPrecision": false,
+      "large": false,
+      "noSymbol": true,
+    },
+  },
+  "$refs": Object {},
+  "$root": VueComponent {
+    "$attrs": Object {},
+    "$children": Array [
+      [Circular],
+    ],
+    "$createElement": [Function],
+    "$el": <span
+      class="token-amount sent"
+    >
+      
+  111
+  
+      <!---->
+       
+      <!---->
+    </span>,
+    "$emit": [Function],
+    "$listeners": Object {},
+    "$options": Object {
+      "$_doNotStubChildren": true,
+      "$_isWrapperParent": true,
+      "_Ctor": Object {
+        "1": [Function],
+      },
+      "_base": [Function],
+      "_isFunctionalContainer": undefined,
+      "beforeCreate": Array [
+        [Function],
+        [Function],
+        [Function],
+      ],
+      "components": Object {
+        "transition": Object {
+          "$_doNotStubChildren": true,
+          "$_vueTestUtils_original": Object {
+            "_Ctor": Object {
+              "1": [Function],
+            },
+            "abstract": true,
+            "name": "transition",
+            "props": Object {
+              "appear": Object {
+                "type": [Function],
+              },
+              "appearActiveClass": Object {
+                "type": [Function],
+              },
+              "appearClass": Object {
+                "type": [Function],
+              },
+              "appearToClass": Object {
+                "type": [Function],
+              },
+              "css": Object {
+                "type": [Function],
+              },
+              "duration": Object {
+                "type": Array [
+                  [Function],
+                  [Function],
+                  [Function],
+                ],
+              },
+              "enterActiveClass": Object {
+                "type": [Function],
+              },
+              "enterClass": Object {
+                "type": [Function],
+              },
+              "enterToClass": Object {
+                "type": [Function],
+              },
+              "leaveActiveClass": Object {
+                "type": [Function],
+              },
+              "leaveClass": Object {
+                "type": [Function],
+              },
+              "leaveToClass": Object {
+                "type": [Function],
+              },
+              "mode": Object {
+                "type": [Function],
+              },
+              "name": Object {
+                "type": [Function],
+              },
+              "type": Object {
+                "type": [Function],
+              },
+            },
+            "render": [Function],
+          },
+          "abstract": true,
+          "attrs": undefined,
+          "class": undefined,
+          "domProps": undefined,
+          "functional": undefined,
+          "key": undefined,
+          "model": undefined,
+          "name": "transition",
+          "nativeOn": undefined,
+          "normalizedStyle": undefined,
+          "on": undefined,
+          "props": Object {
+            "appear": Object {
+              "type": [Function],
+            },
+            "appearActiveClass": Object {
+              "type": [Function],
+            },
+            "appearClass": Object {
+              "type": [Function],
+            },
+            "appearToClass": Object {
+              "type": [Function],
+            },
+            "css": Object {
+              "type": [Function],
+            },
+            "duration": Object {
+              "type": Array [
+                [Function],
+                [Function],
+                [Function],
+              ],
+            },
+            "enterActiveClass": Object {
+              "type": [Function],
+            },
+            "enterClass": Object {
+              "type": [Function],
+            },
+            "enterToClass": Object {
+              "type": [Function],
+            },
+            "leaveActiveClass": Object {
+              "type": [Function],
+            },
+            "leaveClass": Object {
+              "type": [Function],
+            },
+            "leaveToClass": Object {
+              "type": [Function],
+            },
+            "mode": Object {
+              "type": [Function],
+            },
+            "name": Object {
+              "type": [Function],
+            },
+            "type": Object {
+              "type": [Function],
+            },
+          },
+          "render": [Function],
+          "staticClass": undefined,
+          "staticStyle": undefined,
+          "style": undefined,
+        },
+        "transition-group": Object {
+          "$_doNotStubChildren": true,
+          "$_vueTestUtils_original": Object {
+            "_Ctor": Object {
+              "1": [Function],
+            },
+            "beforeMount": [Function],
+            "methods": Object {
+              "hasMove": [Function],
+            },
+            "props": Object {
+              "appear": Object {
+                "type": [Function],
+              },
+              "appearActiveClass": Object {
+                "type": [Function],
+              },
+              "appearClass": Object {
+                "type": [Function],
+              },
+              "appearToClass": Object {
+                "type": [Function],
+              },
+              "css": Object {
+                "type": [Function],
+              },
+              "duration": Object {
+                "type": Array [
+                  [Function],
+                  [Function],
+                  [Function],
+                ],
+              },
+              "enterActiveClass": Object {
+                "type": [Function],
+              },
+              "enterClass": Object {
+                "type": [Function],
+              },
+              "enterToClass": Object {
+                "type": [Function],
+              },
+              "leaveActiveClass": Object {
+                "type": [Function],
+              },
+              "leaveClass": Object {
+                "type": [Function],
+              },
+              "leaveToClass": Object {
+                "type": [Function],
+              },
+              "moveClass": Object {
+                "type": [Function],
+              },
+              "name": Object {
+                "type": [Function],
+              },
+              "tag": Object {
+                "type": [Function],
+              },
+              "type": Object {
+                "type": [Function],
+              },
+            },
+            "render": [Function],
+            "updated": [Function],
+          },
+          "abstract": undefined,
+          "attrs": undefined,
+          "class": undefined,
+          "domProps": undefined,
+          "functional": undefined,
+          "key": undefined,
+          "model": undefined,
+          "name": undefined,
+          "nativeOn": undefined,
+          "normalizedStyle": undefined,
+          "on": undefined,
+          "props": Object {
+            "appear": Object {
+              "type": [Function],
+            },
+            "appearActiveClass": Object {
+              "type": [Function],
+            },
+            "appearClass": Object {
+              "type": [Function],
+            },
+            "appearToClass": Object {
+              "type": [Function],
+            },
+            "css": Object {
+              "type": [Function],
+            },
+            "duration": Object {
+              "type": Array [
+                [Function],
+                [Function],
+                [Function],
+              ],
+            },
+            "enterActiveClass": Object {
+              "type": [Function],
+            },
+            "enterClass": Object {
+              "type": [Function],
+            },
+            "enterToClass": Object {
+              "type": [Function],
+            },
+            "leaveActiveClass": Object {
+              "type": [Function],
+            },
+            "leaveClass": Object {
+              "type": [Function],
+            },
+            "leaveToClass": Object {
+              "type": [Function],
+            },
+            "moveClass": Object {
+              "type": [Function],
+            },
+            "name": Object {
+              "type": [Function],
+            },
+            "tag": Object {
+              "type": [Function],
+            },
+            "type": Object {
+              "type": [Function],
+            },
+          },
+          "render": [Function],
+          "staticClass": undefined,
+          "staticStyle": undefined,
+          "style": undefined,
+        },
+      },
+      "data": [Function],
+      "directives": Object {},
+      "filters": Object {},
+      "methods": undefined,
+      "mocks": Object {
+        "$store": Object {
+          "getters": Object {},
+          "state": Object {},
+        },
+      },
+      "provide": [Function],
+      "render": [Function],
+      "shouldProxy": true,
+      "stubs": Object {
+        "transition": true,
+        "transition-group": true,
+      },
+    },
+    "$parent": undefined,
+    "$refs": Object {},
+    "$root": [Circular],
+    "$scopedSlots": Object {},
+    "$slots": Object {},
+    "$vnode": undefined,
+    "__emitted": Object {},
+    "__emittedByOrder": Array [],
+    "_c": [Function],
+    "_data": Object {
+      "vueTestUtils_childProps": Object {
+        "amount": 111,
+        "direction": "sent",
+        "hideFiat": true,
+        "highPrecision": false,
+        "large": false,
+        "noSymbol": true,
+      },
+    },
+    "_directInactive": false,
+    "_events": Object {},
+    "_hasHookEvent": false,
+    "_inactive": null,
+    "_isBeingDestroyed": false,
+    "_isDestroyed": false,
+    "_isMounted": true,
+    "_isVue": true,
+    "_provided": Object {},
+    "_renderProxy": VueComponent {
+      "$attrs": Object {},
+      "$children": Array [
+        [Circular],
+      ],
+      "$createElement": [Function],
+      "$el": <span
+        class="token-amount sent"
+      >
+        
+  111
+  
+        <!---->
+         
+        <!---->
+      </span>,
+      "$emit": [Function],
+      "$listeners": Object {},
+      "$options": Object {
+        "$_doNotStubChildren": true,
+        "$_isWrapperParent": true,
+        "_Ctor": Object {
+          "1": [Function],
+        },
+        "_base": [Function],
+        "_isFunctionalContainer": undefined,
+        "beforeCreate": Array [
+          [Function],
+          [Function],
+          [Function],
+        ],
+        "components": Object {
+          "transition": Object {
+            "$_doNotStubChildren": true,
+            "$_vueTestUtils_original": Object {
+              "_Ctor": Object {
+                "1": [Function],
+              },
+              "abstract": true,
+              "name": "transition",
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "mode": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+            },
+            "abstract": true,
+            "attrs": undefined,
+            "class": undefined,
+            "domProps": undefined,
+            "functional": undefined,
+            "key": undefined,
+            "model": undefined,
+            "name": "transition",
+            "nativeOn": undefined,
+            "normalizedStyle": undefined,
+            "on": undefined,
+            "props": Object {
+              "appear": Object {
+                "type": [Function],
+              },
+              "appearActiveClass": Object {
+                "type": [Function],
+              },
+              "appearClass": Object {
+                "type": [Function],
+              },
+              "appearToClass": Object {
+                "type": [Function],
+              },
+              "css": Object {
+                "type": [Function],
+              },
+              "duration": Object {
+                "type": Array [
+                  [Function],
+                  [Function],
+                  [Function],
+                ],
+              },
+              "enterActiveClass": Object {
+                "type": [Function],
+              },
+              "enterClass": Object {
+                "type": [Function],
+              },
+              "enterToClass": Object {
+                "type": [Function],
+              },
+              "leaveActiveClass": Object {
+                "type": [Function],
+              },
+              "leaveClass": Object {
+                "type": [Function],
+              },
+              "leaveToClass": Object {
+                "type": [Function],
+              },
+              "mode": Object {
+                "type": [Function],
+              },
+              "name": Object {
+                "type": [Function],
+              },
+              "type": Object {
+                "type": [Function],
+              },
+            },
+            "render": [Function],
+            "staticClass": undefined,
+            "staticStyle": undefined,
+            "style": undefined,
+          },
+          "transition-group": Object {
+            "$_doNotStubChildren": true,
+            "$_vueTestUtils_original": Object {
+              "_Ctor": Object {
+                "1": [Function],
+              },
+              "beforeMount": [Function],
+              "methods": Object {
+                "hasMove": [Function],
+              },
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "moveClass": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "tag": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+              "updated": [Function],
+            },
+            "abstract": undefined,
+            "attrs": undefined,
+            "class": undefined,
+            "domProps": undefined,
+            "functional": undefined,
+            "key": undefined,
+            "model": undefined,
+            "name": undefined,
+            "nativeOn": undefined,
+            "normalizedStyle": undefined,
+            "on": undefined,
+            "props": Object {
+              "appear": Object {
+                "type": [Function],
+              },
+              "appearActiveClass": Object {
+                "type": [Function],
+              },
+              "appearClass": Object {
+                "type": [Function],
+              },
+              "appearToClass": Object {
+                "type": [Function],
+              },
+              "css": Object {
+                "type": [Function],
+              },
+              "duration": Object {
+                "type": Array [
+                  [Function],
+                  [Function],
+                  [Function],
+                ],
+              },
+              "enterActiveClass": Object {
+                "type": [Function],
+              },
+              "enterClass": Object {
+                "type": [Function],
+              },
+              "enterToClass": Object {
+                "type": [Function],
+              },
+              "leaveActiveClass": Object {
+                "type": [Function],
+              },
+              "leaveClass": Object {
+                "type": [Function],
+              },
+              "leaveToClass": Object {
+                "type": [Function],
+              },
+              "moveClass": Object {
+                "type": [Function],
+              },
+              "name": Object {
+                "type": [Function],
+              },
+              "tag": Object {
+                "type": [Function],
+              },
+              "type": Object {
+                "type": [Function],
+              },
+            },
+            "render": [Function],
+            "staticClass": undefined,
+            "staticStyle": undefined,
+            "style": undefined,
+          },
+        },
+        "data": [Function],
+        "directives": Object {},
+        "filters": Object {},
+        "methods": undefined,
+        "mocks": Object {
+          "$store": Object {
+            "getters": Object {},
+            "state": Object {},
+          },
+        },
+        "provide": [Function],
+        "render": [Function],
+        "shouldProxy": true,
+        "stubs": Object {
+          "transition": true,
+          "transition-group": true,
+        },
+      },
+      "$parent": undefined,
+      "$refs": Object {},
+      "$root": [Circular],
+      "$scopedSlots": Object {},
+      "$slots": Object {},
+      "$vnode": undefined,
+      "__emitted": Object {},
+      "__emittedByOrder": Array [],
+      "_c": [Function],
+      "_data": Object {
+        "vueTestUtils_childProps": Object {
+          "amount": 111,
+          "direction": "sent",
+          "hideFiat": true,
+          "highPrecision": false,
+          "large": false,
+          "noSymbol": true,
+        },
+      },
+      "_directInactive": false,
+      "_events": Object {},
+      "_hasHookEvent": false,
+      "_inactive": null,
+      "_isBeingDestroyed": false,
+      "_isDestroyed": false,
+      "_isMounted": true,
+      "_isVue": true,
+      "_provided": Object {},
+      "_renderProxy": [Circular],
+      "_self": [Circular],
+      "_staticTrees": null,
+      "_uid": 0,
+      "_vnode": VNode {
+        "asyncFactory": undefined,
+        "asyncMeta": undefined,
+        "children": undefined,
+        "componentInstance": [Circular],
+        "componentOptions": Object {
+          "Ctor": [Function],
+          "children": undefined,
+          "listeners": Object {},
+          "propsData": Object {
+            "amount": 111,
+            "direction": "sent",
+            "hideFiat": true,
+            "highPrecision": false,
+            "large": false,
+            "noSymbol": true,
+          },
+          "tag": undefined,
+        },
+        "context": [Circular],
+        "data": Object {
+          "attrs": Object {},
+          "hook": Object {
+            "destroy": [Function],
+            "init": [Function],
+            "insert": [Function],
+            "prepatch": [Function],
+          },
+          "on": undefined,
+          "pendingInsert": null,
+          "scopedSlots": Object {
+            "_normalized": Object {},
+          },
+        },
+        "elm": <span
+          class="token-amount sent"
+        >
+          
+  111
+  
+          <!---->
+           
+          <!---->
+        </span>,
+        "fnContext": undefined,
+        "fnOptions": undefined,
+        "fnScopeId": undefined,
+        "isAsyncPlaceholder": false,
+        "isCloned": false,
+        "isComment": false,
+        "isOnce": false,
+        "isRootInsert": true,
+        "isStatic": false,
+        "key": undefined,
+        "ns": undefined,
+        "parent": undefined,
+        "raw": false,
+        "tag": "vue-component-5",
+        "text": undefined,
+      },
+      "_watcher": Watcher {
+        "active": true,
+        "before": [Function],
+        "cb": [Function],
+        "deep": false,
+        "depIds": Set {
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+        },
+        "deps": Array [
+          Dep {
+            "id": 9,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 10,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 11,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 12,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 13,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 14,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 15,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 16,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+        ],
+        "dirty": false,
+        "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+        "getter": [Function],
+        "id": 1,
+        "lazy": false,
+        "newDepIds": Set {},
+        "newDeps": Array [],
+        "sync": false,
+        "user": false,
+        "value": undefined,
+        "vm": [Circular],
+      },
+      "_watchers": Array [
+        Watcher {
+          "active": true,
+          "before": [Function],
+          "cb": [Function],
+          "deep": false,
+          "depIds": Set {
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+          },
+          "deps": Array [
+            Dep {
+              "id": 9,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 10,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 11,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 12,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 13,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 14,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 15,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 16,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+          ],
+          "dirty": false,
+          "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+          "getter": [Function],
+          "id": 1,
+          "lazy": false,
+          "newDepIds": Set {},
+          "newDeps": Array [],
+          "sync": false,
+          "user": false,
+          "value": undefined,
+          "vm": [Circular],
+        },
+      ],
+      "vueTestUtils_childProps": Object {
+        "amount": 111,
+        "direction": "sent",
+        "hideFiat": true,
+        "highPrecision": false,
+        "large": false,
+        "noSymbol": true,
+      },
+    },
+    "_self": [Circular],
+    "_staticTrees": null,
+    "_uid": 0,
+    "_vnode": VNode {
+      "asyncFactory": undefined,
+      "asyncMeta": undefined,
+      "children": undefined,
+      "componentInstance": [Circular],
+      "componentOptions": Object {
+        "Ctor": [Function],
+        "children": undefined,
+        "listeners": Object {},
+        "propsData": Object {
+          "amount": 111,
+          "direction": "sent",
+          "hideFiat": true,
+          "highPrecision": false,
+          "large": false,
+          "noSymbol": true,
+        },
+        "tag": undefined,
+      },
+      "context": [Circular],
+      "data": Object {
+        "attrs": Object {},
+        "hook": Object {
+          "destroy": [Function],
+          "init": [Function],
+          "insert": [Function],
+          "prepatch": [Function],
+        },
+        "on": undefined,
+        "pendingInsert": null,
+        "scopedSlots": Object {
+          "_normalized": Object {},
+        },
+      },
+      "elm": <span
+        class="token-amount sent"
+      >
+        
+  111
+  
+        <!---->
+         
+        <!---->
+      </span>,
+      "fnContext": undefined,
+      "fnOptions": undefined,
+      "fnScopeId": undefined,
+      "isAsyncPlaceholder": false,
+      "isCloned": false,
+      "isComment": false,
+      "isOnce": false,
+      "isRootInsert": true,
+      "isStatic": false,
+      "key": undefined,
+      "ns": undefined,
+      "parent": undefined,
+      "raw": false,
+      "tag": "vue-component-5",
+      "text": undefined,
+    },
+    "_watcher": Watcher {
+      "active": true,
+      "before": [Function],
+      "cb": [Function],
+      "deep": false,
+      "depIds": Set {
+        9,
+        10,
+        11,
+        12,
+        13,
+        14,
+        15,
+        16,
+      },
+      "deps": Array [
+        Dep {
+          "id": 9,
+          "subs": Array [
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 10,
+          "subs": Array [
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 11,
+          "subs": Array [
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 12,
+          "subs": Array [
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 13,
+          "subs": Array [
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 14,
+          "subs": Array [
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 15,
+          "subs": Array [
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 16,
+          "subs": Array [
+            [Circular],
+          ],
+        },
+      ],
+      "dirty": false,
+      "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+      "getter": [Function],
+      "id": 1,
+      "lazy": false,
+      "newDepIds": Set {},
+      "newDeps": Array [],
+      "sync": false,
+      "user": false,
+      "value": undefined,
+      "vm": [Circular],
+    },
+    "_watchers": Array [
+      Watcher {
+        "active": true,
+        "before": [Function],
+        "cb": [Function],
+        "deep": false,
+        "depIds": Set {
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+        },
+        "deps": Array [
+          Dep {
+            "id": 9,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 10,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 11,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 12,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 13,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 14,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 15,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 16,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+        ],
+        "dirty": false,
+        "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+        "getter": [Function],
+        "id": 1,
+        "lazy": false,
+        "newDepIds": Set {},
+        "newDeps": Array [],
+        "sync": false,
+        "user": false,
+        "value": undefined,
+        "vm": [Circular],
+      },
+    ],
+    "vueTestUtils_childProps": Object {
+      "amount": 111,
+      "direction": "sent",
+      "hideFiat": true,
+      "highPrecision": false,
+      "large": false,
+      "noSymbol": true,
+    },
+  },
+  "$scopedSlots": Object {},
+  "$slots": Object {},
+  "$vnode": VNode {
+    "asyncFactory": undefined,
+    "asyncMeta": undefined,
+    "children": undefined,
+    "componentInstance": [Circular],
+    "componentOptions": Object {
+      "Ctor": [Function],
+      "children": undefined,
+      "listeners": Object {},
+      "propsData": Object {
+        "amount": 111,
+        "direction": "sent",
+        "hideFiat": true,
+        "highPrecision": false,
+        "large": false,
+        "noSymbol": true,
+      },
+      "tag": undefined,
+    },
+    "context": VueComponent {
+      "$attrs": Object {},
+      "$children": Array [
+        [Circular],
+      ],
+      "$createElement": [Function],
+      "$el": <span
+        class="token-amount sent"
+      >
+        
+  111
+  
+        <!---->
+         
+        <!---->
+      </span>,
+      "$emit": [Function],
+      "$listeners": Object {},
+      "$options": Object {
+        "$_doNotStubChildren": true,
+        "$_isWrapperParent": true,
+        "_Ctor": Object {
+          "1": [Function],
+        },
+        "_base": [Function],
+        "_isFunctionalContainer": undefined,
+        "beforeCreate": Array [
+          [Function],
+          [Function],
+          [Function],
+        ],
+        "components": Object {
+          "transition": Object {
+            "$_doNotStubChildren": true,
+            "$_vueTestUtils_original": Object {
+              "_Ctor": Object {
+                "1": [Function],
+              },
+              "abstract": true,
+              "name": "transition",
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "mode": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+            },
+            "abstract": true,
+            "attrs": undefined,
+            "class": undefined,
+            "domProps": undefined,
+            "functional": undefined,
+            "key": undefined,
+            "model": undefined,
+            "name": "transition",
+            "nativeOn": undefined,
+            "normalizedStyle": undefined,
+            "on": undefined,
+            "props": Object {
+              "appear": Object {
+                "type": [Function],
+              },
+              "appearActiveClass": Object {
+                "type": [Function],
+              },
+              "appearClass": Object {
+                "type": [Function],
+              },
+              "appearToClass": Object {
+                "type": [Function],
+              },
+              "css": Object {
+                "type": [Function],
+              },
+              "duration": Object {
+                "type": Array [
+                  [Function],
+                  [Function],
+                  [Function],
+                ],
+              },
+              "enterActiveClass": Object {
+                "type": [Function],
+              },
+              "enterClass": Object {
+                "type": [Function],
+              },
+              "enterToClass": Object {
+                "type": [Function],
+              },
+              "leaveActiveClass": Object {
+                "type": [Function],
+              },
+              "leaveClass": Object {
+                "type": [Function],
+              },
+              "leaveToClass": Object {
+                "type": [Function],
+              },
+              "mode": Object {
+                "type": [Function],
+              },
+              "name": Object {
+                "type": [Function],
+              },
+              "type": Object {
+                "type": [Function],
+              },
+            },
+            "render": [Function],
+            "staticClass": undefined,
+            "staticStyle": undefined,
+            "style": undefined,
+          },
+          "transition-group": Object {
+            "$_doNotStubChildren": true,
+            "$_vueTestUtils_original": Object {
+              "_Ctor": Object {
+                "1": [Function],
+              },
+              "beforeMount": [Function],
+              "methods": Object {
+                "hasMove": [Function],
+              },
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "moveClass": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "tag": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+              "updated": [Function],
+            },
+            "abstract": undefined,
+            "attrs": undefined,
+            "class": undefined,
+            "domProps": undefined,
+            "functional": undefined,
+            "key": undefined,
+            "model": undefined,
+            "name": undefined,
+            "nativeOn": undefined,
+            "normalizedStyle": undefined,
+            "on": undefined,
+            "props": Object {
+              "appear": Object {
+                "type": [Function],
+              },
+              "appearActiveClass": Object {
+                "type": [Function],
+              },
+              "appearClass": Object {
+                "type": [Function],
+              },
+              "appearToClass": Object {
+                "type": [Function],
+              },
+              "css": Object {
+                "type": [Function],
+              },
+              "duration": Object {
+                "type": Array [
+                  [Function],
+                  [Function],
+                  [Function],
+                ],
+              },
+              "enterActiveClass": Object {
+                "type": [Function],
+              },
+              "enterClass": Object {
+                "type": [Function],
+              },
+              "enterToClass": Object {
+                "type": [Function],
+              },
+              "leaveActiveClass": Object {
+                "type": [Function],
+              },
+              "leaveClass": Object {
+                "type": [Function],
+              },
+              "leaveToClass": Object {
+                "type": [Function],
+              },
+              "moveClass": Object {
+                "type": [Function],
+              },
+              "name": Object {
+                "type": [Function],
+              },
+              "tag": Object {
+                "type": [Function],
+              },
+              "type": Object {
+                "type": [Function],
+              },
+            },
+            "render": [Function],
+            "staticClass": undefined,
+            "staticStyle": undefined,
+            "style": undefined,
+          },
+        },
+        "data": [Function],
+        "directives": Object {},
+        "filters": Object {},
+        "methods": undefined,
+        "mocks": Object {
+          "$store": Object {
+            "getters": Object {},
+            "state": Object {},
+          },
+        },
+        "provide": [Function],
+        "render": [Function],
+        "shouldProxy": true,
+        "stubs": Object {
+          "transition": true,
+          "transition-group": true,
+        },
+      },
+      "$parent": undefined,
+      "$refs": Object {},
+      "$root": [Circular],
+      "$scopedSlots": Object {},
+      "$slots": Object {},
+      "$vnode": undefined,
+      "__emitted": Object {},
+      "__emittedByOrder": Array [],
+      "_c": [Function],
+      "_data": Object {
+        "vueTestUtils_childProps": Object {
+          "amount": 111,
+          "direction": "sent",
+          "hideFiat": true,
+          "highPrecision": false,
+          "large": false,
+          "noSymbol": true,
+        },
+      },
+      "_directInactive": false,
+      "_events": Object {},
+      "_hasHookEvent": false,
+      "_inactive": null,
+      "_isBeingDestroyed": false,
+      "_isDestroyed": false,
+      "_isMounted": true,
+      "_isVue": true,
+      "_provided": Object {},
+      "_renderProxy": VueComponent {
+        "$attrs": Object {},
+        "$children": Array [
+          [Circular],
+        ],
+        "$createElement": [Function],
+        "$el": <span
+          class="token-amount sent"
+        >
+          
+  111
+  
+          <!---->
+           
+          <!---->
+        </span>,
+        "$emit": [Function],
+        "$listeners": Object {},
+        "$options": Object {
+          "$_doNotStubChildren": true,
+          "$_isWrapperParent": true,
+          "_Ctor": Object {
+            "1": [Function],
+          },
+          "_base": [Function],
+          "_isFunctionalContainer": undefined,
+          "beforeCreate": Array [
+            [Function],
+            [Function],
+            [Function],
+          ],
+          "components": Object {
+            "transition": Object {
+              "$_doNotStubChildren": true,
+              "$_vueTestUtils_original": Object {
+                "_Ctor": Object {
+                  "1": [Function],
+                },
+                "abstract": true,
+                "name": "transition",
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "mode": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+              },
+              "abstract": true,
+              "attrs": undefined,
+              "class": undefined,
+              "domProps": undefined,
+              "functional": undefined,
+              "key": undefined,
+              "model": undefined,
+              "name": "transition",
+              "nativeOn": undefined,
+              "normalizedStyle": undefined,
+              "on": undefined,
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "mode": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+              "staticClass": undefined,
+              "staticStyle": undefined,
+              "style": undefined,
+            },
+            "transition-group": Object {
+              "$_doNotStubChildren": true,
+              "$_vueTestUtils_original": Object {
+                "_Ctor": Object {
+                  "1": [Function],
+                },
+                "beforeMount": [Function],
+                "methods": Object {
+                  "hasMove": [Function],
+                },
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "moveClass": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "tag": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+                "updated": [Function],
+              },
+              "abstract": undefined,
+              "attrs": undefined,
+              "class": undefined,
+              "domProps": undefined,
+              "functional": undefined,
+              "key": undefined,
+              "model": undefined,
+              "name": undefined,
+              "nativeOn": undefined,
+              "normalizedStyle": undefined,
+              "on": undefined,
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "moveClass": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "tag": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+              "staticClass": undefined,
+              "staticStyle": undefined,
+              "style": undefined,
+            },
+          },
+          "data": [Function],
+          "directives": Object {},
+          "filters": Object {},
+          "methods": undefined,
+          "mocks": Object {
+            "$store": Object {
+              "getters": Object {},
+              "state": Object {},
+            },
+          },
+          "provide": [Function],
+          "render": [Function],
+          "shouldProxy": true,
+          "stubs": Object {
+            "transition": true,
+            "transition-group": true,
+          },
+        },
+        "$parent": undefined,
+        "$refs": Object {},
+        "$root": [Circular],
+        "$scopedSlots": Object {},
+        "$slots": Object {},
+        "$vnode": undefined,
+        "__emitted": Object {},
+        "__emittedByOrder": Array [],
+        "_c": [Function],
+        "_data": Object {
+          "vueTestUtils_childProps": Object {
+            "amount": 111,
+            "direction": "sent",
+            "hideFiat": true,
+            "highPrecision": false,
+            "large": false,
+            "noSymbol": true,
+          },
+        },
+        "_directInactive": false,
+        "_events": Object {},
+        "_hasHookEvent": false,
+        "_inactive": null,
+        "_isBeingDestroyed": false,
+        "_isDestroyed": false,
+        "_isMounted": true,
+        "_isVue": true,
+        "_provided": Object {},
+        "_renderProxy": [Circular],
+        "_self": [Circular],
+        "_staticTrees": null,
+        "_uid": 0,
+        "_vnode": [Circular],
+        "_watcher": Watcher {
+          "active": true,
+          "before": [Function],
+          "cb": [Function],
+          "deep": false,
+          "depIds": Set {
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+          },
+          "deps": Array [
+            Dep {
+              "id": 9,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 10,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 11,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 12,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 13,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 14,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 15,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 16,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+          ],
+          "dirty": false,
+          "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+          "getter": [Function],
+          "id": 1,
+          "lazy": false,
+          "newDepIds": Set {},
+          "newDeps": Array [],
+          "sync": false,
+          "user": false,
+          "value": undefined,
+          "vm": [Circular],
+        },
+        "_watchers": Array [
+          Watcher {
+            "active": true,
+            "before": [Function],
+            "cb": [Function],
+            "deep": false,
+            "depIds": Set {
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+            },
+            "deps": Array [
+              Dep {
+                "id": 9,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 10,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 11,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 12,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 13,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 14,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 15,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 16,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+            ],
+            "dirty": false,
+            "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+            "getter": [Function],
+            "id": 1,
+            "lazy": false,
+            "newDepIds": Set {},
+            "newDeps": Array [],
+            "sync": false,
+            "user": false,
+            "value": undefined,
+            "vm": [Circular],
+          },
+        ],
+        "vueTestUtils_childProps": Object {
+          "amount": 111,
+          "direction": "sent",
+          "hideFiat": true,
+          "highPrecision": false,
+          "large": false,
+          "noSymbol": true,
+        },
+      },
+      "_self": [Circular],
+      "_staticTrees": null,
+      "_uid": 0,
+      "_vnode": [Circular],
+      "_watcher": Watcher {
+        "active": true,
+        "before": [Function],
+        "cb": [Function],
+        "deep": false,
+        "depIds": Set {
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+        },
+        "deps": Array [
+          Dep {
+            "id": 9,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 10,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 11,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 12,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 13,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 14,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 15,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 16,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+        ],
+        "dirty": false,
+        "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+        "getter": [Function],
+        "id": 1,
+        "lazy": false,
+        "newDepIds": Set {},
+        "newDeps": Array [],
+        "sync": false,
+        "user": false,
+        "value": undefined,
+        "vm": [Circular],
+      },
+      "_watchers": Array [
+        Watcher {
+          "active": true,
+          "before": [Function],
+          "cb": [Function],
+          "deep": false,
+          "depIds": Set {
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+          },
+          "deps": Array [
+            Dep {
+              "id": 9,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 10,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 11,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 12,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 13,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 14,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 15,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 16,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+          ],
+          "dirty": false,
+          "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+          "getter": [Function],
+          "id": 1,
+          "lazy": false,
+          "newDepIds": Set {},
+          "newDeps": Array [],
+          "sync": false,
+          "user": false,
+          "value": undefined,
+          "vm": [Circular],
+        },
+      ],
+      "vueTestUtils_childProps": Object {
+        "amount": 111,
+        "direction": "sent",
+        "hideFiat": true,
+        "highPrecision": false,
+        "large": false,
+        "noSymbol": true,
+      },
+    },
+    "data": Object {
+      "attrs": Object {},
+      "hook": Object {
+        "destroy": [Function],
+        "init": [Function],
+        "insert": [Function],
+        "prepatch": [Function],
+      },
+      "on": undefined,
+      "pendingInsert": null,
+      "scopedSlots": Object {
+        "_normalized": Object {},
+      },
+    },
+    "elm": <span
+      class="token-amount sent"
+    >
+      
+  111
+  
+      <!---->
+       
+      <!---->
+    </span>,
+    "fnContext": undefined,
+    "fnOptions": undefined,
+    "fnScopeId": undefined,
+    "isAsyncPlaceholder": false,
+    "isCloned": false,
+    "isComment": false,
+    "isOnce": false,
+    "isRootInsert": true,
+    "isStatic": false,
+    "key": undefined,
+    "ns": undefined,
+    "parent": undefined,
+    "raw": false,
+    "tag": "vue-component-5",
+    "text": undefined,
+  },
+  "__emitted": Object {},
+  "__emittedByOrder": Array [],
+  "_c": [Function],
+  "_computedWatchers": Object {
+    "amountFiat": Watcher {
+      "active": true,
+      "before": undefined,
+      "cb": [Function],
+      "deep": false,
+      "depIds": Set {
+        2,
+        3,
+        4,
+        5,
+        23,
+      },
+      "deps": Array [
+        Dep {
+          "id": 2,
+          "subs": Array [
+            [Circular],
+            Watcher {
+              "active": true,
+              "before": [Function],
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                24,
+                25,
+                19,
+                26,
+                23,
+                5,
+                4,
+                3,
+                2,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 24,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 25,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 19,
+                  "subs": Array [
+                    Watcher {
+                      "active": true,
+                      "before": undefined,
+                      "cb": [Function],
+                      "deep": false,
+                      "depIds": Set {
+                        19,
+                      },
+                      "deps": Array [
+                        [Circular],
+                      ],
+                      "dirty": false,
+                      "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+                      "getter": [Function],
+                      "id": 2,
+                      "lazy": true,
+                      "newDepIds": Set {},
+                      "newDeps": Array [],
+                      "sync": false,
+                      "user": false,
+                      "value": 111,
+                      "vm": [Circular],
+                    },
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 26,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 23,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 5,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 4,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 3,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                [Circular],
+              ],
+              "dirty": false,
+              "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+              "getter": [Function],
+              "id": 4,
+              "lazy": false,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": undefined,
+              "vm": [Circular],
+            },
+          ],
+        },
+        Dep {
+          "id": 3,
+          "subs": Array [
+            [Circular],
+            Watcher {
+              "active": true,
+              "before": [Function],
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                24,
+                25,
+                19,
+                26,
+                23,
+                5,
+                4,
+                3,
+                2,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 24,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 25,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 19,
+                  "subs": Array [
+                    Watcher {
+                      "active": true,
+                      "before": undefined,
+                      "cb": [Function],
+                      "deep": false,
+                      "depIds": Set {
+                        19,
+                      },
+                      "deps": Array [
+                        [Circular],
+                      ],
+                      "dirty": false,
+                      "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+                      "getter": [Function],
+                      "id": 2,
+                      "lazy": true,
+                      "newDepIds": Set {},
+                      "newDeps": Array [],
+                      "sync": false,
+                      "user": false,
+                      "value": 111,
+                      "vm": [Circular],
+                    },
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 26,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 23,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 5,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 4,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                [Circular],
+                Dep {
+                  "id": 2,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+              "getter": [Function],
+              "id": 4,
+              "lazy": false,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": undefined,
+              "vm": [Circular],
+            },
+          ],
+        },
+        Dep {
+          "id": 4,
+          "subs": Array [
+            [Circular],
+            Watcher {
+              "active": true,
+              "before": [Function],
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                24,
+                25,
+                19,
+                26,
+                23,
+                5,
+                4,
+                3,
+                2,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 24,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 25,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 19,
+                  "subs": Array [
+                    Watcher {
+                      "active": true,
+                      "before": undefined,
+                      "cb": [Function],
+                      "deep": false,
+                      "depIds": Set {
+                        19,
+                      },
+                      "deps": Array [
+                        [Circular],
+                      ],
+                      "dirty": false,
+                      "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+                      "getter": [Function],
+                      "id": 2,
+                      "lazy": true,
+                      "newDepIds": Set {},
+                      "newDeps": Array [],
+                      "sync": false,
+                      "user": false,
+                      "value": 111,
+                      "vm": [Circular],
+                    },
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 26,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 23,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 5,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                [Circular],
+                Dep {
+                  "id": 3,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 2,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+              "getter": [Function],
+              "id": 4,
+              "lazy": false,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": undefined,
+              "vm": [Circular],
+            },
+          ],
+        },
+        Dep {
+          "id": 5,
+          "subs": Array [
+            [Circular],
+            Watcher {
+              "active": true,
+              "before": [Function],
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                24,
+                25,
+                19,
+                26,
+                23,
+                5,
+                4,
+                3,
+                2,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 24,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 25,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 19,
+                  "subs": Array [
+                    Watcher {
+                      "active": true,
+                      "before": undefined,
+                      "cb": [Function],
+                      "deep": false,
+                      "depIds": Set {
+                        19,
+                      },
+                      "deps": Array [
+                        [Circular],
+                      ],
+                      "dirty": false,
+                      "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+                      "getter": [Function],
+                      "id": 2,
+                      "lazy": true,
+                      "newDepIds": Set {},
+                      "newDeps": Array [],
+                      "sync": false,
+                      "user": false,
+                      "value": 111,
+                      "vm": [Circular],
+                    },
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 26,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 23,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                [Circular],
+                Dep {
+                  "id": 4,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 3,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 2,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+              "getter": [Function],
+              "id": 4,
+              "lazy": false,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": undefined,
+              "vm": [Circular],
+            },
+          ],
+        },
+        Dep {
+          "id": 23,
+          "subs": Array [
+            [Circular],
+            Watcher {
+              "active": true,
+              "before": [Function],
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                24,
+                25,
+                19,
+                26,
+                23,
+                5,
+                4,
+                3,
+                2,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 24,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 25,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 19,
+                  "subs": Array [
+                    Watcher {
+                      "active": true,
+                      "before": undefined,
+                      "cb": [Function],
+                      "deep": false,
+                      "depIds": Set {
+                        19,
+                      },
+                      "deps": Array [
+                        [Circular],
+                      ],
+                      "dirty": false,
+                      "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+                      "getter": [Function],
+                      "id": 2,
+                      "lazy": true,
+                      "newDepIds": Set {},
+                      "newDeps": Array [],
+                      "sync": false,
+                      "user": false,
+                      "value": 111,
+                      "vm": [Circular],
+                    },
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 26,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                [Circular],
+                Dep {
+                  "id": 5,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 4,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 3,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 2,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+              "getter": [Function],
+              "id": 4,
+              "lazy": false,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": undefined,
+              "vm": [Circular],
+            },
+          ],
+        },
+      ],
+      "dirty": false,
+      "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+      "getter": [Function],
+      "id": 3,
+      "lazy": true,
+      "newDepIds": Set {},
+      "newDeps": Array [],
+      "sync": false,
+      "user": false,
+      "value": "",
+      "vm": [Circular],
+    },
+    "amountRounded": Watcher {
+      "active": true,
+      "before": undefined,
+      "cb": [Function],
+      "deep": false,
+      "depIds": Set {
+        19,
+      },
+      "deps": Array [
+        Dep {
+          "id": 19,
+          "subs": Array [
+            [Circular],
+            Watcher {
+              "active": true,
+              "before": [Function],
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                24,
+                25,
+                19,
+                26,
+                23,
+                5,
+                4,
+                3,
+                2,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 24,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 25,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                [Circular],
+                Dep {
+                  "id": 26,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 23,
+                  "subs": Array [
+                    Watcher {
+                      "active": true,
+                      "before": undefined,
+                      "cb": [Function],
+                      "deep": false,
+                      "depIds": Set {
+                        2,
+                        3,
+                        4,
+                        5,
+                        23,
+                      },
+                      "deps": Array [
+                        Dep {
+                          "id": 2,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        Dep {
+                          "id": 3,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        Dep {
+                          "id": 4,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        Dep {
+                          "id": 5,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        [Circular],
+                      ],
+                      "dirty": false,
+                      "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                      "getter": [Function],
+                      "id": 3,
+                      "lazy": true,
+                      "newDepIds": Set {},
+                      "newDeps": Array [],
+                      "sync": false,
+                      "user": false,
+                      "value": "",
+                      "vm": [Circular],
+                    },
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 5,
+                  "subs": Array [
+                    Watcher {
+                      "active": true,
+                      "before": undefined,
+                      "cb": [Function],
+                      "deep": false,
+                      "depIds": Set {
+                        2,
+                        3,
+                        4,
+                        5,
+                        23,
+                      },
+                      "deps": Array [
+                        Dep {
+                          "id": 2,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        Dep {
+                          "id": 3,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        Dep {
+                          "id": 4,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        [Circular],
+                        Dep {
+                          "id": 23,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                      ],
+                      "dirty": false,
+                      "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                      "getter": [Function],
+                      "id": 3,
+                      "lazy": true,
+                      "newDepIds": Set {},
+                      "newDeps": Array [],
+                      "sync": false,
+                      "user": false,
+                      "value": "",
+                      "vm": [Circular],
+                    },
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 4,
+                  "subs": Array [
+                    Watcher {
+                      "active": true,
+                      "before": undefined,
+                      "cb": [Function],
+                      "deep": false,
+                      "depIds": Set {
+                        2,
+                        3,
+                        4,
+                        5,
+                        23,
+                      },
+                      "deps": Array [
+                        Dep {
+                          "id": 2,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        Dep {
+                          "id": 3,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        [Circular],
+                        Dep {
+                          "id": 5,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        Dep {
+                          "id": 23,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                      ],
+                      "dirty": false,
+                      "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                      "getter": [Function],
+                      "id": 3,
+                      "lazy": true,
+                      "newDepIds": Set {},
+                      "newDeps": Array [],
+                      "sync": false,
+                      "user": false,
+                      "value": "",
+                      "vm": [Circular],
+                    },
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 3,
+                  "subs": Array [
+                    Watcher {
+                      "active": true,
+                      "before": undefined,
+                      "cb": [Function],
+                      "deep": false,
+                      "depIds": Set {
+                        2,
+                        3,
+                        4,
+                        5,
+                        23,
+                      },
+                      "deps": Array [
+                        Dep {
+                          "id": 2,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        [Circular],
+                        Dep {
+                          "id": 4,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        Dep {
+                          "id": 5,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        Dep {
+                          "id": 23,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                      ],
+                      "dirty": false,
+                      "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                      "getter": [Function],
+                      "id": 3,
+                      "lazy": true,
+                      "newDepIds": Set {},
+                      "newDeps": Array [],
+                      "sync": false,
+                      "user": false,
+                      "value": "",
+                      "vm": [Circular],
+                    },
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 2,
+                  "subs": Array [
+                    Watcher {
+                      "active": true,
+                      "before": undefined,
+                      "cb": [Function],
+                      "deep": false,
+                      "depIds": Set {
+                        2,
+                        3,
+                        4,
+                        5,
+                        23,
+                      },
+                      "deps": Array [
+                        [Circular],
+                        Dep {
+                          "id": 3,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        Dep {
+                          "id": 4,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        Dep {
+                          "id": 5,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        Dep {
+                          "id": 23,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                      ],
+                      "dirty": false,
+                      "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                      "getter": [Function],
+                      "id": 3,
+                      "lazy": true,
+                      "newDepIds": Set {},
+                      "newDeps": Array [],
+                      "sync": false,
+                      "user": false,
+                      "value": "",
+                      "vm": [Circular],
+                    },
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+              "getter": [Function],
+              "id": 4,
+              "lazy": false,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": undefined,
+              "vm": [Circular],
+            },
+          ],
+        },
+      ],
+      "dirty": false,
+      "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+      "getter": [Function],
+      "id": 2,
+      "lazy": true,
+      "newDepIds": Set {},
+      "newDeps": Array [],
+      "sync": false,
+      "user": false,
+      "value": 111,
+      "vm": [Circular],
+    },
+  },
+  "_data": Object {},
+  "_directInactive": false,
+  "_events": Object {},
+  "_hasHookEvent": false,
+  "_inactive": null,
+  "_isBeingDestroyed": false,
+  "_isDestroyed": false,
+  "_isMounted": true,
+  "_isVue": true,
+  "_props": Object {
+    "aex9": false,
+    "amount": 111,
+    "direction": "sent",
+    "fiatBelow": false,
+    "hideFiat": true,
+    "highPrecision": false,
+    "large": false,
+    "noSymbol": true,
+    "symbol": "AE",
+  },
+  "_renderProxy": VueComponent {
+    "$attrs": Object {},
+    "$children": Array [],
+    "$createElement": [Function],
+    "$el": <span
+      class="token-amount sent"
+    >
+      
+  111
+  
+      <!---->
+       
+      <!---->
+    </span>,
+    "$emit": [Function],
+    "$listeners": Object {},
+    "$options": Object {
+      "_componentTag": undefined,
+      "_parentListeners": Object {},
+      "_parentVnode": VNode {
+        "asyncFactory": undefined,
+        "asyncMeta": undefined,
+        "children": undefined,
+        "componentInstance": [Circular],
+        "componentOptions": Object {
+          "Ctor": [Function],
+          "children": undefined,
+          "listeners": Object {},
+          "propsData": Object {
+            "amount": 111,
+            "direction": "sent",
+            "hideFiat": true,
+            "highPrecision": false,
+            "large": false,
+            "noSymbol": true,
+          },
+          "tag": undefined,
+        },
+        "context": VueComponent {
+          "$attrs": Object {},
+          "$children": Array [
+            [Circular],
+          ],
+          "$createElement": [Function],
+          "$el": <span
+            class="token-amount sent"
+          >
+            
+  111
+  
+            <!---->
+             
+            <!---->
+          </span>,
+          "$emit": [Function],
+          "$listeners": Object {},
+          "$options": Object {
+            "$_doNotStubChildren": true,
+            "$_isWrapperParent": true,
+            "_Ctor": Object {
+              "1": [Function],
+            },
+            "_base": [Function],
+            "_isFunctionalContainer": undefined,
+            "beforeCreate": Array [
+              [Function],
+              [Function],
+              [Function],
+            ],
+            "components": Object {
+              "transition": Object {
+                "$_doNotStubChildren": true,
+                "$_vueTestUtils_original": Object {
+                  "_Ctor": Object {
+                    "1": [Function],
+                  },
+                  "abstract": true,
+                  "name": "transition",
+                  "props": Object {
+                    "appear": Object {
+                      "type": [Function],
+                    },
+                    "appearActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "appearClass": Object {
+                      "type": [Function],
+                    },
+                    "appearToClass": Object {
+                      "type": [Function],
+                    },
+                    "css": Object {
+                      "type": [Function],
+                    },
+                    "duration": Object {
+                      "type": Array [
+                        [Function],
+                        [Function],
+                        [Function],
+                      ],
+                    },
+                    "enterActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "enterClass": Object {
+                      "type": [Function],
+                    },
+                    "enterToClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveToClass": Object {
+                      "type": [Function],
+                    },
+                    "mode": Object {
+                      "type": [Function],
+                    },
+                    "name": Object {
+                      "type": [Function],
+                    },
+                    "type": Object {
+                      "type": [Function],
+                    },
+                  },
+                  "render": [Function],
+                },
+                "abstract": true,
+                "attrs": undefined,
+                "class": undefined,
+                "domProps": undefined,
+                "functional": undefined,
+                "key": undefined,
+                "model": undefined,
+                "name": "transition",
+                "nativeOn": undefined,
+                "normalizedStyle": undefined,
+                "on": undefined,
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "mode": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+                "staticClass": undefined,
+                "staticStyle": undefined,
+                "style": undefined,
+              },
+              "transition-group": Object {
+                "$_doNotStubChildren": true,
+                "$_vueTestUtils_original": Object {
+                  "_Ctor": Object {
+                    "1": [Function],
+                  },
+                  "beforeMount": [Function],
+                  "methods": Object {
+                    "hasMove": [Function],
+                  },
+                  "props": Object {
+                    "appear": Object {
+                      "type": [Function],
+                    },
+                    "appearActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "appearClass": Object {
+                      "type": [Function],
+                    },
+                    "appearToClass": Object {
+                      "type": [Function],
+                    },
+                    "css": Object {
+                      "type": [Function],
+                    },
+                    "duration": Object {
+                      "type": Array [
+                        [Function],
+                        [Function],
+                        [Function],
+                      ],
+                    },
+                    "enterActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "enterClass": Object {
+                      "type": [Function],
+                    },
+                    "enterToClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveToClass": Object {
+                      "type": [Function],
+                    },
+                    "moveClass": Object {
+                      "type": [Function],
+                    },
+                    "name": Object {
+                      "type": [Function],
+                    },
+                    "tag": Object {
+                      "type": [Function],
+                    },
+                    "type": Object {
+                      "type": [Function],
+                    },
+                  },
+                  "render": [Function],
+                  "updated": [Function],
+                },
+                "abstract": undefined,
+                "attrs": undefined,
+                "class": undefined,
+                "domProps": undefined,
+                "functional": undefined,
+                "key": undefined,
+                "model": undefined,
+                "name": undefined,
+                "nativeOn": undefined,
+                "normalizedStyle": undefined,
+                "on": undefined,
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "moveClass": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "tag": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+                "staticClass": undefined,
+                "staticStyle": undefined,
+                "style": undefined,
+              },
+            },
+            "data": [Function],
+            "directives": Object {},
+            "filters": Object {},
+            "methods": undefined,
+            "mocks": Object {
+              "$store": Object {
+                "getters": Object {},
+                "state": Object {},
+              },
+            },
+            "provide": [Function],
+            "render": [Function],
+            "shouldProxy": true,
+            "stubs": Object {
+              "transition": true,
+              "transition-group": true,
+            },
+          },
+          "$parent": undefined,
+          "$refs": Object {},
+          "$root": [Circular],
+          "$scopedSlots": Object {},
+          "$slots": Object {},
+          "$vnode": undefined,
+          "__emitted": Object {},
+          "__emittedByOrder": Array [],
+          "_c": [Function],
+          "_data": Object {
+            "vueTestUtils_childProps": Object {
+              "amount": 111,
+              "direction": "sent",
+              "hideFiat": true,
+              "highPrecision": false,
+              "large": false,
+              "noSymbol": true,
+            },
+          },
+          "_directInactive": false,
+          "_events": Object {},
+          "_hasHookEvent": false,
+          "_inactive": null,
+          "_isBeingDestroyed": false,
+          "_isDestroyed": false,
+          "_isMounted": true,
+          "_isVue": true,
+          "_provided": Object {},
+          "_renderProxy": VueComponent {
+            "$attrs": Object {},
+            "$children": Array [
+              [Circular],
+            ],
+            "$createElement": [Function],
+            "$el": <span
+              class="token-amount sent"
+            >
+              
+  111
+  
+              <!---->
+               
+              <!---->
+            </span>,
+            "$emit": [Function],
+            "$listeners": Object {},
+            "$options": Object {
+              "$_doNotStubChildren": true,
+              "$_isWrapperParent": true,
+              "_Ctor": Object {
+                "1": [Function],
+              },
+              "_base": [Function],
+              "_isFunctionalContainer": undefined,
+              "beforeCreate": Array [
+                [Function],
+                [Function],
+                [Function],
+              ],
+              "components": Object {
+                "transition": Object {
+                  "$_doNotStubChildren": true,
+                  "$_vueTestUtils_original": Object {
+                    "_Ctor": Object {
+                      "1": [Function],
+                    },
+                    "abstract": true,
+                    "name": "transition",
+                    "props": Object {
+                      "appear": Object {
+                        "type": [Function],
+                      },
+                      "appearActiveClass": Object {
+                        "type": [Function],
+                      },
+                      "appearClass": Object {
+                        "type": [Function],
+                      },
+                      "appearToClass": Object {
+                        "type": [Function],
+                      },
+                      "css": Object {
+                        "type": [Function],
+                      },
+                      "duration": Object {
+                        "type": Array [
+                          [Function],
+                          [Function],
+                          [Function],
+                        ],
+                      },
+                      "enterActiveClass": Object {
+                        "type": [Function],
+                      },
+                      "enterClass": Object {
+                        "type": [Function],
+                      },
+                      "enterToClass": Object {
+                        "type": [Function],
+                      },
+                      "leaveActiveClass": Object {
+                        "type": [Function],
+                      },
+                      "leaveClass": Object {
+                        "type": [Function],
+                      },
+                      "leaveToClass": Object {
+                        "type": [Function],
+                      },
+                      "mode": Object {
+                        "type": [Function],
+                      },
+                      "name": Object {
+                        "type": [Function],
+                      },
+                      "type": Object {
+                        "type": [Function],
+                      },
+                    },
+                    "render": [Function],
+                  },
+                  "abstract": true,
+                  "attrs": undefined,
+                  "class": undefined,
+                  "domProps": undefined,
+                  "functional": undefined,
+                  "key": undefined,
+                  "model": undefined,
+                  "name": "transition",
+                  "nativeOn": undefined,
+                  "normalizedStyle": undefined,
+                  "on": undefined,
+                  "props": Object {
+                    "appear": Object {
+                      "type": [Function],
+                    },
+                    "appearActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "appearClass": Object {
+                      "type": [Function],
+                    },
+                    "appearToClass": Object {
+                      "type": [Function],
+                    },
+                    "css": Object {
+                      "type": [Function],
+                    },
+                    "duration": Object {
+                      "type": Array [
+                        [Function],
+                        [Function],
+                        [Function],
+                      ],
+                    },
+                    "enterActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "enterClass": Object {
+                      "type": [Function],
+                    },
+                    "enterToClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveToClass": Object {
+                      "type": [Function],
+                    },
+                    "mode": Object {
+                      "type": [Function],
+                    },
+                    "name": Object {
+                      "type": [Function],
+                    },
+                    "type": Object {
+                      "type": [Function],
+                    },
+                  },
+                  "render": [Function],
+                  "staticClass": undefined,
+                  "staticStyle": undefined,
+                  "style": undefined,
+                },
+                "transition-group": Object {
+                  "$_doNotStubChildren": true,
+                  "$_vueTestUtils_original": Object {
+                    "_Ctor": Object {
+                      "1": [Function],
+                    },
+                    "beforeMount": [Function],
+                    "methods": Object {
+                      "hasMove": [Function],
+                    },
+                    "props": Object {
+                      "appear": Object {
+                        "type": [Function],
+                      },
+                      "appearActiveClass": Object {
+                        "type": [Function],
+                      },
+                      "appearClass": Object {
+                        "type": [Function],
+                      },
+                      "appearToClass": Object {
+                        "type": [Function],
+                      },
+                      "css": Object {
+                        "type": [Function],
+                      },
+                      "duration": Object {
+                        "type": Array [
+                          [Function],
+                          [Function],
+                          [Function],
+                        ],
+                      },
+                      "enterActiveClass": Object {
+                        "type": [Function],
+                      },
+                      "enterClass": Object {
+                        "type": [Function],
+                      },
+                      "enterToClass": Object {
+                        "type": [Function],
+                      },
+                      "leaveActiveClass": Object {
+                        "type": [Function],
+                      },
+                      "leaveClass": Object {
+                        "type": [Function],
+                      },
+                      "leaveToClass": Object {
+                        "type": [Function],
+                      },
+                      "moveClass": Object {
+                        "type": [Function],
+                      },
+                      "name": Object {
+                        "type": [Function],
+                      },
+                      "tag": Object {
+                        "type": [Function],
+                      },
+                      "type": Object {
+                        "type": [Function],
+                      },
+                    },
+                    "render": [Function],
+                    "updated": [Function],
+                  },
+                  "abstract": undefined,
+                  "attrs": undefined,
+                  "class": undefined,
+                  "domProps": undefined,
+                  "functional": undefined,
+                  "key": undefined,
+                  "model": undefined,
+                  "name": undefined,
+                  "nativeOn": undefined,
+                  "normalizedStyle": undefined,
+                  "on": undefined,
+                  "props": Object {
+                    "appear": Object {
+                      "type": [Function],
+                    },
+                    "appearActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "appearClass": Object {
+                      "type": [Function],
+                    },
+                    "appearToClass": Object {
+                      "type": [Function],
+                    },
+                    "css": Object {
+                      "type": [Function],
+                    },
+                    "duration": Object {
+                      "type": Array [
+                        [Function],
+                        [Function],
+                        [Function],
+                      ],
+                    },
+                    "enterActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "enterClass": Object {
+                      "type": [Function],
+                    },
+                    "enterToClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveToClass": Object {
+                      "type": [Function],
+                    },
+                    "moveClass": Object {
+                      "type": [Function],
+                    },
+                    "name": Object {
+                      "type": [Function],
+                    },
+                    "tag": Object {
+                      "type": [Function],
+                    },
+                    "type": Object {
+                      "type": [Function],
+                    },
+                  },
+                  "render": [Function],
+                  "staticClass": undefined,
+                  "staticStyle": undefined,
+                  "style": undefined,
+                },
+              },
+              "data": [Function],
+              "directives": Object {},
+              "filters": Object {},
+              "methods": undefined,
+              "mocks": Object {
+                "$store": Object {
+                  "getters": Object {},
+                  "state": Object {},
+                },
+              },
+              "provide": [Function],
+              "render": [Function],
+              "shouldProxy": true,
+              "stubs": Object {
+                "transition": true,
+                "transition-group": true,
+              },
+            },
+            "$parent": undefined,
+            "$refs": Object {},
+            "$root": [Circular],
+            "$scopedSlots": Object {},
+            "$slots": Object {},
+            "$vnode": undefined,
+            "__emitted": Object {},
+            "__emittedByOrder": Array [],
+            "_c": [Function],
+            "_data": Object {
+              "vueTestUtils_childProps": Object {
+                "amount": 111,
+                "direction": "sent",
+                "hideFiat": true,
+                "highPrecision": false,
+                "large": false,
+                "noSymbol": true,
+              },
+            },
+            "_directInactive": false,
+            "_events": Object {},
+            "_hasHookEvent": false,
+            "_inactive": null,
+            "_isBeingDestroyed": false,
+            "_isDestroyed": false,
+            "_isMounted": true,
+            "_isVue": true,
+            "_provided": Object {},
+            "_renderProxy": [Circular],
+            "_self": [Circular],
+            "_staticTrees": null,
+            "_uid": 0,
+            "_vnode": [Circular],
+            "_watcher": Watcher {
+              "active": true,
+              "before": [Function],
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15,
+                16,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 9,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 10,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 11,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 12,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 13,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 14,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 15,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 16,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+              "getter": [Function],
+              "id": 1,
+              "lazy": false,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": undefined,
+              "vm": [Circular],
+            },
+            "_watchers": Array [
+              Watcher {
+                "active": true,
+                "before": [Function],
+                "cb": [Function],
+                "deep": false,
+                "depIds": Set {
+                  9,
+                  10,
+                  11,
+                  12,
+                  13,
+                  14,
+                  15,
+                  16,
+                },
+                "deps": Array [
+                  Dep {
+                    "id": 9,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 10,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 11,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 12,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 13,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 14,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 15,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 16,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                ],
+                "dirty": false,
+                "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+                "getter": [Function],
+                "id": 1,
+                "lazy": false,
+                "newDepIds": Set {},
+                "newDeps": Array [],
+                "sync": false,
+                "user": false,
+                "value": undefined,
+                "vm": [Circular],
+              },
+            ],
+            "vueTestUtils_childProps": Object {
+              "amount": 111,
+              "direction": "sent",
+              "hideFiat": true,
+              "highPrecision": false,
+              "large": false,
+              "noSymbol": true,
+            },
+          },
+          "_self": [Circular],
+          "_staticTrees": null,
+          "_uid": 0,
+          "_vnode": [Circular],
+          "_watcher": Watcher {
+            "active": true,
+            "before": [Function],
+            "cb": [Function],
+            "deep": false,
+            "depIds": Set {
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+            },
+            "deps": Array [
+              Dep {
+                "id": 9,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 10,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 11,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 12,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 13,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 14,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 15,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 16,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+            ],
+            "dirty": false,
+            "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+            "getter": [Function],
+            "id": 1,
+            "lazy": false,
+            "newDepIds": Set {},
+            "newDeps": Array [],
+            "sync": false,
+            "user": false,
+            "value": undefined,
+            "vm": [Circular],
+          },
+          "_watchers": Array [
+            Watcher {
+              "active": true,
+              "before": [Function],
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15,
+                16,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 9,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 10,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 11,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 12,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 13,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 14,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 15,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 16,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+              "getter": [Function],
+              "id": 1,
+              "lazy": false,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": undefined,
+              "vm": [Circular],
+            },
+          ],
+          "vueTestUtils_childProps": Object {
+            "amount": 111,
+            "direction": "sent",
+            "hideFiat": true,
+            "highPrecision": false,
+            "large": false,
+            "noSymbol": true,
+          },
+        },
+        "data": Object {
+          "attrs": Object {},
+          "hook": Object {
+            "destroy": [Function],
+            "init": [Function],
+            "insert": [Function],
+            "prepatch": [Function],
+          },
+          "on": undefined,
+          "pendingInsert": null,
+          "scopedSlots": Object {
+            "_normalized": Object {},
+          },
+        },
+        "elm": <span
+          class="token-amount sent"
+        >
+          
+  111
+  
+          <!---->
+           
+          <!---->
+        </span>,
+        "fnContext": undefined,
+        "fnOptions": undefined,
+        "fnScopeId": undefined,
+        "isAsyncPlaceholder": false,
+        "isCloned": false,
+        "isComment": false,
+        "isOnce": false,
+        "isRootInsert": true,
+        "isStatic": false,
+        "key": undefined,
+        "ns": undefined,
+        "parent": undefined,
+        "raw": false,
+        "tag": "vue-component-5",
+        "text": undefined,
+      },
+      "_propKeys": Array [
+        "amount",
+        "symbol",
+        "aex9",
+        "fiatBelow",
+        "hideFiat",
+        "direction",
+        "large",
+        "noSymbol",
+        "highPrecision",
+      ],
+      "_renderChildren": undefined,
+      "parent": VueComponent {
+        "$attrs": Object {},
+        "$children": Array [
+          [Circular],
+        ],
+        "$createElement": [Function],
+        "$el": <span
+          class="token-amount sent"
+        >
+          
+  111
+  
+          <!---->
+           
+          <!---->
+        </span>,
+        "$emit": [Function],
+        "$listeners": Object {},
+        "$options": Object {
+          "$_doNotStubChildren": true,
+          "$_isWrapperParent": true,
+          "_Ctor": Object {
+            "1": [Function],
+          },
+          "_base": [Function],
+          "_isFunctionalContainer": undefined,
+          "beforeCreate": Array [
+            [Function],
+            [Function],
+            [Function],
+          ],
+          "components": Object {
+            "transition": Object {
+              "$_doNotStubChildren": true,
+              "$_vueTestUtils_original": Object {
+                "_Ctor": Object {
+                  "1": [Function],
+                },
+                "abstract": true,
+                "name": "transition",
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "mode": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+              },
+              "abstract": true,
+              "attrs": undefined,
+              "class": undefined,
+              "domProps": undefined,
+              "functional": undefined,
+              "key": undefined,
+              "model": undefined,
+              "name": "transition",
+              "nativeOn": undefined,
+              "normalizedStyle": undefined,
+              "on": undefined,
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "mode": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+              "staticClass": undefined,
+              "staticStyle": undefined,
+              "style": undefined,
+            },
+            "transition-group": Object {
+              "$_doNotStubChildren": true,
+              "$_vueTestUtils_original": Object {
+                "_Ctor": Object {
+                  "1": [Function],
+                },
+                "beforeMount": [Function],
+                "methods": Object {
+                  "hasMove": [Function],
+                },
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "moveClass": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "tag": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+                "updated": [Function],
+              },
+              "abstract": undefined,
+              "attrs": undefined,
+              "class": undefined,
+              "domProps": undefined,
+              "functional": undefined,
+              "key": undefined,
+              "model": undefined,
+              "name": undefined,
+              "nativeOn": undefined,
+              "normalizedStyle": undefined,
+              "on": undefined,
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "moveClass": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "tag": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+              "staticClass": undefined,
+              "staticStyle": undefined,
+              "style": undefined,
+            },
+          },
+          "data": [Function],
+          "directives": Object {},
+          "filters": Object {},
+          "methods": undefined,
+          "mocks": Object {
+            "$store": Object {
+              "getters": Object {},
+              "state": Object {},
+            },
+          },
+          "provide": [Function],
+          "render": [Function],
+          "shouldProxy": true,
+          "stubs": Object {
+            "transition": true,
+            "transition-group": true,
+          },
+        },
+        "$parent": undefined,
+        "$refs": Object {},
+        "$root": [Circular],
+        "$scopedSlots": Object {},
+        "$slots": Object {},
+        "$vnode": undefined,
+        "__emitted": Object {},
+        "__emittedByOrder": Array [],
+        "_c": [Function],
+        "_data": Object {
+          "vueTestUtils_childProps": Object {
+            "amount": 111,
+            "direction": "sent",
+            "hideFiat": true,
+            "highPrecision": false,
+            "large": false,
+            "noSymbol": true,
+          },
+        },
+        "_directInactive": false,
+        "_events": Object {},
+        "_hasHookEvent": false,
+        "_inactive": null,
+        "_isBeingDestroyed": false,
+        "_isDestroyed": false,
+        "_isMounted": true,
+        "_isVue": true,
+        "_provided": Object {},
+        "_renderProxy": VueComponent {
+          "$attrs": Object {},
+          "$children": Array [
+            [Circular],
+          ],
+          "$createElement": [Function],
+          "$el": <span
+            class="token-amount sent"
+          >
+            
+  111
+  
+            <!---->
+             
+            <!---->
+          </span>,
+          "$emit": [Function],
+          "$listeners": Object {},
+          "$options": Object {
+            "$_doNotStubChildren": true,
+            "$_isWrapperParent": true,
+            "_Ctor": Object {
+              "1": [Function],
+            },
+            "_base": [Function],
+            "_isFunctionalContainer": undefined,
+            "beforeCreate": Array [
+              [Function],
+              [Function],
+              [Function],
+            ],
+            "components": Object {
+              "transition": Object {
+                "$_doNotStubChildren": true,
+                "$_vueTestUtils_original": Object {
+                  "_Ctor": Object {
+                    "1": [Function],
+                  },
+                  "abstract": true,
+                  "name": "transition",
+                  "props": Object {
+                    "appear": Object {
+                      "type": [Function],
+                    },
+                    "appearActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "appearClass": Object {
+                      "type": [Function],
+                    },
+                    "appearToClass": Object {
+                      "type": [Function],
+                    },
+                    "css": Object {
+                      "type": [Function],
+                    },
+                    "duration": Object {
+                      "type": Array [
+                        [Function],
+                        [Function],
+                        [Function],
+                      ],
+                    },
+                    "enterActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "enterClass": Object {
+                      "type": [Function],
+                    },
+                    "enterToClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveToClass": Object {
+                      "type": [Function],
+                    },
+                    "mode": Object {
+                      "type": [Function],
+                    },
+                    "name": Object {
+                      "type": [Function],
+                    },
+                    "type": Object {
+                      "type": [Function],
+                    },
+                  },
+                  "render": [Function],
+                },
+                "abstract": true,
+                "attrs": undefined,
+                "class": undefined,
+                "domProps": undefined,
+                "functional": undefined,
+                "key": undefined,
+                "model": undefined,
+                "name": "transition",
+                "nativeOn": undefined,
+                "normalizedStyle": undefined,
+                "on": undefined,
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "mode": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+                "staticClass": undefined,
+                "staticStyle": undefined,
+                "style": undefined,
+              },
+              "transition-group": Object {
+                "$_doNotStubChildren": true,
+                "$_vueTestUtils_original": Object {
+                  "_Ctor": Object {
+                    "1": [Function],
+                  },
+                  "beforeMount": [Function],
+                  "methods": Object {
+                    "hasMove": [Function],
+                  },
+                  "props": Object {
+                    "appear": Object {
+                      "type": [Function],
+                    },
+                    "appearActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "appearClass": Object {
+                      "type": [Function],
+                    },
+                    "appearToClass": Object {
+                      "type": [Function],
+                    },
+                    "css": Object {
+                      "type": [Function],
+                    },
+                    "duration": Object {
+                      "type": Array [
+                        [Function],
+                        [Function],
+                        [Function],
+                      ],
+                    },
+                    "enterActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "enterClass": Object {
+                      "type": [Function],
+                    },
+                    "enterToClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveToClass": Object {
+                      "type": [Function],
+                    },
+                    "moveClass": Object {
+                      "type": [Function],
+                    },
+                    "name": Object {
+                      "type": [Function],
+                    },
+                    "tag": Object {
+                      "type": [Function],
+                    },
+                    "type": Object {
+                      "type": [Function],
+                    },
+                  },
+                  "render": [Function],
+                  "updated": [Function],
+                },
+                "abstract": undefined,
+                "attrs": undefined,
+                "class": undefined,
+                "domProps": undefined,
+                "functional": undefined,
+                "key": undefined,
+                "model": undefined,
+                "name": undefined,
+                "nativeOn": undefined,
+                "normalizedStyle": undefined,
+                "on": undefined,
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "moveClass": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "tag": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+                "staticClass": undefined,
+                "staticStyle": undefined,
+                "style": undefined,
+              },
+            },
+            "data": [Function],
+            "directives": Object {},
+            "filters": Object {},
+            "methods": undefined,
+            "mocks": Object {
+              "$store": Object {
+                "getters": Object {},
+                "state": Object {},
+              },
+            },
+            "provide": [Function],
+            "render": [Function],
+            "shouldProxy": true,
+            "stubs": Object {
+              "transition": true,
+              "transition-group": true,
+            },
+          },
+          "$parent": undefined,
+          "$refs": Object {},
+          "$root": [Circular],
+          "$scopedSlots": Object {},
+          "$slots": Object {},
+          "$vnode": undefined,
+          "__emitted": Object {},
+          "__emittedByOrder": Array [],
+          "_c": [Function],
+          "_data": Object {
+            "vueTestUtils_childProps": Object {
+              "amount": 111,
+              "direction": "sent",
+              "hideFiat": true,
+              "highPrecision": false,
+              "large": false,
+              "noSymbol": true,
+            },
+          },
+          "_directInactive": false,
+          "_events": Object {},
+          "_hasHookEvent": false,
+          "_inactive": null,
+          "_isBeingDestroyed": false,
+          "_isDestroyed": false,
+          "_isMounted": true,
+          "_isVue": true,
+          "_provided": Object {},
+          "_renderProxy": [Circular],
+          "_self": [Circular],
+          "_staticTrees": null,
+          "_uid": 0,
+          "_vnode": VNode {
+            "asyncFactory": undefined,
+            "asyncMeta": undefined,
+            "children": undefined,
+            "componentInstance": [Circular],
+            "componentOptions": Object {
+              "Ctor": [Function],
+              "children": undefined,
+              "listeners": Object {},
+              "propsData": Object {
+                "amount": 111,
+                "direction": "sent",
+                "hideFiat": true,
+                "highPrecision": false,
+                "large": false,
+                "noSymbol": true,
+              },
+              "tag": undefined,
+            },
+            "context": [Circular],
+            "data": Object {
+              "attrs": Object {},
+              "hook": Object {
+                "destroy": [Function],
+                "init": [Function],
+                "insert": [Function],
+                "prepatch": [Function],
+              },
+              "on": undefined,
+              "pendingInsert": null,
+              "scopedSlots": Object {
+                "_normalized": Object {},
+              },
+            },
+            "elm": <span
+              class="token-amount sent"
+            >
+              
+  111
+  
+              <!---->
+               
+              <!---->
+            </span>,
+            "fnContext": undefined,
+            "fnOptions": undefined,
+            "fnScopeId": undefined,
+            "isAsyncPlaceholder": false,
+            "isCloned": false,
+            "isComment": false,
+            "isOnce": false,
+            "isRootInsert": true,
+            "isStatic": false,
+            "key": undefined,
+            "ns": undefined,
+            "parent": undefined,
+            "raw": false,
+            "tag": "vue-component-5",
+            "text": undefined,
+          },
+          "_watcher": Watcher {
+            "active": true,
+            "before": [Function],
+            "cb": [Function],
+            "deep": false,
+            "depIds": Set {
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+            },
+            "deps": Array [
+              Dep {
+                "id": 9,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 10,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 11,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 12,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 13,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 14,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 15,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 16,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+            ],
+            "dirty": false,
+            "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+            "getter": [Function],
+            "id": 1,
+            "lazy": false,
+            "newDepIds": Set {},
+            "newDeps": Array [],
+            "sync": false,
+            "user": false,
+            "value": undefined,
+            "vm": [Circular],
+          },
+          "_watchers": Array [
+            Watcher {
+              "active": true,
+              "before": [Function],
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15,
+                16,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 9,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 10,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 11,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 12,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 13,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 14,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 15,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 16,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+              "getter": [Function],
+              "id": 1,
+              "lazy": false,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": undefined,
+              "vm": [Circular],
+            },
+          ],
+          "vueTestUtils_childProps": Object {
+            "amount": 111,
+            "direction": "sent",
+            "hideFiat": true,
+            "highPrecision": false,
+            "large": false,
+            "noSymbol": true,
+          },
+        },
+        "_self": [Circular],
+        "_staticTrees": null,
+        "_uid": 0,
+        "_vnode": VNode {
+          "asyncFactory": undefined,
+          "asyncMeta": undefined,
+          "children": undefined,
+          "componentInstance": [Circular],
+          "componentOptions": Object {
+            "Ctor": [Function],
+            "children": undefined,
+            "listeners": Object {},
+            "propsData": Object {
+              "amount": 111,
+              "direction": "sent",
+              "hideFiat": true,
+              "highPrecision": false,
+              "large": false,
+              "noSymbol": true,
+            },
+            "tag": undefined,
+          },
+          "context": [Circular],
+          "data": Object {
+            "attrs": Object {},
+            "hook": Object {
+              "destroy": [Function],
+              "init": [Function],
+              "insert": [Function],
+              "prepatch": [Function],
+            },
+            "on": undefined,
+            "pendingInsert": null,
+            "scopedSlots": Object {
+              "_normalized": Object {},
+            },
+          },
+          "elm": <span
+            class="token-amount sent"
+          >
+            
+  111
+  
+            <!---->
+             
+            <!---->
+          </span>,
+          "fnContext": undefined,
+          "fnOptions": undefined,
+          "fnScopeId": undefined,
+          "isAsyncPlaceholder": false,
+          "isCloned": false,
+          "isComment": false,
+          "isOnce": false,
+          "isRootInsert": true,
+          "isStatic": false,
+          "key": undefined,
+          "ns": undefined,
+          "parent": undefined,
+          "raw": false,
+          "tag": "vue-component-5",
+          "text": undefined,
+        },
+        "_watcher": Watcher {
+          "active": true,
+          "before": [Function],
+          "cb": [Function],
+          "deep": false,
+          "depIds": Set {
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+          },
+          "deps": Array [
+            Dep {
+              "id": 9,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 10,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 11,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 12,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 13,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 14,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 15,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 16,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+          ],
+          "dirty": false,
+          "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+          "getter": [Function],
+          "id": 1,
+          "lazy": false,
+          "newDepIds": Set {},
+          "newDeps": Array [],
+          "sync": false,
+          "user": false,
+          "value": undefined,
+          "vm": [Circular],
+        },
+        "_watchers": Array [
+          Watcher {
+            "active": true,
+            "before": [Function],
+            "cb": [Function],
+            "deep": false,
+            "depIds": Set {
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+            },
+            "deps": Array [
+              Dep {
+                "id": 9,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 10,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 11,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 12,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 13,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 14,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 15,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 16,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+            ],
+            "dirty": false,
+            "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+            "getter": [Function],
+            "id": 1,
+            "lazy": false,
+            "newDepIds": Set {},
+            "newDeps": Array [],
+            "sync": false,
+            "user": false,
+            "value": undefined,
+            "vm": [Circular],
+          },
+        ],
+        "vueTestUtils_childProps": Object {
+          "amount": 111,
+          "direction": "sent",
+          "hideFiat": true,
+          "highPrecision": false,
+          "large": false,
+          "noSymbol": true,
+        },
+      },
+      "propsData": Object {
+        "amount": 111,
+        "direction": "sent",
+        "hideFiat": true,
+        "highPrecision": false,
+        "large": false,
+        "noSymbol": true,
+      },
+    },
+    "$parent": VueComponent {
+      "$attrs": Object {},
+      "$children": Array [
+        [Circular],
+      ],
+      "$createElement": [Function],
+      "$el": <span
+        class="token-amount sent"
+      >
+        
+  111
+  
+        <!---->
+         
+        <!---->
+      </span>,
+      "$emit": [Function],
+      "$listeners": Object {},
+      "$options": Object {
+        "$_doNotStubChildren": true,
+        "$_isWrapperParent": true,
+        "_Ctor": Object {
+          "1": [Function],
+        },
+        "_base": [Function],
+        "_isFunctionalContainer": undefined,
+        "beforeCreate": Array [
+          [Function],
+          [Function],
+          [Function],
+        ],
+        "components": Object {
+          "transition": Object {
+            "$_doNotStubChildren": true,
+            "$_vueTestUtils_original": Object {
+              "_Ctor": Object {
+                "1": [Function],
+              },
+              "abstract": true,
+              "name": "transition",
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "mode": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+            },
+            "abstract": true,
+            "attrs": undefined,
+            "class": undefined,
+            "domProps": undefined,
+            "functional": undefined,
+            "key": undefined,
+            "model": undefined,
+            "name": "transition",
+            "nativeOn": undefined,
+            "normalizedStyle": undefined,
+            "on": undefined,
+            "props": Object {
+              "appear": Object {
+                "type": [Function],
+              },
+              "appearActiveClass": Object {
+                "type": [Function],
+              },
+              "appearClass": Object {
+                "type": [Function],
+              },
+              "appearToClass": Object {
+                "type": [Function],
+              },
+              "css": Object {
+                "type": [Function],
+              },
+              "duration": Object {
+                "type": Array [
+                  [Function],
+                  [Function],
+                  [Function],
+                ],
+              },
+              "enterActiveClass": Object {
+                "type": [Function],
+              },
+              "enterClass": Object {
+                "type": [Function],
+              },
+              "enterToClass": Object {
+                "type": [Function],
+              },
+              "leaveActiveClass": Object {
+                "type": [Function],
+              },
+              "leaveClass": Object {
+                "type": [Function],
+              },
+              "leaveToClass": Object {
+                "type": [Function],
+              },
+              "mode": Object {
+                "type": [Function],
+              },
+              "name": Object {
+                "type": [Function],
+              },
+              "type": Object {
+                "type": [Function],
+              },
+            },
+            "render": [Function],
+            "staticClass": undefined,
+            "staticStyle": undefined,
+            "style": undefined,
+          },
+          "transition-group": Object {
+            "$_doNotStubChildren": true,
+            "$_vueTestUtils_original": Object {
+              "_Ctor": Object {
+                "1": [Function],
+              },
+              "beforeMount": [Function],
+              "methods": Object {
+                "hasMove": [Function],
+              },
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "moveClass": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "tag": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+              "updated": [Function],
+            },
+            "abstract": undefined,
+            "attrs": undefined,
+            "class": undefined,
+            "domProps": undefined,
+            "functional": undefined,
+            "key": undefined,
+            "model": undefined,
+            "name": undefined,
+            "nativeOn": undefined,
+            "normalizedStyle": undefined,
+            "on": undefined,
+            "props": Object {
+              "appear": Object {
+                "type": [Function],
+              },
+              "appearActiveClass": Object {
+                "type": [Function],
+              },
+              "appearClass": Object {
+                "type": [Function],
+              },
+              "appearToClass": Object {
+                "type": [Function],
+              },
+              "css": Object {
+                "type": [Function],
+              },
+              "duration": Object {
+                "type": Array [
+                  [Function],
+                  [Function],
+                  [Function],
+                ],
+              },
+              "enterActiveClass": Object {
+                "type": [Function],
+              },
+              "enterClass": Object {
+                "type": [Function],
+              },
+              "enterToClass": Object {
+                "type": [Function],
+              },
+              "leaveActiveClass": Object {
+                "type": [Function],
+              },
+              "leaveClass": Object {
+                "type": [Function],
+              },
+              "leaveToClass": Object {
+                "type": [Function],
+              },
+              "moveClass": Object {
+                "type": [Function],
+              },
+              "name": Object {
+                "type": [Function],
+              },
+              "tag": Object {
+                "type": [Function],
+              },
+              "type": Object {
+                "type": [Function],
+              },
+            },
+            "render": [Function],
+            "staticClass": undefined,
+            "staticStyle": undefined,
+            "style": undefined,
+          },
+        },
+        "data": [Function],
+        "directives": Object {},
+        "filters": Object {},
+        "methods": undefined,
+        "mocks": Object {
+          "$store": Object {
+            "getters": Object {},
+            "state": Object {},
+          },
+        },
+        "provide": [Function],
+        "render": [Function],
+        "shouldProxy": true,
+        "stubs": Object {
+          "transition": true,
+          "transition-group": true,
+        },
+      },
+      "$parent": undefined,
+      "$refs": Object {},
+      "$root": [Circular],
+      "$scopedSlots": Object {},
+      "$slots": Object {},
+      "$vnode": undefined,
+      "__emitted": Object {},
+      "__emittedByOrder": Array [],
+      "_c": [Function],
+      "_data": Object {
+        "vueTestUtils_childProps": Object {
+          "amount": 111,
+          "direction": "sent",
+          "hideFiat": true,
+          "highPrecision": false,
+          "large": false,
+          "noSymbol": true,
+        },
+      },
+      "_directInactive": false,
+      "_events": Object {},
+      "_hasHookEvent": false,
+      "_inactive": null,
+      "_isBeingDestroyed": false,
+      "_isDestroyed": false,
+      "_isMounted": true,
+      "_isVue": true,
+      "_provided": Object {},
+      "_renderProxy": VueComponent {
+        "$attrs": Object {},
+        "$children": Array [
+          [Circular],
+        ],
+        "$createElement": [Function],
+        "$el": <span
+          class="token-amount sent"
+        >
+          
+  111
+  
+          <!---->
+           
+          <!---->
+        </span>,
+        "$emit": [Function],
+        "$listeners": Object {},
+        "$options": Object {
+          "$_doNotStubChildren": true,
+          "$_isWrapperParent": true,
+          "_Ctor": Object {
+            "1": [Function],
+          },
+          "_base": [Function],
+          "_isFunctionalContainer": undefined,
+          "beforeCreate": Array [
+            [Function],
+            [Function],
+            [Function],
+          ],
+          "components": Object {
+            "transition": Object {
+              "$_doNotStubChildren": true,
+              "$_vueTestUtils_original": Object {
+                "_Ctor": Object {
+                  "1": [Function],
+                },
+                "abstract": true,
+                "name": "transition",
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "mode": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+              },
+              "abstract": true,
+              "attrs": undefined,
+              "class": undefined,
+              "domProps": undefined,
+              "functional": undefined,
+              "key": undefined,
+              "model": undefined,
+              "name": "transition",
+              "nativeOn": undefined,
+              "normalizedStyle": undefined,
+              "on": undefined,
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "mode": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+              "staticClass": undefined,
+              "staticStyle": undefined,
+              "style": undefined,
+            },
+            "transition-group": Object {
+              "$_doNotStubChildren": true,
+              "$_vueTestUtils_original": Object {
+                "_Ctor": Object {
+                  "1": [Function],
+                },
+                "beforeMount": [Function],
+                "methods": Object {
+                  "hasMove": [Function],
+                },
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "moveClass": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "tag": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+                "updated": [Function],
+              },
+              "abstract": undefined,
+              "attrs": undefined,
+              "class": undefined,
+              "domProps": undefined,
+              "functional": undefined,
+              "key": undefined,
+              "model": undefined,
+              "name": undefined,
+              "nativeOn": undefined,
+              "normalizedStyle": undefined,
+              "on": undefined,
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "moveClass": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "tag": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+              "staticClass": undefined,
+              "staticStyle": undefined,
+              "style": undefined,
+            },
+          },
+          "data": [Function],
+          "directives": Object {},
+          "filters": Object {},
+          "methods": undefined,
+          "mocks": Object {
+            "$store": Object {
+              "getters": Object {},
+              "state": Object {},
+            },
+          },
+          "provide": [Function],
+          "render": [Function],
+          "shouldProxy": true,
+          "stubs": Object {
+            "transition": true,
+            "transition-group": true,
+          },
+        },
+        "$parent": undefined,
+        "$refs": Object {},
+        "$root": [Circular],
+        "$scopedSlots": Object {},
+        "$slots": Object {},
+        "$vnode": undefined,
+        "__emitted": Object {},
+        "__emittedByOrder": Array [],
+        "_c": [Function],
+        "_data": Object {
+          "vueTestUtils_childProps": Object {
+            "amount": 111,
+            "direction": "sent",
+            "hideFiat": true,
+            "highPrecision": false,
+            "large": false,
+            "noSymbol": true,
+          },
+        },
+        "_directInactive": false,
+        "_events": Object {},
+        "_hasHookEvent": false,
+        "_inactive": null,
+        "_isBeingDestroyed": false,
+        "_isDestroyed": false,
+        "_isMounted": true,
+        "_isVue": true,
+        "_provided": Object {},
+        "_renderProxy": [Circular],
+        "_self": [Circular],
+        "_staticTrees": null,
+        "_uid": 0,
+        "_vnode": VNode {
+          "asyncFactory": undefined,
+          "asyncMeta": undefined,
+          "children": undefined,
+          "componentInstance": [Circular],
+          "componentOptions": Object {
+            "Ctor": [Function],
+            "children": undefined,
+            "listeners": Object {},
+            "propsData": Object {
+              "amount": 111,
+              "direction": "sent",
+              "hideFiat": true,
+              "highPrecision": false,
+              "large": false,
+              "noSymbol": true,
+            },
+            "tag": undefined,
+          },
+          "context": [Circular],
+          "data": Object {
+            "attrs": Object {},
+            "hook": Object {
+              "destroy": [Function],
+              "init": [Function],
+              "insert": [Function],
+              "prepatch": [Function],
+            },
+            "on": undefined,
+            "pendingInsert": null,
+            "scopedSlots": Object {
+              "_normalized": Object {},
+            },
+          },
+          "elm": <span
+            class="token-amount sent"
+          >
+            
+  111
+  
+            <!---->
+             
+            <!---->
+          </span>,
+          "fnContext": undefined,
+          "fnOptions": undefined,
+          "fnScopeId": undefined,
+          "isAsyncPlaceholder": false,
+          "isCloned": false,
+          "isComment": false,
+          "isOnce": false,
+          "isRootInsert": true,
+          "isStatic": false,
+          "key": undefined,
+          "ns": undefined,
+          "parent": undefined,
+          "raw": false,
+          "tag": "vue-component-5",
+          "text": undefined,
+        },
+        "_watcher": Watcher {
+          "active": true,
+          "before": [Function],
+          "cb": [Function],
+          "deep": false,
+          "depIds": Set {
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+          },
+          "deps": Array [
+            Dep {
+              "id": 9,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 10,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 11,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 12,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 13,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 14,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 15,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 16,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+          ],
+          "dirty": false,
+          "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+          "getter": [Function],
+          "id": 1,
+          "lazy": false,
+          "newDepIds": Set {},
+          "newDeps": Array [],
+          "sync": false,
+          "user": false,
+          "value": undefined,
+          "vm": [Circular],
+        },
+        "_watchers": Array [
+          Watcher {
+            "active": true,
+            "before": [Function],
+            "cb": [Function],
+            "deep": false,
+            "depIds": Set {
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+            },
+            "deps": Array [
+              Dep {
+                "id": 9,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 10,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 11,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 12,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 13,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 14,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 15,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 16,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+            ],
+            "dirty": false,
+            "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+            "getter": [Function],
+            "id": 1,
+            "lazy": false,
+            "newDepIds": Set {},
+            "newDeps": Array [],
+            "sync": false,
+            "user": false,
+            "value": undefined,
+            "vm": [Circular],
+          },
+        ],
+        "vueTestUtils_childProps": Object {
+          "amount": 111,
+          "direction": "sent",
+          "hideFiat": true,
+          "highPrecision": false,
+          "large": false,
+          "noSymbol": true,
+        },
+      },
+      "_self": [Circular],
+      "_staticTrees": null,
+      "_uid": 0,
+      "_vnode": VNode {
+        "asyncFactory": undefined,
+        "asyncMeta": undefined,
+        "children": undefined,
+        "componentInstance": [Circular],
+        "componentOptions": Object {
+          "Ctor": [Function],
+          "children": undefined,
+          "listeners": Object {},
+          "propsData": Object {
+            "amount": 111,
+            "direction": "sent",
+            "hideFiat": true,
+            "highPrecision": false,
+            "large": false,
+            "noSymbol": true,
+          },
+          "tag": undefined,
+        },
+        "context": [Circular],
+        "data": Object {
+          "attrs": Object {},
+          "hook": Object {
+            "destroy": [Function],
+            "init": [Function],
+            "insert": [Function],
+            "prepatch": [Function],
+          },
+          "on": undefined,
+          "pendingInsert": null,
+          "scopedSlots": Object {
+            "_normalized": Object {},
+          },
+        },
+        "elm": <span
+          class="token-amount sent"
+        >
+          
+  111
+  
+          <!---->
+           
+          <!---->
+        </span>,
+        "fnContext": undefined,
+        "fnOptions": undefined,
+        "fnScopeId": undefined,
+        "isAsyncPlaceholder": false,
+        "isCloned": false,
+        "isComment": false,
+        "isOnce": false,
+        "isRootInsert": true,
+        "isStatic": false,
+        "key": undefined,
+        "ns": undefined,
+        "parent": undefined,
+        "raw": false,
+        "tag": "vue-component-5",
+        "text": undefined,
+      },
+      "_watcher": Watcher {
+        "active": true,
+        "before": [Function],
+        "cb": [Function],
+        "deep": false,
+        "depIds": Set {
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+        },
+        "deps": Array [
+          Dep {
+            "id": 9,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 10,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 11,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 12,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 13,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 14,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 15,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 16,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+        ],
+        "dirty": false,
+        "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+        "getter": [Function],
+        "id": 1,
+        "lazy": false,
+        "newDepIds": Set {},
+        "newDeps": Array [],
+        "sync": false,
+        "user": false,
+        "value": undefined,
+        "vm": [Circular],
+      },
+      "_watchers": Array [
+        Watcher {
+          "active": true,
+          "before": [Function],
+          "cb": [Function],
+          "deep": false,
+          "depIds": Set {
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+          },
+          "deps": Array [
+            Dep {
+              "id": 9,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 10,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 11,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 12,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 13,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 14,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 15,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 16,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+          ],
+          "dirty": false,
+          "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+          "getter": [Function],
+          "id": 1,
+          "lazy": false,
+          "newDepIds": Set {},
+          "newDeps": Array [],
+          "sync": false,
+          "user": false,
+          "value": undefined,
+          "vm": [Circular],
+        },
+      ],
+      "vueTestUtils_childProps": Object {
+        "amount": 111,
+        "direction": "sent",
+        "hideFiat": true,
+        "highPrecision": false,
+        "large": false,
+        "noSymbol": true,
+      },
+    },
+    "$refs": Object {},
+    "$root": VueComponent {
+      "$attrs": Object {},
+      "$children": Array [
+        [Circular],
+      ],
+      "$createElement": [Function],
+      "$el": <span
+        class="token-amount sent"
+      >
+        
+  111
+  
+        <!---->
+         
+        <!---->
+      </span>,
+      "$emit": [Function],
+      "$listeners": Object {},
+      "$options": Object {
+        "$_doNotStubChildren": true,
+        "$_isWrapperParent": true,
+        "_Ctor": Object {
+          "1": [Function],
+        },
+        "_base": [Function],
+        "_isFunctionalContainer": undefined,
+        "beforeCreate": Array [
+          [Function],
+          [Function],
+          [Function],
+        ],
+        "components": Object {
+          "transition": Object {
+            "$_doNotStubChildren": true,
+            "$_vueTestUtils_original": Object {
+              "_Ctor": Object {
+                "1": [Function],
+              },
+              "abstract": true,
+              "name": "transition",
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "mode": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+            },
+            "abstract": true,
+            "attrs": undefined,
+            "class": undefined,
+            "domProps": undefined,
+            "functional": undefined,
+            "key": undefined,
+            "model": undefined,
+            "name": "transition",
+            "nativeOn": undefined,
+            "normalizedStyle": undefined,
+            "on": undefined,
+            "props": Object {
+              "appear": Object {
+                "type": [Function],
+              },
+              "appearActiveClass": Object {
+                "type": [Function],
+              },
+              "appearClass": Object {
+                "type": [Function],
+              },
+              "appearToClass": Object {
+                "type": [Function],
+              },
+              "css": Object {
+                "type": [Function],
+              },
+              "duration": Object {
+                "type": Array [
+                  [Function],
+                  [Function],
+                  [Function],
+                ],
+              },
+              "enterActiveClass": Object {
+                "type": [Function],
+              },
+              "enterClass": Object {
+                "type": [Function],
+              },
+              "enterToClass": Object {
+                "type": [Function],
+              },
+              "leaveActiveClass": Object {
+                "type": [Function],
+              },
+              "leaveClass": Object {
+                "type": [Function],
+              },
+              "leaveToClass": Object {
+                "type": [Function],
+              },
+              "mode": Object {
+                "type": [Function],
+              },
+              "name": Object {
+                "type": [Function],
+              },
+              "type": Object {
+                "type": [Function],
+              },
+            },
+            "render": [Function],
+            "staticClass": undefined,
+            "staticStyle": undefined,
+            "style": undefined,
+          },
+          "transition-group": Object {
+            "$_doNotStubChildren": true,
+            "$_vueTestUtils_original": Object {
+              "_Ctor": Object {
+                "1": [Function],
+              },
+              "beforeMount": [Function],
+              "methods": Object {
+                "hasMove": [Function],
+              },
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "moveClass": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "tag": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+              "updated": [Function],
+            },
+            "abstract": undefined,
+            "attrs": undefined,
+            "class": undefined,
+            "domProps": undefined,
+            "functional": undefined,
+            "key": undefined,
+            "model": undefined,
+            "name": undefined,
+            "nativeOn": undefined,
+            "normalizedStyle": undefined,
+            "on": undefined,
+            "props": Object {
+              "appear": Object {
+                "type": [Function],
+              },
+              "appearActiveClass": Object {
+                "type": [Function],
+              },
+              "appearClass": Object {
+                "type": [Function],
+              },
+              "appearToClass": Object {
+                "type": [Function],
+              },
+              "css": Object {
+                "type": [Function],
+              },
+              "duration": Object {
+                "type": Array [
+                  [Function],
+                  [Function],
+                  [Function],
+                ],
+              },
+              "enterActiveClass": Object {
+                "type": [Function],
+              },
+              "enterClass": Object {
+                "type": [Function],
+              },
+              "enterToClass": Object {
+                "type": [Function],
+              },
+              "leaveActiveClass": Object {
+                "type": [Function],
+              },
+              "leaveClass": Object {
+                "type": [Function],
+              },
+              "leaveToClass": Object {
+                "type": [Function],
+              },
+              "moveClass": Object {
+                "type": [Function],
+              },
+              "name": Object {
+                "type": [Function],
+              },
+              "tag": Object {
+                "type": [Function],
+              },
+              "type": Object {
+                "type": [Function],
+              },
+            },
+            "render": [Function],
+            "staticClass": undefined,
+            "staticStyle": undefined,
+            "style": undefined,
+          },
+        },
+        "data": [Function],
+        "directives": Object {},
+        "filters": Object {},
+        "methods": undefined,
+        "mocks": Object {
+          "$store": Object {
+            "getters": Object {},
+            "state": Object {},
+          },
+        },
+        "provide": [Function],
+        "render": [Function],
+        "shouldProxy": true,
+        "stubs": Object {
+          "transition": true,
+          "transition-group": true,
+        },
+      },
+      "$parent": undefined,
+      "$refs": Object {},
+      "$root": [Circular],
+      "$scopedSlots": Object {},
+      "$slots": Object {},
+      "$vnode": undefined,
+      "__emitted": Object {},
+      "__emittedByOrder": Array [],
+      "_c": [Function],
+      "_data": Object {
+        "vueTestUtils_childProps": Object {
+          "amount": 111,
+          "direction": "sent",
+          "hideFiat": true,
+          "highPrecision": false,
+          "large": false,
+          "noSymbol": true,
+        },
+      },
+      "_directInactive": false,
+      "_events": Object {},
+      "_hasHookEvent": false,
+      "_inactive": null,
+      "_isBeingDestroyed": false,
+      "_isDestroyed": false,
+      "_isMounted": true,
+      "_isVue": true,
+      "_provided": Object {},
+      "_renderProxy": VueComponent {
+        "$attrs": Object {},
+        "$children": Array [
+          [Circular],
+        ],
+        "$createElement": [Function],
+        "$el": <span
+          class="token-amount sent"
+        >
+          
+  111
+  
+          <!---->
+           
+          <!---->
+        </span>,
+        "$emit": [Function],
+        "$listeners": Object {},
+        "$options": Object {
+          "$_doNotStubChildren": true,
+          "$_isWrapperParent": true,
+          "_Ctor": Object {
+            "1": [Function],
+          },
+          "_base": [Function],
+          "_isFunctionalContainer": undefined,
+          "beforeCreate": Array [
+            [Function],
+            [Function],
+            [Function],
+          ],
+          "components": Object {
+            "transition": Object {
+              "$_doNotStubChildren": true,
+              "$_vueTestUtils_original": Object {
+                "_Ctor": Object {
+                  "1": [Function],
+                },
+                "abstract": true,
+                "name": "transition",
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "mode": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+              },
+              "abstract": true,
+              "attrs": undefined,
+              "class": undefined,
+              "domProps": undefined,
+              "functional": undefined,
+              "key": undefined,
+              "model": undefined,
+              "name": "transition",
+              "nativeOn": undefined,
+              "normalizedStyle": undefined,
+              "on": undefined,
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "mode": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+              "staticClass": undefined,
+              "staticStyle": undefined,
+              "style": undefined,
+            },
+            "transition-group": Object {
+              "$_doNotStubChildren": true,
+              "$_vueTestUtils_original": Object {
+                "_Ctor": Object {
+                  "1": [Function],
+                },
+                "beforeMount": [Function],
+                "methods": Object {
+                  "hasMove": [Function],
+                },
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "moveClass": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "tag": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+                "updated": [Function],
+              },
+              "abstract": undefined,
+              "attrs": undefined,
+              "class": undefined,
+              "domProps": undefined,
+              "functional": undefined,
+              "key": undefined,
+              "model": undefined,
+              "name": undefined,
+              "nativeOn": undefined,
+              "normalizedStyle": undefined,
+              "on": undefined,
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "moveClass": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "tag": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+              "staticClass": undefined,
+              "staticStyle": undefined,
+              "style": undefined,
+            },
+          },
+          "data": [Function],
+          "directives": Object {},
+          "filters": Object {},
+          "methods": undefined,
+          "mocks": Object {
+            "$store": Object {
+              "getters": Object {},
+              "state": Object {},
+            },
+          },
+          "provide": [Function],
+          "render": [Function],
+          "shouldProxy": true,
+          "stubs": Object {
+            "transition": true,
+            "transition-group": true,
+          },
+        },
+        "$parent": undefined,
+        "$refs": Object {},
+        "$root": [Circular],
+        "$scopedSlots": Object {},
+        "$slots": Object {},
+        "$vnode": undefined,
+        "__emitted": Object {},
+        "__emittedByOrder": Array [],
+        "_c": [Function],
+        "_data": Object {
+          "vueTestUtils_childProps": Object {
+            "amount": 111,
+            "direction": "sent",
+            "hideFiat": true,
+            "highPrecision": false,
+            "large": false,
+            "noSymbol": true,
+          },
+        },
+        "_directInactive": false,
+        "_events": Object {},
+        "_hasHookEvent": false,
+        "_inactive": null,
+        "_isBeingDestroyed": false,
+        "_isDestroyed": false,
+        "_isMounted": true,
+        "_isVue": true,
+        "_provided": Object {},
+        "_renderProxy": [Circular],
+        "_self": [Circular],
+        "_staticTrees": null,
+        "_uid": 0,
+        "_vnode": VNode {
+          "asyncFactory": undefined,
+          "asyncMeta": undefined,
+          "children": undefined,
+          "componentInstance": [Circular],
+          "componentOptions": Object {
+            "Ctor": [Function],
+            "children": undefined,
+            "listeners": Object {},
+            "propsData": Object {
+              "amount": 111,
+              "direction": "sent",
+              "hideFiat": true,
+              "highPrecision": false,
+              "large": false,
+              "noSymbol": true,
+            },
+            "tag": undefined,
+          },
+          "context": [Circular],
+          "data": Object {
+            "attrs": Object {},
+            "hook": Object {
+              "destroy": [Function],
+              "init": [Function],
+              "insert": [Function],
+              "prepatch": [Function],
+            },
+            "on": undefined,
+            "pendingInsert": null,
+            "scopedSlots": Object {
+              "_normalized": Object {},
+            },
+          },
+          "elm": <span
+            class="token-amount sent"
+          >
+            
+  111
+  
+            <!---->
+             
+            <!---->
+          </span>,
+          "fnContext": undefined,
+          "fnOptions": undefined,
+          "fnScopeId": undefined,
+          "isAsyncPlaceholder": false,
+          "isCloned": false,
+          "isComment": false,
+          "isOnce": false,
+          "isRootInsert": true,
+          "isStatic": false,
+          "key": undefined,
+          "ns": undefined,
+          "parent": undefined,
+          "raw": false,
+          "tag": "vue-component-5",
+          "text": undefined,
+        },
+        "_watcher": Watcher {
+          "active": true,
+          "before": [Function],
+          "cb": [Function],
+          "deep": false,
+          "depIds": Set {
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+          },
+          "deps": Array [
+            Dep {
+              "id": 9,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 10,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 11,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 12,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 13,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 14,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 15,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 16,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+          ],
+          "dirty": false,
+          "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+          "getter": [Function],
+          "id": 1,
+          "lazy": false,
+          "newDepIds": Set {},
+          "newDeps": Array [],
+          "sync": false,
+          "user": false,
+          "value": undefined,
+          "vm": [Circular],
+        },
+        "_watchers": Array [
+          Watcher {
+            "active": true,
+            "before": [Function],
+            "cb": [Function],
+            "deep": false,
+            "depIds": Set {
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+            },
+            "deps": Array [
+              Dep {
+                "id": 9,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 10,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 11,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 12,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 13,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 14,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 15,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 16,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+            ],
+            "dirty": false,
+            "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+            "getter": [Function],
+            "id": 1,
+            "lazy": false,
+            "newDepIds": Set {},
+            "newDeps": Array [],
+            "sync": false,
+            "user": false,
+            "value": undefined,
+            "vm": [Circular],
+          },
+        ],
+        "vueTestUtils_childProps": Object {
+          "amount": 111,
+          "direction": "sent",
+          "hideFiat": true,
+          "highPrecision": false,
+          "large": false,
+          "noSymbol": true,
+        },
+      },
+      "_self": [Circular],
+      "_staticTrees": null,
+      "_uid": 0,
+      "_vnode": VNode {
+        "asyncFactory": undefined,
+        "asyncMeta": undefined,
+        "children": undefined,
+        "componentInstance": [Circular],
+        "componentOptions": Object {
+          "Ctor": [Function],
+          "children": undefined,
+          "listeners": Object {},
+          "propsData": Object {
+            "amount": 111,
+            "direction": "sent",
+            "hideFiat": true,
+            "highPrecision": false,
+            "large": false,
+            "noSymbol": true,
+          },
+          "tag": undefined,
+        },
+        "context": [Circular],
+        "data": Object {
+          "attrs": Object {},
+          "hook": Object {
+            "destroy": [Function],
+            "init": [Function],
+            "insert": [Function],
+            "prepatch": [Function],
+          },
+          "on": undefined,
+          "pendingInsert": null,
+          "scopedSlots": Object {
+            "_normalized": Object {},
+          },
+        },
+        "elm": <span
+          class="token-amount sent"
+        >
+          
+  111
+  
+          <!---->
+           
+          <!---->
+        </span>,
+        "fnContext": undefined,
+        "fnOptions": undefined,
+        "fnScopeId": undefined,
+        "isAsyncPlaceholder": false,
+        "isCloned": false,
+        "isComment": false,
+        "isOnce": false,
+        "isRootInsert": true,
+        "isStatic": false,
+        "key": undefined,
+        "ns": undefined,
+        "parent": undefined,
+        "raw": false,
+        "tag": "vue-component-5",
+        "text": undefined,
+      },
+      "_watcher": Watcher {
+        "active": true,
+        "before": [Function],
+        "cb": [Function],
+        "deep": false,
+        "depIds": Set {
+          9,
+          10,
+          11,
+          12,
+          13,
+          14,
+          15,
+          16,
+        },
+        "deps": Array [
+          Dep {
+            "id": 9,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 10,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 11,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 12,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 13,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 14,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 15,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 16,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+        ],
+        "dirty": false,
+        "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+        "getter": [Function],
+        "id": 1,
+        "lazy": false,
+        "newDepIds": Set {},
+        "newDeps": Array [],
+        "sync": false,
+        "user": false,
+        "value": undefined,
+        "vm": [Circular],
+      },
+      "_watchers": Array [
+        Watcher {
+          "active": true,
+          "before": [Function],
+          "cb": [Function],
+          "deep": false,
+          "depIds": Set {
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+          },
+          "deps": Array [
+            Dep {
+              "id": 9,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 10,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 11,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 12,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 13,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 14,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 15,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 16,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+          ],
+          "dirty": false,
+          "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+          "getter": [Function],
+          "id": 1,
+          "lazy": false,
+          "newDepIds": Set {},
+          "newDeps": Array [],
+          "sync": false,
+          "user": false,
+          "value": undefined,
+          "vm": [Circular],
+        },
+      ],
+      "vueTestUtils_childProps": Object {
+        "amount": 111,
+        "direction": "sent",
+        "hideFiat": true,
+        "highPrecision": false,
+        "large": false,
+        "noSymbol": true,
+      },
+    },
+    "$scopedSlots": Object {},
+    "$slots": Object {},
+    "$vnode": VNode {
+      "asyncFactory": undefined,
+      "asyncMeta": undefined,
+      "children": undefined,
+      "componentInstance": [Circular],
+      "componentOptions": Object {
+        "Ctor": [Function],
+        "children": undefined,
+        "listeners": Object {},
+        "propsData": Object {
+          "amount": 111,
+          "direction": "sent",
+          "hideFiat": true,
+          "highPrecision": false,
+          "large": false,
+          "noSymbol": true,
+        },
+        "tag": undefined,
+      },
+      "context": VueComponent {
+        "$attrs": Object {},
+        "$children": Array [
+          [Circular],
+        ],
+        "$createElement": [Function],
+        "$el": <span
+          class="token-amount sent"
+        >
+          
+  111
+  
+          <!---->
+           
+          <!---->
+        </span>,
+        "$emit": [Function],
+        "$listeners": Object {},
+        "$options": Object {
+          "$_doNotStubChildren": true,
+          "$_isWrapperParent": true,
+          "_Ctor": Object {
+            "1": [Function],
+          },
+          "_base": [Function],
+          "_isFunctionalContainer": undefined,
+          "beforeCreate": Array [
+            [Function],
+            [Function],
+            [Function],
+          ],
+          "components": Object {
+            "transition": Object {
+              "$_doNotStubChildren": true,
+              "$_vueTestUtils_original": Object {
+                "_Ctor": Object {
+                  "1": [Function],
+                },
+                "abstract": true,
+                "name": "transition",
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "mode": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+              },
+              "abstract": true,
+              "attrs": undefined,
+              "class": undefined,
+              "domProps": undefined,
+              "functional": undefined,
+              "key": undefined,
+              "model": undefined,
+              "name": "transition",
+              "nativeOn": undefined,
+              "normalizedStyle": undefined,
+              "on": undefined,
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "mode": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+              "staticClass": undefined,
+              "staticStyle": undefined,
+              "style": undefined,
+            },
+            "transition-group": Object {
+              "$_doNotStubChildren": true,
+              "$_vueTestUtils_original": Object {
+                "_Ctor": Object {
+                  "1": [Function],
+                },
+                "beforeMount": [Function],
+                "methods": Object {
+                  "hasMove": [Function],
+                },
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "moveClass": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "tag": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+                "updated": [Function],
+              },
+              "abstract": undefined,
+              "attrs": undefined,
+              "class": undefined,
+              "domProps": undefined,
+              "functional": undefined,
+              "key": undefined,
+              "model": undefined,
+              "name": undefined,
+              "nativeOn": undefined,
+              "normalizedStyle": undefined,
+              "on": undefined,
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "moveClass": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "tag": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+              "staticClass": undefined,
+              "staticStyle": undefined,
+              "style": undefined,
+            },
+          },
+          "data": [Function],
+          "directives": Object {},
+          "filters": Object {},
+          "methods": undefined,
+          "mocks": Object {
+            "$store": Object {
+              "getters": Object {},
+              "state": Object {},
+            },
+          },
+          "provide": [Function],
+          "render": [Function],
+          "shouldProxy": true,
+          "stubs": Object {
+            "transition": true,
+            "transition-group": true,
+          },
+        },
+        "$parent": undefined,
+        "$refs": Object {},
+        "$root": [Circular],
+        "$scopedSlots": Object {},
+        "$slots": Object {},
+        "$vnode": undefined,
+        "__emitted": Object {},
+        "__emittedByOrder": Array [],
+        "_c": [Function],
+        "_data": Object {
+          "vueTestUtils_childProps": Object {
+            "amount": 111,
+            "direction": "sent",
+            "hideFiat": true,
+            "highPrecision": false,
+            "large": false,
+            "noSymbol": true,
+          },
+        },
+        "_directInactive": false,
+        "_events": Object {},
+        "_hasHookEvent": false,
+        "_inactive": null,
+        "_isBeingDestroyed": false,
+        "_isDestroyed": false,
+        "_isMounted": true,
+        "_isVue": true,
+        "_provided": Object {},
+        "_renderProxy": VueComponent {
+          "$attrs": Object {},
+          "$children": Array [
+            [Circular],
+          ],
+          "$createElement": [Function],
+          "$el": <span
+            class="token-amount sent"
+          >
+            
+  111
+  
+            <!---->
+             
+            <!---->
+          </span>,
+          "$emit": [Function],
+          "$listeners": Object {},
+          "$options": Object {
+            "$_doNotStubChildren": true,
+            "$_isWrapperParent": true,
+            "_Ctor": Object {
+              "1": [Function],
+            },
+            "_base": [Function],
+            "_isFunctionalContainer": undefined,
+            "beforeCreate": Array [
+              [Function],
+              [Function],
+              [Function],
+            ],
+            "components": Object {
+              "transition": Object {
+                "$_doNotStubChildren": true,
+                "$_vueTestUtils_original": Object {
+                  "_Ctor": Object {
+                    "1": [Function],
+                  },
+                  "abstract": true,
+                  "name": "transition",
+                  "props": Object {
+                    "appear": Object {
+                      "type": [Function],
+                    },
+                    "appearActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "appearClass": Object {
+                      "type": [Function],
+                    },
+                    "appearToClass": Object {
+                      "type": [Function],
+                    },
+                    "css": Object {
+                      "type": [Function],
+                    },
+                    "duration": Object {
+                      "type": Array [
+                        [Function],
+                        [Function],
+                        [Function],
+                      ],
+                    },
+                    "enterActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "enterClass": Object {
+                      "type": [Function],
+                    },
+                    "enterToClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveToClass": Object {
+                      "type": [Function],
+                    },
+                    "mode": Object {
+                      "type": [Function],
+                    },
+                    "name": Object {
+                      "type": [Function],
+                    },
+                    "type": Object {
+                      "type": [Function],
+                    },
+                  },
+                  "render": [Function],
+                },
+                "abstract": true,
+                "attrs": undefined,
+                "class": undefined,
+                "domProps": undefined,
+                "functional": undefined,
+                "key": undefined,
+                "model": undefined,
+                "name": "transition",
+                "nativeOn": undefined,
+                "normalizedStyle": undefined,
+                "on": undefined,
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "mode": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+                "staticClass": undefined,
+                "staticStyle": undefined,
+                "style": undefined,
+              },
+              "transition-group": Object {
+                "$_doNotStubChildren": true,
+                "$_vueTestUtils_original": Object {
+                  "_Ctor": Object {
+                    "1": [Function],
+                  },
+                  "beforeMount": [Function],
+                  "methods": Object {
+                    "hasMove": [Function],
+                  },
+                  "props": Object {
+                    "appear": Object {
+                      "type": [Function],
+                    },
+                    "appearActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "appearClass": Object {
+                      "type": [Function],
+                    },
+                    "appearToClass": Object {
+                      "type": [Function],
+                    },
+                    "css": Object {
+                      "type": [Function],
+                    },
+                    "duration": Object {
+                      "type": Array [
+                        [Function],
+                        [Function],
+                        [Function],
+                      ],
+                    },
+                    "enterActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "enterClass": Object {
+                      "type": [Function],
+                    },
+                    "enterToClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveToClass": Object {
+                      "type": [Function],
+                    },
+                    "moveClass": Object {
+                      "type": [Function],
+                    },
+                    "name": Object {
+                      "type": [Function],
+                    },
+                    "tag": Object {
+                      "type": [Function],
+                    },
+                    "type": Object {
+                      "type": [Function],
+                    },
+                  },
+                  "render": [Function],
+                  "updated": [Function],
+                },
+                "abstract": undefined,
+                "attrs": undefined,
+                "class": undefined,
+                "domProps": undefined,
+                "functional": undefined,
+                "key": undefined,
+                "model": undefined,
+                "name": undefined,
+                "nativeOn": undefined,
+                "normalizedStyle": undefined,
+                "on": undefined,
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "moveClass": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "tag": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+                "staticClass": undefined,
+                "staticStyle": undefined,
+                "style": undefined,
+              },
+            },
+            "data": [Function],
+            "directives": Object {},
+            "filters": Object {},
+            "methods": undefined,
+            "mocks": Object {
+              "$store": Object {
+                "getters": Object {},
+                "state": Object {},
+              },
+            },
+            "provide": [Function],
+            "render": [Function],
+            "shouldProxy": true,
+            "stubs": Object {
+              "transition": true,
+              "transition-group": true,
+            },
+          },
+          "$parent": undefined,
+          "$refs": Object {},
+          "$root": [Circular],
+          "$scopedSlots": Object {},
+          "$slots": Object {},
+          "$vnode": undefined,
+          "__emitted": Object {},
+          "__emittedByOrder": Array [],
+          "_c": [Function],
+          "_data": Object {
+            "vueTestUtils_childProps": Object {
+              "amount": 111,
+              "direction": "sent",
+              "hideFiat": true,
+              "highPrecision": false,
+              "large": false,
+              "noSymbol": true,
+            },
+          },
+          "_directInactive": false,
+          "_events": Object {},
+          "_hasHookEvent": false,
+          "_inactive": null,
+          "_isBeingDestroyed": false,
+          "_isDestroyed": false,
+          "_isMounted": true,
+          "_isVue": true,
+          "_provided": Object {},
+          "_renderProxy": [Circular],
+          "_self": [Circular],
+          "_staticTrees": null,
+          "_uid": 0,
+          "_vnode": [Circular],
+          "_watcher": Watcher {
+            "active": true,
+            "before": [Function],
+            "cb": [Function],
+            "deep": false,
+            "depIds": Set {
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+            },
+            "deps": Array [
+              Dep {
+                "id": 9,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 10,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 11,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 12,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 13,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 14,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 15,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 16,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+            ],
+            "dirty": false,
+            "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+            "getter": [Function],
+            "id": 1,
+            "lazy": false,
+            "newDepIds": Set {},
+            "newDeps": Array [],
+            "sync": false,
+            "user": false,
+            "value": undefined,
+            "vm": [Circular],
+          },
+          "_watchers": Array [
+            Watcher {
+              "active": true,
+              "before": [Function],
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15,
+                16,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 9,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 10,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 11,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 12,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 13,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 14,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 15,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 16,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+              "getter": [Function],
+              "id": 1,
+              "lazy": false,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": undefined,
+              "vm": [Circular],
+            },
+          ],
+          "vueTestUtils_childProps": Object {
+            "amount": 111,
+            "direction": "sent",
+            "hideFiat": true,
+            "highPrecision": false,
+            "large": false,
+            "noSymbol": true,
+          },
+        },
+        "_self": [Circular],
+        "_staticTrees": null,
+        "_uid": 0,
+        "_vnode": [Circular],
+        "_watcher": Watcher {
+          "active": true,
+          "before": [Function],
+          "cb": [Function],
+          "deep": false,
+          "depIds": Set {
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+          },
+          "deps": Array [
+            Dep {
+              "id": 9,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 10,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 11,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 12,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 13,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 14,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 15,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 16,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+          ],
+          "dirty": false,
+          "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+          "getter": [Function],
+          "id": 1,
+          "lazy": false,
+          "newDepIds": Set {},
+          "newDeps": Array [],
+          "sync": false,
+          "user": false,
+          "value": undefined,
+          "vm": [Circular],
+        },
+        "_watchers": Array [
+          Watcher {
+            "active": true,
+            "before": [Function],
+            "cb": [Function],
+            "deep": false,
+            "depIds": Set {
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+            },
+            "deps": Array [
+              Dep {
+                "id": 9,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 10,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 11,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 12,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 13,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 14,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 15,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 16,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+            ],
+            "dirty": false,
+            "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+            "getter": [Function],
+            "id": 1,
+            "lazy": false,
+            "newDepIds": Set {},
+            "newDeps": Array [],
+            "sync": false,
+            "user": false,
+            "value": undefined,
+            "vm": [Circular],
+          },
+        ],
+        "vueTestUtils_childProps": Object {
+          "amount": 111,
+          "direction": "sent",
+          "hideFiat": true,
+          "highPrecision": false,
+          "large": false,
+          "noSymbol": true,
+        },
+      },
+      "data": Object {
+        "attrs": Object {},
+        "hook": Object {
+          "destroy": [Function],
+          "init": [Function],
+          "insert": [Function],
+          "prepatch": [Function],
+        },
+        "on": undefined,
+        "pendingInsert": null,
+        "scopedSlots": Object {
+          "_normalized": Object {},
+        },
+      },
+      "elm": <span
+        class="token-amount sent"
+      >
+        
+  111
+  
+        <!---->
+         
+        <!---->
+      </span>,
+      "fnContext": undefined,
+      "fnOptions": undefined,
+      "fnScopeId": undefined,
+      "isAsyncPlaceholder": false,
+      "isCloned": false,
+      "isComment": false,
+      "isOnce": false,
+      "isRootInsert": true,
+      "isStatic": false,
+      "key": undefined,
+      "ns": undefined,
+      "parent": undefined,
+      "raw": false,
+      "tag": "vue-component-5",
+      "text": undefined,
+    },
+    "__emitted": Object {},
+    "__emittedByOrder": Array [],
+    "_c": [Function],
+    "_computedWatchers": Object {
+      "amountFiat": Watcher {
+        "active": true,
+        "before": undefined,
+        "cb": [Function],
+        "deep": false,
+        "depIds": Set {
+          2,
+          3,
+          4,
+          5,
+          23,
+        },
+        "deps": Array [
+          Dep {
+            "id": 2,
+            "subs": Array [
+              [Circular],
+              Watcher {
+                "active": true,
+                "before": [Function],
+                "cb": [Function],
+                "deep": false,
+                "depIds": Set {
+                  24,
+                  25,
+                  19,
+                  26,
+                  23,
+                  5,
+                  4,
+                  3,
+                  2,
+                },
+                "deps": Array [
+                  Dep {
+                    "id": 24,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 25,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 19,
+                    "subs": Array [
+                      Watcher {
+                        "active": true,
+                        "before": undefined,
+                        "cb": [Function],
+                        "deep": false,
+                        "depIds": Set {
+                          19,
+                        },
+                        "deps": Array [
+                          [Circular],
+                        ],
+                        "dirty": false,
+                        "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+                        "getter": [Function],
+                        "id": 2,
+                        "lazy": true,
+                        "newDepIds": Set {},
+                        "newDeps": Array [],
+                        "sync": false,
+                        "user": false,
+                        "value": 111,
+                        "vm": [Circular],
+                      },
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 26,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 23,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 5,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 4,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 3,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  [Circular],
+                ],
+                "dirty": false,
+                "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+                "getter": [Function],
+                "id": 4,
+                "lazy": false,
+                "newDepIds": Set {},
+                "newDeps": Array [],
+                "sync": false,
+                "user": false,
+                "value": undefined,
+                "vm": [Circular],
+              },
+            ],
+          },
+          Dep {
+            "id": 3,
+            "subs": Array [
+              [Circular],
+              Watcher {
+                "active": true,
+                "before": [Function],
+                "cb": [Function],
+                "deep": false,
+                "depIds": Set {
+                  24,
+                  25,
+                  19,
+                  26,
+                  23,
+                  5,
+                  4,
+                  3,
+                  2,
+                },
+                "deps": Array [
+                  Dep {
+                    "id": 24,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 25,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 19,
+                    "subs": Array [
+                      Watcher {
+                        "active": true,
+                        "before": undefined,
+                        "cb": [Function],
+                        "deep": false,
+                        "depIds": Set {
+                          19,
+                        },
+                        "deps": Array [
+                          [Circular],
+                        ],
+                        "dirty": false,
+                        "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+                        "getter": [Function],
+                        "id": 2,
+                        "lazy": true,
+                        "newDepIds": Set {},
+                        "newDeps": Array [],
+                        "sync": false,
+                        "user": false,
+                        "value": 111,
+                        "vm": [Circular],
+                      },
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 26,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 23,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 5,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 4,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  [Circular],
+                  Dep {
+                    "id": 2,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                ],
+                "dirty": false,
+                "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+                "getter": [Function],
+                "id": 4,
+                "lazy": false,
+                "newDepIds": Set {},
+                "newDeps": Array [],
+                "sync": false,
+                "user": false,
+                "value": undefined,
+                "vm": [Circular],
+              },
+            ],
+          },
+          Dep {
+            "id": 4,
+            "subs": Array [
+              [Circular],
+              Watcher {
+                "active": true,
+                "before": [Function],
+                "cb": [Function],
+                "deep": false,
+                "depIds": Set {
+                  24,
+                  25,
+                  19,
+                  26,
+                  23,
+                  5,
+                  4,
+                  3,
+                  2,
+                },
+                "deps": Array [
+                  Dep {
+                    "id": 24,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 25,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 19,
+                    "subs": Array [
+                      Watcher {
+                        "active": true,
+                        "before": undefined,
+                        "cb": [Function],
+                        "deep": false,
+                        "depIds": Set {
+                          19,
+                        },
+                        "deps": Array [
+                          [Circular],
+                        ],
+                        "dirty": false,
+                        "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+                        "getter": [Function],
+                        "id": 2,
+                        "lazy": true,
+                        "newDepIds": Set {},
+                        "newDeps": Array [],
+                        "sync": false,
+                        "user": false,
+                        "value": 111,
+                        "vm": [Circular],
+                      },
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 26,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 23,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 5,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  [Circular],
+                  Dep {
+                    "id": 3,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 2,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                ],
+                "dirty": false,
+                "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+                "getter": [Function],
+                "id": 4,
+                "lazy": false,
+                "newDepIds": Set {},
+                "newDeps": Array [],
+                "sync": false,
+                "user": false,
+                "value": undefined,
+                "vm": [Circular],
+              },
+            ],
+          },
+          Dep {
+            "id": 5,
+            "subs": Array [
+              [Circular],
+              Watcher {
+                "active": true,
+                "before": [Function],
+                "cb": [Function],
+                "deep": false,
+                "depIds": Set {
+                  24,
+                  25,
+                  19,
+                  26,
+                  23,
+                  5,
+                  4,
+                  3,
+                  2,
+                },
+                "deps": Array [
+                  Dep {
+                    "id": 24,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 25,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 19,
+                    "subs": Array [
+                      Watcher {
+                        "active": true,
+                        "before": undefined,
+                        "cb": [Function],
+                        "deep": false,
+                        "depIds": Set {
+                          19,
+                        },
+                        "deps": Array [
+                          [Circular],
+                        ],
+                        "dirty": false,
+                        "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+                        "getter": [Function],
+                        "id": 2,
+                        "lazy": true,
+                        "newDepIds": Set {},
+                        "newDeps": Array [],
+                        "sync": false,
+                        "user": false,
+                        "value": 111,
+                        "vm": [Circular],
+                      },
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 26,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 23,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  [Circular],
+                  Dep {
+                    "id": 4,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 3,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 2,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                ],
+                "dirty": false,
+                "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+                "getter": [Function],
+                "id": 4,
+                "lazy": false,
+                "newDepIds": Set {},
+                "newDeps": Array [],
+                "sync": false,
+                "user": false,
+                "value": undefined,
+                "vm": [Circular],
+              },
+            ],
+          },
+          Dep {
+            "id": 23,
+            "subs": Array [
+              [Circular],
+              Watcher {
+                "active": true,
+                "before": [Function],
+                "cb": [Function],
+                "deep": false,
+                "depIds": Set {
+                  24,
+                  25,
+                  19,
+                  26,
+                  23,
+                  5,
+                  4,
+                  3,
+                  2,
+                },
+                "deps": Array [
+                  Dep {
+                    "id": 24,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 25,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 19,
+                    "subs": Array [
+                      Watcher {
+                        "active": true,
+                        "before": undefined,
+                        "cb": [Function],
+                        "deep": false,
+                        "depIds": Set {
+                          19,
+                        },
+                        "deps": Array [
+                          [Circular],
+                        ],
+                        "dirty": false,
+                        "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+                        "getter": [Function],
+                        "id": 2,
+                        "lazy": true,
+                        "newDepIds": Set {},
+                        "newDeps": Array [],
+                        "sync": false,
+                        "user": false,
+                        "value": 111,
+                        "vm": [Circular],
+                      },
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 26,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  [Circular],
+                  Dep {
+                    "id": 5,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 4,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 3,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 2,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                ],
+                "dirty": false,
+                "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+                "getter": [Function],
+                "id": 4,
+                "lazy": false,
+                "newDepIds": Set {},
+                "newDeps": Array [],
+                "sync": false,
+                "user": false,
+                "value": undefined,
+                "vm": [Circular],
+              },
+            ],
+          },
+        ],
+        "dirty": false,
+        "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+        "getter": [Function],
+        "id": 3,
+        "lazy": true,
+        "newDepIds": Set {},
+        "newDeps": Array [],
+        "sync": false,
+        "user": false,
+        "value": "",
+        "vm": [Circular],
+      },
+      "amountRounded": Watcher {
+        "active": true,
+        "before": undefined,
+        "cb": [Function],
+        "deep": false,
+        "depIds": Set {
+          19,
+        },
+        "deps": Array [
+          Dep {
+            "id": 19,
+            "subs": Array [
+              [Circular],
+              Watcher {
+                "active": true,
+                "before": [Function],
+                "cb": [Function],
+                "deep": false,
+                "depIds": Set {
+                  24,
+                  25,
+                  19,
+                  26,
+                  23,
+                  5,
+                  4,
+                  3,
+                  2,
+                },
+                "deps": Array [
+                  Dep {
+                    "id": 24,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 25,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  [Circular],
+                  Dep {
+                    "id": 26,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 23,
+                    "subs": Array [
+                      Watcher {
+                        "active": true,
+                        "before": undefined,
+                        "cb": [Function],
+                        "deep": false,
+                        "depIds": Set {
+                          2,
+                          3,
+                          4,
+                          5,
+                          23,
+                        },
+                        "deps": Array [
+                          Dep {
+                            "id": 2,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          Dep {
+                            "id": 3,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          Dep {
+                            "id": 4,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          Dep {
+                            "id": 5,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          [Circular],
+                        ],
+                        "dirty": false,
+                        "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                        "getter": [Function],
+                        "id": 3,
+                        "lazy": true,
+                        "newDepIds": Set {},
+                        "newDeps": Array [],
+                        "sync": false,
+                        "user": false,
+                        "value": "",
+                        "vm": [Circular],
+                      },
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 5,
+                    "subs": Array [
+                      Watcher {
+                        "active": true,
+                        "before": undefined,
+                        "cb": [Function],
+                        "deep": false,
+                        "depIds": Set {
+                          2,
+                          3,
+                          4,
+                          5,
+                          23,
+                        },
+                        "deps": Array [
+                          Dep {
+                            "id": 2,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          Dep {
+                            "id": 3,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          Dep {
+                            "id": 4,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          [Circular],
+                          Dep {
+                            "id": 23,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                        ],
+                        "dirty": false,
+                        "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                        "getter": [Function],
+                        "id": 3,
+                        "lazy": true,
+                        "newDepIds": Set {},
+                        "newDeps": Array [],
+                        "sync": false,
+                        "user": false,
+                        "value": "",
+                        "vm": [Circular],
+                      },
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 4,
+                    "subs": Array [
+                      Watcher {
+                        "active": true,
+                        "before": undefined,
+                        "cb": [Function],
+                        "deep": false,
+                        "depIds": Set {
+                          2,
+                          3,
+                          4,
+                          5,
+                          23,
+                        },
+                        "deps": Array [
+                          Dep {
+                            "id": 2,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          Dep {
+                            "id": 3,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          [Circular],
+                          Dep {
+                            "id": 5,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          Dep {
+                            "id": 23,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                        ],
+                        "dirty": false,
+                        "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                        "getter": [Function],
+                        "id": 3,
+                        "lazy": true,
+                        "newDepIds": Set {},
+                        "newDeps": Array [],
+                        "sync": false,
+                        "user": false,
+                        "value": "",
+                        "vm": [Circular],
+                      },
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 3,
+                    "subs": Array [
+                      Watcher {
+                        "active": true,
+                        "before": undefined,
+                        "cb": [Function],
+                        "deep": false,
+                        "depIds": Set {
+                          2,
+                          3,
+                          4,
+                          5,
+                          23,
+                        },
+                        "deps": Array [
+                          Dep {
+                            "id": 2,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          [Circular],
+                          Dep {
+                            "id": 4,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          Dep {
+                            "id": 5,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          Dep {
+                            "id": 23,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                        ],
+                        "dirty": false,
+                        "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                        "getter": [Function],
+                        "id": 3,
+                        "lazy": true,
+                        "newDepIds": Set {},
+                        "newDeps": Array [],
+                        "sync": false,
+                        "user": false,
+                        "value": "",
+                        "vm": [Circular],
+                      },
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 2,
+                    "subs": Array [
+                      Watcher {
+                        "active": true,
+                        "before": undefined,
+                        "cb": [Function],
+                        "deep": false,
+                        "depIds": Set {
+                          2,
+                          3,
+                          4,
+                          5,
+                          23,
+                        },
+                        "deps": Array [
+                          [Circular],
+                          Dep {
+                            "id": 3,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          Dep {
+                            "id": 4,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          Dep {
+                            "id": 5,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          Dep {
+                            "id": 23,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                        ],
+                        "dirty": false,
+                        "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                        "getter": [Function],
+                        "id": 3,
+                        "lazy": true,
+                        "newDepIds": Set {},
+                        "newDeps": Array [],
+                        "sync": false,
+                        "user": false,
+                        "value": "",
+                        "vm": [Circular],
+                      },
+                      [Circular],
+                    ],
+                  },
+                ],
+                "dirty": false,
+                "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+                "getter": [Function],
+                "id": 4,
+                "lazy": false,
+                "newDepIds": Set {},
+                "newDeps": Array [],
+                "sync": false,
+                "user": false,
+                "value": undefined,
+                "vm": [Circular],
+              },
+            ],
+          },
+        ],
+        "dirty": false,
+        "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+        "getter": [Function],
+        "id": 2,
+        "lazy": true,
+        "newDepIds": Set {},
+        "newDeps": Array [],
+        "sync": false,
+        "user": false,
+        "value": 111,
+        "vm": [Circular],
+      },
+    },
+    "_data": Object {},
+    "_directInactive": false,
+    "_events": Object {},
+    "_hasHookEvent": false,
+    "_inactive": null,
+    "_isBeingDestroyed": false,
+    "_isDestroyed": false,
+    "_isMounted": true,
+    "_isVue": true,
+    "_props": Object {
+      "aex9": false,
+      "amount": 111,
+      "direction": "sent",
+      "fiatBelow": false,
+      "hideFiat": true,
+      "highPrecision": false,
+      "large": false,
+      "noSymbol": true,
+      "symbol": "AE",
+    },
+    "_renderProxy": [Circular],
+    "_self": [Circular],
+    "_staticTrees": null,
+    "_uid": 1,
+    "_vnode": VNode {
+      "asyncFactory": undefined,
+      "asyncMeta": undefined,
+      "children": Array [
+        VNode {
+          "asyncFactory": undefined,
+          "asyncMeta": undefined,
+          "children": undefined,
+          "componentInstance": undefined,
+          "componentOptions": undefined,
+          "context": undefined,
+          "data": undefined,
+          "elm": 
+  111
+  ,
+          "fnContext": undefined,
+          "fnOptions": undefined,
+          "fnScopeId": undefined,
+          "isAsyncPlaceholder": false,
+          "isCloned": false,
+          "isComment": false,
+          "isOnce": false,
+          "isRootInsert": false,
+          "isStatic": false,
+          "key": undefined,
+          "ns": undefined,
+          "parent": undefined,
+          "raw": false,
+          "tag": undefined,
+          "text": "
+  111
+  ",
+        },
+        VNode {
+          "asyncFactory": undefined,
+          "asyncMeta": undefined,
+          "children": undefined,
+          "componentInstance": undefined,
+          "componentOptions": undefined,
+          "context": undefined,
+          "data": undefined,
+          "elm": <!---->,
+          "fnContext": undefined,
+          "fnOptions": undefined,
+          "fnScopeId": undefined,
+          "isAsyncPlaceholder": false,
+          "isCloned": false,
+          "isComment": true,
+          "isOnce": false,
+          "isRootInsert": false,
+          "isStatic": false,
+          "key": undefined,
+          "ns": undefined,
+          "parent": undefined,
+          "raw": false,
+          "tag": undefined,
+          "text": "",
+        },
+        VNode {
+          "asyncFactory": undefined,
+          "asyncMeta": undefined,
+          "children": undefined,
+          "componentInstance": undefined,
+          "componentOptions": undefined,
+          "context": undefined,
+          "data": undefined,
+          "elm":  ,
+          "fnContext": undefined,
+          "fnOptions": undefined,
+          "fnScopeId": undefined,
+          "isAsyncPlaceholder": false,
+          "isCloned": false,
+          "isComment": false,
+          "isOnce": false,
+          "isRootInsert": false,
+          "isStatic": false,
+          "key": undefined,
+          "ns": undefined,
+          "parent": undefined,
+          "raw": false,
+          "tag": undefined,
+          "text": " ",
+        },
+        VNode {
+          "asyncFactory": undefined,
+          "asyncMeta": undefined,
+          "children": undefined,
+          "componentInstance": undefined,
+          "componentOptions": undefined,
+          "context": undefined,
+          "data": undefined,
+          "elm": <!---->,
+          "fnContext": undefined,
+          "fnOptions": undefined,
+          "fnScopeId": undefined,
+          "isAsyncPlaceholder": false,
+          "isCloned": false,
+          "isComment": true,
+          "isOnce": false,
+          "isRootInsert": false,
+          "isStatic": false,
+          "key": undefined,
+          "ns": undefined,
+          "parent": undefined,
+          "raw": false,
+          "tag": undefined,
+          "text": "",
+        },
+      ],
+      "componentInstance": undefined,
+      "componentOptions": undefined,
+      "context": [Circular],
+      "data": Object {
+        "class": Array [
+          "sent",
+          Object {
+            "large": false,
+          },
+        ],
+        "staticClass": "token-amount",
+      },
+      "elm": <span
+        class="token-amount sent"
+      >
+        
+  111
+  
+        <!---->
+         
+        <!---->
+      </span>,
+      "fnContext": undefined,
+      "fnOptions": undefined,
+      "fnScopeId": undefined,
+      "isAsyncPlaceholder": false,
+      "isCloned": false,
+      "isComment": false,
+      "isOnce": false,
+      "isRootInsert": true,
+      "isStatic": false,
+      "key": undefined,
+      "ns": undefined,
+      "parent": VNode {
+        "asyncFactory": undefined,
+        "asyncMeta": undefined,
+        "children": undefined,
+        "componentInstance": [Circular],
+        "componentOptions": Object {
+          "Ctor": [Function],
+          "children": undefined,
+          "listeners": Object {},
+          "propsData": Object {
+            "amount": 111,
+            "direction": "sent",
+            "hideFiat": true,
+            "highPrecision": false,
+            "large": false,
+            "noSymbol": true,
+          },
+          "tag": undefined,
+        },
+        "context": VueComponent {
+          "$attrs": Object {},
+          "$children": Array [
+            [Circular],
+          ],
+          "$createElement": [Function],
+          "$el": <span
+            class="token-amount sent"
+          >
+            
+  111
+  
+            <!---->
+             
+            <!---->
+          </span>,
+          "$emit": [Function],
+          "$listeners": Object {},
+          "$options": Object {
+            "$_doNotStubChildren": true,
+            "$_isWrapperParent": true,
+            "_Ctor": Object {
+              "1": [Function],
+            },
+            "_base": [Function],
+            "_isFunctionalContainer": undefined,
+            "beforeCreate": Array [
+              [Function],
+              [Function],
+              [Function],
+            ],
+            "components": Object {
+              "transition": Object {
+                "$_doNotStubChildren": true,
+                "$_vueTestUtils_original": Object {
+                  "_Ctor": Object {
+                    "1": [Function],
+                  },
+                  "abstract": true,
+                  "name": "transition",
+                  "props": Object {
+                    "appear": Object {
+                      "type": [Function],
+                    },
+                    "appearActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "appearClass": Object {
+                      "type": [Function],
+                    },
+                    "appearToClass": Object {
+                      "type": [Function],
+                    },
+                    "css": Object {
+                      "type": [Function],
+                    },
+                    "duration": Object {
+                      "type": Array [
+                        [Function],
+                        [Function],
+                        [Function],
+                      ],
+                    },
+                    "enterActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "enterClass": Object {
+                      "type": [Function],
+                    },
+                    "enterToClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveToClass": Object {
+                      "type": [Function],
+                    },
+                    "mode": Object {
+                      "type": [Function],
+                    },
+                    "name": Object {
+                      "type": [Function],
+                    },
+                    "type": Object {
+                      "type": [Function],
+                    },
+                  },
+                  "render": [Function],
+                },
+                "abstract": true,
+                "attrs": undefined,
+                "class": undefined,
+                "domProps": undefined,
+                "functional": undefined,
+                "key": undefined,
+                "model": undefined,
+                "name": "transition",
+                "nativeOn": undefined,
+                "normalizedStyle": undefined,
+                "on": undefined,
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "mode": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+                "staticClass": undefined,
+                "staticStyle": undefined,
+                "style": undefined,
+              },
+              "transition-group": Object {
+                "$_doNotStubChildren": true,
+                "$_vueTestUtils_original": Object {
+                  "_Ctor": Object {
+                    "1": [Function],
+                  },
+                  "beforeMount": [Function],
+                  "methods": Object {
+                    "hasMove": [Function],
+                  },
+                  "props": Object {
+                    "appear": Object {
+                      "type": [Function],
+                    },
+                    "appearActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "appearClass": Object {
+                      "type": [Function],
+                    },
+                    "appearToClass": Object {
+                      "type": [Function],
+                    },
+                    "css": Object {
+                      "type": [Function],
+                    },
+                    "duration": Object {
+                      "type": Array [
+                        [Function],
+                        [Function],
+                        [Function],
+                      ],
+                    },
+                    "enterActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "enterClass": Object {
+                      "type": [Function],
+                    },
+                    "enterToClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveToClass": Object {
+                      "type": [Function],
+                    },
+                    "moveClass": Object {
+                      "type": [Function],
+                    },
+                    "name": Object {
+                      "type": [Function],
+                    },
+                    "tag": Object {
+                      "type": [Function],
+                    },
+                    "type": Object {
+                      "type": [Function],
+                    },
+                  },
+                  "render": [Function],
+                  "updated": [Function],
+                },
+                "abstract": undefined,
+                "attrs": undefined,
+                "class": undefined,
+                "domProps": undefined,
+                "functional": undefined,
+                "key": undefined,
+                "model": undefined,
+                "name": undefined,
+                "nativeOn": undefined,
+                "normalizedStyle": undefined,
+                "on": undefined,
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "moveClass": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "tag": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+                "staticClass": undefined,
+                "staticStyle": undefined,
+                "style": undefined,
+              },
+            },
+            "data": [Function],
+            "directives": Object {},
+            "filters": Object {},
+            "methods": undefined,
+            "mocks": Object {
+              "$store": Object {
+                "getters": Object {},
+                "state": Object {},
+              },
+            },
+            "provide": [Function],
+            "render": [Function],
+            "shouldProxy": true,
+            "stubs": Object {
+              "transition": true,
+              "transition-group": true,
+            },
+          },
+          "$parent": undefined,
+          "$refs": Object {},
+          "$root": [Circular],
+          "$scopedSlots": Object {},
+          "$slots": Object {},
+          "$vnode": undefined,
+          "__emitted": Object {},
+          "__emittedByOrder": Array [],
+          "_c": [Function],
+          "_data": Object {
+            "vueTestUtils_childProps": Object {
+              "amount": 111,
+              "direction": "sent",
+              "hideFiat": true,
+              "highPrecision": false,
+              "large": false,
+              "noSymbol": true,
+            },
+          },
+          "_directInactive": false,
+          "_events": Object {},
+          "_hasHookEvent": false,
+          "_inactive": null,
+          "_isBeingDestroyed": false,
+          "_isDestroyed": false,
+          "_isMounted": true,
+          "_isVue": true,
+          "_provided": Object {},
+          "_renderProxy": VueComponent {
+            "$attrs": Object {},
+            "$children": Array [
+              [Circular],
+            ],
+            "$createElement": [Function],
+            "$el": <span
+              class="token-amount sent"
+            >
+              
+  111
+  
+              <!---->
+               
+              <!---->
+            </span>,
+            "$emit": [Function],
+            "$listeners": Object {},
+            "$options": Object {
+              "$_doNotStubChildren": true,
+              "$_isWrapperParent": true,
+              "_Ctor": Object {
+                "1": [Function],
+              },
+              "_base": [Function],
+              "_isFunctionalContainer": undefined,
+              "beforeCreate": Array [
+                [Function],
+                [Function],
+                [Function],
+              ],
+              "components": Object {
+                "transition": Object {
+                  "$_doNotStubChildren": true,
+                  "$_vueTestUtils_original": Object {
+                    "_Ctor": Object {
+                      "1": [Function],
+                    },
+                    "abstract": true,
+                    "name": "transition",
+                    "props": Object {
+                      "appear": Object {
+                        "type": [Function],
+                      },
+                      "appearActiveClass": Object {
+                        "type": [Function],
+                      },
+                      "appearClass": Object {
+                        "type": [Function],
+                      },
+                      "appearToClass": Object {
+                        "type": [Function],
+                      },
+                      "css": Object {
+                        "type": [Function],
+                      },
+                      "duration": Object {
+                        "type": Array [
+                          [Function],
+                          [Function],
+                          [Function],
+                        ],
+                      },
+                      "enterActiveClass": Object {
+                        "type": [Function],
+                      },
+                      "enterClass": Object {
+                        "type": [Function],
+                      },
+                      "enterToClass": Object {
+                        "type": [Function],
+                      },
+                      "leaveActiveClass": Object {
+                        "type": [Function],
+                      },
+                      "leaveClass": Object {
+                        "type": [Function],
+                      },
+                      "leaveToClass": Object {
+                        "type": [Function],
+                      },
+                      "mode": Object {
+                        "type": [Function],
+                      },
+                      "name": Object {
+                        "type": [Function],
+                      },
+                      "type": Object {
+                        "type": [Function],
+                      },
+                    },
+                    "render": [Function],
+                  },
+                  "abstract": true,
+                  "attrs": undefined,
+                  "class": undefined,
+                  "domProps": undefined,
+                  "functional": undefined,
+                  "key": undefined,
+                  "model": undefined,
+                  "name": "transition",
+                  "nativeOn": undefined,
+                  "normalizedStyle": undefined,
+                  "on": undefined,
+                  "props": Object {
+                    "appear": Object {
+                      "type": [Function],
+                    },
+                    "appearActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "appearClass": Object {
+                      "type": [Function],
+                    },
+                    "appearToClass": Object {
+                      "type": [Function],
+                    },
+                    "css": Object {
+                      "type": [Function],
+                    },
+                    "duration": Object {
+                      "type": Array [
+                        [Function],
+                        [Function],
+                        [Function],
+                      ],
+                    },
+                    "enterActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "enterClass": Object {
+                      "type": [Function],
+                    },
+                    "enterToClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveToClass": Object {
+                      "type": [Function],
+                    },
+                    "mode": Object {
+                      "type": [Function],
+                    },
+                    "name": Object {
+                      "type": [Function],
+                    },
+                    "type": Object {
+                      "type": [Function],
+                    },
+                  },
+                  "render": [Function],
+                  "staticClass": undefined,
+                  "staticStyle": undefined,
+                  "style": undefined,
+                },
+                "transition-group": Object {
+                  "$_doNotStubChildren": true,
+                  "$_vueTestUtils_original": Object {
+                    "_Ctor": Object {
+                      "1": [Function],
+                    },
+                    "beforeMount": [Function],
+                    "methods": Object {
+                      "hasMove": [Function],
+                    },
+                    "props": Object {
+                      "appear": Object {
+                        "type": [Function],
+                      },
+                      "appearActiveClass": Object {
+                        "type": [Function],
+                      },
+                      "appearClass": Object {
+                        "type": [Function],
+                      },
+                      "appearToClass": Object {
+                        "type": [Function],
+                      },
+                      "css": Object {
+                        "type": [Function],
+                      },
+                      "duration": Object {
+                        "type": Array [
+                          [Function],
+                          [Function],
+                          [Function],
+                        ],
+                      },
+                      "enterActiveClass": Object {
+                        "type": [Function],
+                      },
+                      "enterClass": Object {
+                        "type": [Function],
+                      },
+                      "enterToClass": Object {
+                        "type": [Function],
+                      },
+                      "leaveActiveClass": Object {
+                        "type": [Function],
+                      },
+                      "leaveClass": Object {
+                        "type": [Function],
+                      },
+                      "leaveToClass": Object {
+                        "type": [Function],
+                      },
+                      "moveClass": Object {
+                        "type": [Function],
+                      },
+                      "name": Object {
+                        "type": [Function],
+                      },
+                      "tag": Object {
+                        "type": [Function],
+                      },
+                      "type": Object {
+                        "type": [Function],
+                      },
+                    },
+                    "render": [Function],
+                    "updated": [Function],
+                  },
+                  "abstract": undefined,
+                  "attrs": undefined,
+                  "class": undefined,
+                  "domProps": undefined,
+                  "functional": undefined,
+                  "key": undefined,
+                  "model": undefined,
+                  "name": undefined,
+                  "nativeOn": undefined,
+                  "normalizedStyle": undefined,
+                  "on": undefined,
+                  "props": Object {
+                    "appear": Object {
+                      "type": [Function],
+                    },
+                    "appearActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "appearClass": Object {
+                      "type": [Function],
+                    },
+                    "appearToClass": Object {
+                      "type": [Function],
+                    },
+                    "css": Object {
+                      "type": [Function],
+                    },
+                    "duration": Object {
+                      "type": Array [
+                        [Function],
+                        [Function],
+                        [Function],
+                      ],
+                    },
+                    "enterActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "enterClass": Object {
+                      "type": [Function],
+                    },
+                    "enterToClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveToClass": Object {
+                      "type": [Function],
+                    },
+                    "moveClass": Object {
+                      "type": [Function],
+                    },
+                    "name": Object {
+                      "type": [Function],
+                    },
+                    "tag": Object {
+                      "type": [Function],
+                    },
+                    "type": Object {
+                      "type": [Function],
+                    },
+                  },
+                  "render": [Function],
+                  "staticClass": undefined,
+                  "staticStyle": undefined,
+                  "style": undefined,
+                },
+              },
+              "data": [Function],
+              "directives": Object {},
+              "filters": Object {},
+              "methods": undefined,
+              "mocks": Object {
+                "$store": Object {
+                  "getters": Object {},
+                  "state": Object {},
+                },
+              },
+              "provide": [Function],
+              "render": [Function],
+              "shouldProxy": true,
+              "stubs": Object {
+                "transition": true,
+                "transition-group": true,
+              },
+            },
+            "$parent": undefined,
+            "$refs": Object {},
+            "$root": [Circular],
+            "$scopedSlots": Object {},
+            "$slots": Object {},
+            "$vnode": undefined,
+            "__emitted": Object {},
+            "__emittedByOrder": Array [],
+            "_c": [Function],
+            "_data": Object {
+              "vueTestUtils_childProps": Object {
+                "amount": 111,
+                "direction": "sent",
+                "hideFiat": true,
+                "highPrecision": false,
+                "large": false,
+                "noSymbol": true,
+              },
+            },
+            "_directInactive": false,
+            "_events": Object {},
+            "_hasHookEvent": false,
+            "_inactive": null,
+            "_isBeingDestroyed": false,
+            "_isDestroyed": false,
+            "_isMounted": true,
+            "_isVue": true,
+            "_provided": Object {},
+            "_renderProxy": [Circular],
+            "_self": [Circular],
+            "_staticTrees": null,
+            "_uid": 0,
+            "_vnode": [Circular],
+            "_watcher": Watcher {
+              "active": true,
+              "before": [Function],
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15,
+                16,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 9,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 10,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 11,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 12,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 13,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 14,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 15,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 16,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+              "getter": [Function],
+              "id": 1,
+              "lazy": false,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": undefined,
+              "vm": [Circular],
+            },
+            "_watchers": Array [
+              Watcher {
+                "active": true,
+                "before": [Function],
+                "cb": [Function],
+                "deep": false,
+                "depIds": Set {
+                  9,
+                  10,
+                  11,
+                  12,
+                  13,
+                  14,
+                  15,
+                  16,
+                },
+                "deps": Array [
+                  Dep {
+                    "id": 9,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 10,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 11,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 12,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 13,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 14,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 15,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 16,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                ],
+                "dirty": false,
+                "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+                "getter": [Function],
+                "id": 1,
+                "lazy": false,
+                "newDepIds": Set {},
+                "newDeps": Array [],
+                "sync": false,
+                "user": false,
+                "value": undefined,
+                "vm": [Circular],
+              },
+            ],
+            "vueTestUtils_childProps": Object {
+              "amount": 111,
+              "direction": "sent",
+              "hideFiat": true,
+              "highPrecision": false,
+              "large": false,
+              "noSymbol": true,
+            },
+          },
+          "_self": [Circular],
+          "_staticTrees": null,
+          "_uid": 0,
+          "_vnode": [Circular],
+          "_watcher": Watcher {
+            "active": true,
+            "before": [Function],
+            "cb": [Function],
+            "deep": false,
+            "depIds": Set {
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+            },
+            "deps": Array [
+              Dep {
+                "id": 9,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 10,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 11,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 12,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 13,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 14,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 15,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 16,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+            ],
+            "dirty": false,
+            "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+            "getter": [Function],
+            "id": 1,
+            "lazy": false,
+            "newDepIds": Set {},
+            "newDeps": Array [],
+            "sync": false,
+            "user": false,
+            "value": undefined,
+            "vm": [Circular],
+          },
+          "_watchers": Array [
+            Watcher {
+              "active": true,
+              "before": [Function],
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15,
+                16,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 9,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 10,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 11,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 12,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 13,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 14,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 15,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 16,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+              "getter": [Function],
+              "id": 1,
+              "lazy": false,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": undefined,
+              "vm": [Circular],
+            },
+          ],
+          "vueTestUtils_childProps": Object {
+            "amount": 111,
+            "direction": "sent",
+            "hideFiat": true,
+            "highPrecision": false,
+            "large": false,
+            "noSymbol": true,
+          },
+        },
+        "data": Object {
+          "attrs": Object {},
+          "hook": Object {
+            "destroy": [Function],
+            "init": [Function],
+            "insert": [Function],
+            "prepatch": [Function],
+          },
+          "on": undefined,
+          "pendingInsert": null,
+          "scopedSlots": Object {
+            "_normalized": Object {},
+          },
+        },
+        "elm": <span
+          class="token-amount sent"
+        >
+          
+  111
+  
+          <!---->
+           
+          <!---->
+        </span>,
+        "fnContext": undefined,
+        "fnOptions": undefined,
+        "fnScopeId": undefined,
+        "isAsyncPlaceholder": false,
+        "isCloned": false,
+        "isComment": false,
+        "isOnce": false,
+        "isRootInsert": true,
+        "isStatic": false,
+        "key": undefined,
+        "ns": undefined,
+        "parent": undefined,
+        "raw": false,
+        "tag": "vue-component-5",
+        "text": undefined,
+      },
+      "raw": false,
+      "tag": "span",
+      "text": undefined,
+    },
+    "_watcher": Watcher {
+      "active": true,
+      "before": [Function],
+      "cb": [Function],
+      "deep": false,
+      "depIds": Set {
+        24,
+        25,
+        19,
+        26,
+        23,
+        5,
+        4,
+        3,
+        2,
+      },
+      "deps": Array [
+        Dep {
+          "id": 24,
+          "subs": Array [
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 25,
+          "subs": Array [
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 19,
+          "subs": Array [
+            Watcher {
+              "active": true,
+              "before": undefined,
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                19,
+              },
+              "deps": Array [
+                [Circular],
+              ],
+              "dirty": false,
+              "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+              "getter": [Function],
+              "id": 2,
+              "lazy": true,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": 111,
+              "vm": [Circular],
+            },
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 26,
+          "subs": Array [
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 23,
+          "subs": Array [
+            Watcher {
+              "active": true,
+              "before": undefined,
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                2,
+                3,
+                4,
+                5,
+                23,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 2,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 3,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 4,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 5,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                [Circular],
+              ],
+              "dirty": false,
+              "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+              "getter": [Function],
+              "id": 3,
+              "lazy": true,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": "",
+              "vm": [Circular],
+            },
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 5,
+          "subs": Array [
+            Watcher {
+              "active": true,
+              "before": undefined,
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                2,
+                3,
+                4,
+                5,
+                23,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 2,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 3,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 4,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                [Circular],
+                Dep {
+                  "id": 23,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+              "getter": [Function],
+              "id": 3,
+              "lazy": true,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": "",
+              "vm": [Circular],
+            },
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 4,
+          "subs": Array [
+            Watcher {
+              "active": true,
+              "before": undefined,
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                2,
+                3,
+                4,
+                5,
+                23,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 2,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 3,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                [Circular],
+                Dep {
+                  "id": 5,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 23,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+              "getter": [Function],
+              "id": 3,
+              "lazy": true,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": "",
+              "vm": [Circular],
+            },
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 3,
+          "subs": Array [
+            Watcher {
+              "active": true,
+              "before": undefined,
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                2,
+                3,
+                4,
+                5,
+                23,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 2,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                [Circular],
+                Dep {
+                  "id": 4,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 5,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 23,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+              "getter": [Function],
+              "id": 3,
+              "lazy": true,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": "",
+              "vm": [Circular],
+            },
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 2,
+          "subs": Array [
+            Watcher {
+              "active": true,
+              "before": undefined,
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                2,
+                3,
+                4,
+                5,
+                23,
+              },
+              "deps": Array [
+                [Circular],
+                Dep {
+                  "id": 3,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 4,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 5,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 23,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+              "getter": [Function],
+              "id": 3,
+              "lazy": true,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": "",
+              "vm": [Circular],
+            },
+            [Circular],
+          ],
+        },
+      ],
+      "dirty": false,
+      "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+      "getter": [Function],
+      "id": 4,
+      "lazy": false,
+      "newDepIds": Set {},
+      "newDeps": Array [],
+      "sync": false,
+      "user": false,
+      "value": undefined,
+      "vm": [Circular],
+    },
+    "_watchers": Array [
+      Watcher {
+        "active": true,
+        "before": undefined,
+        "cb": [Function],
+        "deep": false,
+        "depIds": Set {
+          19,
+        },
+        "deps": Array [
+          Dep {
+            "id": 19,
+            "subs": Array [
+              [Circular],
+              Watcher {
+                "active": true,
+                "before": [Function],
+                "cb": [Function],
+                "deep": false,
+                "depIds": Set {
+                  24,
+                  25,
+                  19,
+                  26,
+                  23,
+                  5,
+                  4,
+                  3,
+                  2,
+                },
+                "deps": Array [
+                  Dep {
+                    "id": 24,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 25,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  [Circular],
+                  Dep {
+                    "id": 26,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 23,
+                    "subs": Array [
+                      Watcher {
+                        "active": true,
+                        "before": undefined,
+                        "cb": [Function],
+                        "deep": false,
+                        "depIds": Set {
+                          2,
+                          3,
+                          4,
+                          5,
+                          23,
+                        },
+                        "deps": Array [
+                          Dep {
+                            "id": 2,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          Dep {
+                            "id": 3,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          Dep {
+                            "id": 4,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          Dep {
+                            "id": 5,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          [Circular],
+                        ],
+                        "dirty": false,
+                        "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                        "getter": [Function],
+                        "id": 3,
+                        "lazy": true,
+                        "newDepIds": Set {},
+                        "newDeps": Array [],
+                        "sync": false,
+                        "user": false,
+                        "value": "",
+                        "vm": [Circular],
+                      },
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 5,
+                    "subs": Array [
+                      Watcher {
+                        "active": true,
+                        "before": undefined,
+                        "cb": [Function],
+                        "deep": false,
+                        "depIds": Set {
+                          2,
+                          3,
+                          4,
+                          5,
+                          23,
+                        },
+                        "deps": Array [
+                          Dep {
+                            "id": 2,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          Dep {
+                            "id": 3,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          Dep {
+                            "id": 4,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          [Circular],
+                          Dep {
+                            "id": 23,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                        ],
+                        "dirty": false,
+                        "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                        "getter": [Function],
+                        "id": 3,
+                        "lazy": true,
+                        "newDepIds": Set {},
+                        "newDeps": Array [],
+                        "sync": false,
+                        "user": false,
+                        "value": "",
+                        "vm": [Circular],
+                      },
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 4,
+                    "subs": Array [
+                      Watcher {
+                        "active": true,
+                        "before": undefined,
+                        "cb": [Function],
+                        "deep": false,
+                        "depIds": Set {
+                          2,
+                          3,
+                          4,
+                          5,
+                          23,
+                        },
+                        "deps": Array [
+                          Dep {
+                            "id": 2,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          Dep {
+                            "id": 3,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          [Circular],
+                          Dep {
+                            "id": 5,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          Dep {
+                            "id": 23,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                        ],
+                        "dirty": false,
+                        "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                        "getter": [Function],
+                        "id": 3,
+                        "lazy": true,
+                        "newDepIds": Set {},
+                        "newDeps": Array [],
+                        "sync": false,
+                        "user": false,
+                        "value": "",
+                        "vm": [Circular],
+                      },
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 3,
+                    "subs": Array [
+                      Watcher {
+                        "active": true,
+                        "before": undefined,
+                        "cb": [Function],
+                        "deep": false,
+                        "depIds": Set {
+                          2,
+                          3,
+                          4,
+                          5,
+                          23,
+                        },
+                        "deps": Array [
+                          Dep {
+                            "id": 2,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          [Circular],
+                          Dep {
+                            "id": 4,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          Dep {
+                            "id": 5,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          Dep {
+                            "id": 23,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                        ],
+                        "dirty": false,
+                        "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                        "getter": [Function],
+                        "id": 3,
+                        "lazy": true,
+                        "newDepIds": Set {},
+                        "newDeps": Array [],
+                        "sync": false,
+                        "user": false,
+                        "value": "",
+                        "vm": [Circular],
+                      },
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 2,
+                    "subs": Array [
+                      Watcher {
+                        "active": true,
+                        "before": undefined,
+                        "cb": [Function],
+                        "deep": false,
+                        "depIds": Set {
+                          2,
+                          3,
+                          4,
+                          5,
+                          23,
+                        },
+                        "deps": Array [
+                          [Circular],
+                          Dep {
+                            "id": 3,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          Dep {
+                            "id": 4,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          Dep {
+                            "id": 5,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                          Dep {
+                            "id": 23,
+                            "subs": Array [
+                              [Circular],
+                              [Circular],
+                            ],
+                          },
+                        ],
+                        "dirty": false,
+                        "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                        "getter": [Function],
+                        "id": 3,
+                        "lazy": true,
+                        "newDepIds": Set {},
+                        "newDeps": Array [],
+                        "sync": false,
+                        "user": false,
+                        "value": "",
+                        "vm": [Circular],
+                      },
+                      [Circular],
+                    ],
+                  },
+                ],
+                "dirty": false,
+                "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+                "getter": [Function],
+                "id": 4,
+                "lazy": false,
+                "newDepIds": Set {},
+                "newDeps": Array [],
+                "sync": false,
+                "user": false,
+                "value": undefined,
+                "vm": [Circular],
+              },
+            ],
+          },
+        ],
+        "dirty": false,
+        "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+        "getter": [Function],
+        "id": 2,
+        "lazy": true,
+        "newDepIds": Set {},
+        "newDeps": Array [],
+        "sync": false,
+        "user": false,
+        "value": 111,
+        "vm": [Circular],
+      },
+      Watcher {
+        "active": true,
+        "before": undefined,
+        "cb": [Function],
+        "deep": false,
+        "depIds": Set {
+          2,
+          3,
+          4,
+          5,
+          23,
+        },
+        "deps": Array [
+          Dep {
+            "id": 2,
+            "subs": Array [
+              [Circular],
+              Watcher {
+                "active": true,
+                "before": [Function],
+                "cb": [Function],
+                "deep": false,
+                "depIds": Set {
+                  24,
+                  25,
+                  19,
+                  26,
+                  23,
+                  5,
+                  4,
+                  3,
+                  2,
+                },
+                "deps": Array [
+                  Dep {
+                    "id": 24,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 25,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 19,
+                    "subs": Array [
+                      Watcher {
+                        "active": true,
+                        "before": undefined,
+                        "cb": [Function],
+                        "deep": false,
+                        "depIds": Set {
+                          19,
+                        },
+                        "deps": Array [
+                          [Circular],
+                        ],
+                        "dirty": false,
+                        "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+                        "getter": [Function],
+                        "id": 2,
+                        "lazy": true,
+                        "newDepIds": Set {},
+                        "newDeps": Array [],
+                        "sync": false,
+                        "user": false,
+                        "value": 111,
+                        "vm": [Circular],
+                      },
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 26,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 23,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 5,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 4,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 3,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  [Circular],
+                ],
+                "dirty": false,
+                "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+                "getter": [Function],
+                "id": 4,
+                "lazy": false,
+                "newDepIds": Set {},
+                "newDeps": Array [],
+                "sync": false,
+                "user": false,
+                "value": undefined,
+                "vm": [Circular],
+              },
+            ],
+          },
+          Dep {
+            "id": 3,
+            "subs": Array [
+              [Circular],
+              Watcher {
+                "active": true,
+                "before": [Function],
+                "cb": [Function],
+                "deep": false,
+                "depIds": Set {
+                  24,
+                  25,
+                  19,
+                  26,
+                  23,
+                  5,
+                  4,
+                  3,
+                  2,
+                },
+                "deps": Array [
+                  Dep {
+                    "id": 24,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 25,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 19,
+                    "subs": Array [
+                      Watcher {
+                        "active": true,
+                        "before": undefined,
+                        "cb": [Function],
+                        "deep": false,
+                        "depIds": Set {
+                          19,
+                        },
+                        "deps": Array [
+                          [Circular],
+                        ],
+                        "dirty": false,
+                        "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+                        "getter": [Function],
+                        "id": 2,
+                        "lazy": true,
+                        "newDepIds": Set {},
+                        "newDeps": Array [],
+                        "sync": false,
+                        "user": false,
+                        "value": 111,
+                        "vm": [Circular],
+                      },
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 26,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 23,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 5,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 4,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  [Circular],
+                  Dep {
+                    "id": 2,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                ],
+                "dirty": false,
+                "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+                "getter": [Function],
+                "id": 4,
+                "lazy": false,
+                "newDepIds": Set {},
+                "newDeps": Array [],
+                "sync": false,
+                "user": false,
+                "value": undefined,
+                "vm": [Circular],
+              },
+            ],
+          },
+          Dep {
+            "id": 4,
+            "subs": Array [
+              [Circular],
+              Watcher {
+                "active": true,
+                "before": [Function],
+                "cb": [Function],
+                "deep": false,
+                "depIds": Set {
+                  24,
+                  25,
+                  19,
+                  26,
+                  23,
+                  5,
+                  4,
+                  3,
+                  2,
+                },
+                "deps": Array [
+                  Dep {
+                    "id": 24,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 25,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 19,
+                    "subs": Array [
+                      Watcher {
+                        "active": true,
+                        "before": undefined,
+                        "cb": [Function],
+                        "deep": false,
+                        "depIds": Set {
+                          19,
+                        },
+                        "deps": Array [
+                          [Circular],
+                        ],
+                        "dirty": false,
+                        "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+                        "getter": [Function],
+                        "id": 2,
+                        "lazy": true,
+                        "newDepIds": Set {},
+                        "newDeps": Array [],
+                        "sync": false,
+                        "user": false,
+                        "value": 111,
+                        "vm": [Circular],
+                      },
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 26,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 23,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 5,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  [Circular],
+                  Dep {
+                    "id": 3,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 2,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                ],
+                "dirty": false,
+                "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+                "getter": [Function],
+                "id": 4,
+                "lazy": false,
+                "newDepIds": Set {},
+                "newDeps": Array [],
+                "sync": false,
+                "user": false,
+                "value": undefined,
+                "vm": [Circular],
+              },
+            ],
+          },
+          Dep {
+            "id": 5,
+            "subs": Array [
+              [Circular],
+              Watcher {
+                "active": true,
+                "before": [Function],
+                "cb": [Function],
+                "deep": false,
+                "depIds": Set {
+                  24,
+                  25,
+                  19,
+                  26,
+                  23,
+                  5,
+                  4,
+                  3,
+                  2,
+                },
+                "deps": Array [
+                  Dep {
+                    "id": 24,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 25,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 19,
+                    "subs": Array [
+                      Watcher {
+                        "active": true,
+                        "before": undefined,
+                        "cb": [Function],
+                        "deep": false,
+                        "depIds": Set {
+                          19,
+                        },
+                        "deps": Array [
+                          [Circular],
+                        ],
+                        "dirty": false,
+                        "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+                        "getter": [Function],
+                        "id": 2,
+                        "lazy": true,
+                        "newDepIds": Set {},
+                        "newDeps": Array [],
+                        "sync": false,
+                        "user": false,
+                        "value": 111,
+                        "vm": [Circular],
+                      },
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 26,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 23,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  [Circular],
+                  Dep {
+                    "id": 4,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 3,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 2,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                ],
+                "dirty": false,
+                "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+                "getter": [Function],
+                "id": 4,
+                "lazy": false,
+                "newDepIds": Set {},
+                "newDeps": Array [],
+                "sync": false,
+                "user": false,
+                "value": undefined,
+                "vm": [Circular],
+              },
+            ],
+          },
+          Dep {
+            "id": 23,
+            "subs": Array [
+              [Circular],
+              Watcher {
+                "active": true,
+                "before": [Function],
+                "cb": [Function],
+                "deep": false,
+                "depIds": Set {
+                  24,
+                  25,
+                  19,
+                  26,
+                  23,
+                  5,
+                  4,
+                  3,
+                  2,
+                },
+                "deps": Array [
+                  Dep {
+                    "id": 24,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 25,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 19,
+                    "subs": Array [
+                      Watcher {
+                        "active": true,
+                        "before": undefined,
+                        "cb": [Function],
+                        "deep": false,
+                        "depIds": Set {
+                          19,
+                        },
+                        "deps": Array [
+                          [Circular],
+                        ],
+                        "dirty": false,
+                        "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+                        "getter": [Function],
+                        "id": 2,
+                        "lazy": true,
+                        "newDepIds": Set {},
+                        "newDeps": Array [],
+                        "sync": false,
+                        "user": false,
+                        "value": 111,
+                        "vm": [Circular],
+                      },
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 26,
+                    "subs": Array [
+                      [Circular],
+                    ],
+                  },
+                  [Circular],
+                  Dep {
+                    "id": 5,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 4,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 3,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 2,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                ],
+                "dirty": false,
+                "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+                "getter": [Function],
+                "id": 4,
+                "lazy": false,
+                "newDepIds": Set {},
+                "newDeps": Array [],
+                "sync": false,
+                "user": false,
+                "value": undefined,
+                "vm": [Circular],
+              },
+            ],
+          },
+        ],
+        "dirty": false,
+        "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+        "getter": [Function],
+        "id": 3,
+        "lazy": true,
+        "newDepIds": Set {},
+        "newDeps": Array [],
+        "sync": false,
+        "user": false,
+        "value": "",
+        "vm": [Circular],
+      },
+      Watcher {
+        "active": true,
+        "before": [Function],
+        "cb": [Function],
+        "deep": false,
+        "depIds": Set {
+          24,
+          25,
+          19,
+          26,
+          23,
+          5,
+          4,
+          3,
+          2,
+        },
+        "deps": Array [
+          Dep {
+            "id": 24,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 25,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 19,
+            "subs": Array [
+              Watcher {
+                "active": true,
+                "before": undefined,
+                "cb": [Function],
+                "deep": false,
+                "depIds": Set {
+                  19,
+                },
+                "deps": Array [
+                  [Circular],
+                ],
+                "dirty": false,
+                "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+                "getter": [Function],
+                "id": 2,
+                "lazy": true,
+                "newDepIds": Set {},
+                "newDeps": Array [],
+                "sync": false,
+                "user": false,
+                "value": 111,
+                "vm": [Circular],
+              },
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 26,
+            "subs": Array [
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 23,
+            "subs": Array [
+              Watcher {
+                "active": true,
+                "before": undefined,
+                "cb": [Function],
+                "deep": false,
+                "depIds": Set {
+                  2,
+                  3,
+                  4,
+                  5,
+                  23,
+                },
+                "deps": Array [
+                  Dep {
+                    "id": 2,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 3,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 4,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 5,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  [Circular],
+                ],
+                "dirty": false,
+                "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                "getter": [Function],
+                "id": 3,
+                "lazy": true,
+                "newDepIds": Set {},
+                "newDeps": Array [],
+                "sync": false,
+                "user": false,
+                "value": "",
+                "vm": [Circular],
+              },
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 5,
+            "subs": Array [
+              Watcher {
+                "active": true,
+                "before": undefined,
+                "cb": [Function],
+                "deep": false,
+                "depIds": Set {
+                  2,
+                  3,
+                  4,
+                  5,
+                  23,
+                },
+                "deps": Array [
+                  Dep {
+                    "id": 2,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 3,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 4,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  [Circular],
+                  Dep {
+                    "id": 23,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                ],
+                "dirty": false,
+                "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                "getter": [Function],
+                "id": 3,
+                "lazy": true,
+                "newDepIds": Set {},
+                "newDeps": Array [],
+                "sync": false,
+                "user": false,
+                "value": "",
+                "vm": [Circular],
+              },
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 4,
+            "subs": Array [
+              Watcher {
+                "active": true,
+                "before": undefined,
+                "cb": [Function],
+                "deep": false,
+                "depIds": Set {
+                  2,
+                  3,
+                  4,
+                  5,
+                  23,
+                },
+                "deps": Array [
+                  Dep {
+                    "id": 2,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 3,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  [Circular],
+                  Dep {
+                    "id": 5,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 23,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                ],
+                "dirty": false,
+                "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                "getter": [Function],
+                "id": 3,
+                "lazy": true,
+                "newDepIds": Set {},
+                "newDeps": Array [],
+                "sync": false,
+                "user": false,
+                "value": "",
+                "vm": [Circular],
+              },
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 3,
+            "subs": Array [
+              Watcher {
+                "active": true,
+                "before": undefined,
+                "cb": [Function],
+                "deep": false,
+                "depIds": Set {
+                  2,
+                  3,
+                  4,
+                  5,
+                  23,
+                },
+                "deps": Array [
+                  Dep {
+                    "id": 2,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  [Circular],
+                  Dep {
+                    "id": 4,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 5,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 23,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                ],
+                "dirty": false,
+                "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                "getter": [Function],
+                "id": 3,
+                "lazy": true,
+                "newDepIds": Set {},
+                "newDeps": Array [],
+                "sync": false,
+                "user": false,
+                "value": "",
+                "vm": [Circular],
+              },
+              [Circular],
+            ],
+          },
+          Dep {
+            "id": 2,
+            "subs": Array [
+              Watcher {
+                "active": true,
+                "before": undefined,
+                "cb": [Function],
+                "deep": false,
+                "depIds": Set {
+                  2,
+                  3,
+                  4,
+                  5,
+                  23,
+                },
+                "deps": Array [
+                  [Circular],
+                  Dep {
+                    "id": 3,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 4,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 5,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                  Dep {
+                    "id": 23,
+                    "subs": Array [
+                      [Circular],
+                      [Circular],
+                    ],
+                  },
+                ],
+                "dirty": false,
+                "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                "getter": [Function],
+                "id": 3,
+                "lazy": true,
+                "newDepIds": Set {},
+                "newDeps": Array [],
+                "sync": false,
+                "user": false,
+                "value": "",
+                "vm": [Circular],
+              },
+              [Circular],
+            ],
+          },
+        ],
+        "dirty": false,
+        "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+        "getter": [Function],
+        "id": 4,
+        "lazy": false,
+        "newDepIds": Set {},
+        "newDeps": Array [],
+        "sync": false,
+        "user": false,
+        "value": undefined,
+        "vm": [Circular],
+      },
+    ],
+  },
+  "_self": [Circular],
+  "_staticTrees": null,
+  "_uid": 1,
+  "_vnode": VNode {
+    "asyncFactory": undefined,
+    "asyncMeta": undefined,
+    "children": Array [
+      VNode {
+        "asyncFactory": undefined,
+        "asyncMeta": undefined,
+        "children": undefined,
+        "componentInstance": undefined,
+        "componentOptions": undefined,
+        "context": undefined,
+        "data": undefined,
+        "elm": 
+  111
+  ,
+        "fnContext": undefined,
+        "fnOptions": undefined,
+        "fnScopeId": undefined,
+        "isAsyncPlaceholder": false,
+        "isCloned": false,
+        "isComment": false,
+        "isOnce": false,
+        "isRootInsert": false,
+        "isStatic": false,
+        "key": undefined,
+        "ns": undefined,
+        "parent": undefined,
+        "raw": false,
+        "tag": undefined,
+        "text": "
+  111
+  ",
+      },
+      VNode {
+        "asyncFactory": undefined,
+        "asyncMeta": undefined,
+        "children": undefined,
+        "componentInstance": undefined,
+        "componentOptions": undefined,
+        "context": undefined,
+        "data": undefined,
+        "elm": <!---->,
+        "fnContext": undefined,
+        "fnOptions": undefined,
+        "fnScopeId": undefined,
+        "isAsyncPlaceholder": false,
+        "isCloned": false,
+        "isComment": true,
+        "isOnce": false,
+        "isRootInsert": false,
+        "isStatic": false,
+        "key": undefined,
+        "ns": undefined,
+        "parent": undefined,
+        "raw": false,
+        "tag": undefined,
+        "text": "",
+      },
+      VNode {
+        "asyncFactory": undefined,
+        "asyncMeta": undefined,
+        "children": undefined,
+        "componentInstance": undefined,
+        "componentOptions": undefined,
+        "context": undefined,
+        "data": undefined,
+        "elm":  ,
+        "fnContext": undefined,
+        "fnOptions": undefined,
+        "fnScopeId": undefined,
+        "isAsyncPlaceholder": false,
+        "isCloned": false,
+        "isComment": false,
+        "isOnce": false,
+        "isRootInsert": false,
+        "isStatic": false,
+        "key": undefined,
+        "ns": undefined,
+        "parent": undefined,
+        "raw": false,
+        "tag": undefined,
+        "text": " ",
+      },
+      VNode {
+        "asyncFactory": undefined,
+        "asyncMeta": undefined,
+        "children": undefined,
+        "componentInstance": undefined,
+        "componentOptions": undefined,
+        "context": undefined,
+        "data": undefined,
+        "elm": <!---->,
+        "fnContext": undefined,
+        "fnOptions": undefined,
+        "fnScopeId": undefined,
+        "isAsyncPlaceholder": false,
+        "isCloned": false,
+        "isComment": true,
+        "isOnce": false,
+        "isRootInsert": false,
+        "isStatic": false,
+        "key": undefined,
+        "ns": undefined,
+        "parent": undefined,
+        "raw": false,
+        "tag": undefined,
+        "text": "",
+      },
+    ],
+    "componentInstance": undefined,
+    "componentOptions": undefined,
+    "context": [Circular],
+    "data": Object {
+      "class": Array [
+        "sent",
+        Object {
+          "large": false,
+        },
+      ],
+      "staticClass": "token-amount",
+    },
+    "elm": <span
+      class="token-amount sent"
+    >
+      
+  111
+  
+      <!---->
+       
+      <!---->
+    </span>,
+    "fnContext": undefined,
+    "fnOptions": undefined,
+    "fnScopeId": undefined,
+    "isAsyncPlaceholder": false,
+    "isCloned": false,
+    "isComment": false,
+    "isOnce": false,
+    "isRootInsert": true,
+    "isStatic": false,
+    "key": undefined,
+    "ns": undefined,
+    "parent": VNode {
+      "asyncFactory": undefined,
+      "asyncMeta": undefined,
+      "children": undefined,
+      "componentInstance": [Circular],
+      "componentOptions": Object {
+        "Ctor": [Function],
+        "children": undefined,
+        "listeners": Object {},
+        "propsData": Object {
+          "amount": 111,
+          "direction": "sent",
+          "hideFiat": true,
+          "highPrecision": false,
+          "large": false,
+          "noSymbol": true,
+        },
+        "tag": undefined,
+      },
+      "context": VueComponent {
+        "$attrs": Object {},
+        "$children": Array [
+          [Circular],
+        ],
+        "$createElement": [Function],
+        "$el": <span
+          class="token-amount sent"
+        >
+          
+  111
+  
+          <!---->
+           
+          <!---->
+        </span>,
+        "$emit": [Function],
+        "$listeners": Object {},
+        "$options": Object {
+          "$_doNotStubChildren": true,
+          "$_isWrapperParent": true,
+          "_Ctor": Object {
+            "1": [Function],
+          },
+          "_base": [Function],
+          "_isFunctionalContainer": undefined,
+          "beforeCreate": Array [
+            [Function],
+            [Function],
+            [Function],
+          ],
+          "components": Object {
+            "transition": Object {
+              "$_doNotStubChildren": true,
+              "$_vueTestUtils_original": Object {
+                "_Ctor": Object {
+                  "1": [Function],
+                },
+                "abstract": true,
+                "name": "transition",
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "mode": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+              },
+              "abstract": true,
+              "attrs": undefined,
+              "class": undefined,
+              "domProps": undefined,
+              "functional": undefined,
+              "key": undefined,
+              "model": undefined,
+              "name": "transition",
+              "nativeOn": undefined,
+              "normalizedStyle": undefined,
+              "on": undefined,
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "mode": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+              "staticClass": undefined,
+              "staticStyle": undefined,
+              "style": undefined,
+            },
+            "transition-group": Object {
+              "$_doNotStubChildren": true,
+              "$_vueTestUtils_original": Object {
+                "_Ctor": Object {
+                  "1": [Function],
+                },
+                "beforeMount": [Function],
+                "methods": Object {
+                  "hasMove": [Function],
+                },
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "moveClass": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "tag": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+                "updated": [Function],
+              },
+              "abstract": undefined,
+              "attrs": undefined,
+              "class": undefined,
+              "domProps": undefined,
+              "functional": undefined,
+              "key": undefined,
+              "model": undefined,
+              "name": undefined,
+              "nativeOn": undefined,
+              "normalizedStyle": undefined,
+              "on": undefined,
+              "props": Object {
+                "appear": Object {
+                  "type": [Function],
+                },
+                "appearActiveClass": Object {
+                  "type": [Function],
+                },
+                "appearClass": Object {
+                  "type": [Function],
+                },
+                "appearToClass": Object {
+                  "type": [Function],
+                },
+                "css": Object {
+                  "type": [Function],
+                },
+                "duration": Object {
+                  "type": Array [
+                    [Function],
+                    [Function],
+                    [Function],
+                  ],
+                },
+                "enterActiveClass": Object {
+                  "type": [Function],
+                },
+                "enterClass": Object {
+                  "type": [Function],
+                },
+                "enterToClass": Object {
+                  "type": [Function],
+                },
+                "leaveActiveClass": Object {
+                  "type": [Function],
+                },
+                "leaveClass": Object {
+                  "type": [Function],
+                },
+                "leaveToClass": Object {
+                  "type": [Function],
+                },
+                "moveClass": Object {
+                  "type": [Function],
+                },
+                "name": Object {
+                  "type": [Function],
+                },
+                "tag": Object {
+                  "type": [Function],
+                },
+                "type": Object {
+                  "type": [Function],
+                },
+              },
+              "render": [Function],
+              "staticClass": undefined,
+              "staticStyle": undefined,
+              "style": undefined,
+            },
+          },
+          "data": [Function],
+          "directives": Object {},
+          "filters": Object {},
+          "methods": undefined,
+          "mocks": Object {
+            "$store": Object {
+              "getters": Object {},
+              "state": Object {},
+            },
+          },
+          "provide": [Function],
+          "render": [Function],
+          "shouldProxy": true,
+          "stubs": Object {
+            "transition": true,
+            "transition-group": true,
+          },
+        },
+        "$parent": undefined,
+        "$refs": Object {},
+        "$root": [Circular],
+        "$scopedSlots": Object {},
+        "$slots": Object {},
+        "$vnode": undefined,
+        "__emitted": Object {},
+        "__emittedByOrder": Array [],
+        "_c": [Function],
+        "_data": Object {
+          "vueTestUtils_childProps": Object {
+            "amount": 111,
+            "direction": "sent",
+            "hideFiat": true,
+            "highPrecision": false,
+            "large": false,
+            "noSymbol": true,
+          },
+        },
+        "_directInactive": false,
+        "_events": Object {},
+        "_hasHookEvent": false,
+        "_inactive": null,
+        "_isBeingDestroyed": false,
+        "_isDestroyed": false,
+        "_isMounted": true,
+        "_isVue": true,
+        "_provided": Object {},
+        "_renderProxy": VueComponent {
+          "$attrs": Object {},
+          "$children": Array [
+            [Circular],
+          ],
+          "$createElement": [Function],
+          "$el": <span
+            class="token-amount sent"
+          >
+            
+  111
+  
+            <!---->
+             
+            <!---->
+          </span>,
+          "$emit": [Function],
+          "$listeners": Object {},
+          "$options": Object {
+            "$_doNotStubChildren": true,
+            "$_isWrapperParent": true,
+            "_Ctor": Object {
+              "1": [Function],
+            },
+            "_base": [Function],
+            "_isFunctionalContainer": undefined,
+            "beforeCreate": Array [
+              [Function],
+              [Function],
+              [Function],
+            ],
+            "components": Object {
+              "transition": Object {
+                "$_doNotStubChildren": true,
+                "$_vueTestUtils_original": Object {
+                  "_Ctor": Object {
+                    "1": [Function],
+                  },
+                  "abstract": true,
+                  "name": "transition",
+                  "props": Object {
+                    "appear": Object {
+                      "type": [Function],
+                    },
+                    "appearActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "appearClass": Object {
+                      "type": [Function],
+                    },
+                    "appearToClass": Object {
+                      "type": [Function],
+                    },
+                    "css": Object {
+                      "type": [Function],
+                    },
+                    "duration": Object {
+                      "type": Array [
+                        [Function],
+                        [Function],
+                        [Function],
+                      ],
+                    },
+                    "enterActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "enterClass": Object {
+                      "type": [Function],
+                    },
+                    "enterToClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveToClass": Object {
+                      "type": [Function],
+                    },
+                    "mode": Object {
+                      "type": [Function],
+                    },
+                    "name": Object {
+                      "type": [Function],
+                    },
+                    "type": Object {
+                      "type": [Function],
+                    },
+                  },
+                  "render": [Function],
+                },
+                "abstract": true,
+                "attrs": undefined,
+                "class": undefined,
+                "domProps": undefined,
+                "functional": undefined,
+                "key": undefined,
+                "model": undefined,
+                "name": "transition",
+                "nativeOn": undefined,
+                "normalizedStyle": undefined,
+                "on": undefined,
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "mode": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+                "staticClass": undefined,
+                "staticStyle": undefined,
+                "style": undefined,
+              },
+              "transition-group": Object {
+                "$_doNotStubChildren": true,
+                "$_vueTestUtils_original": Object {
+                  "_Ctor": Object {
+                    "1": [Function],
+                  },
+                  "beforeMount": [Function],
+                  "methods": Object {
+                    "hasMove": [Function],
+                  },
+                  "props": Object {
+                    "appear": Object {
+                      "type": [Function],
+                    },
+                    "appearActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "appearClass": Object {
+                      "type": [Function],
+                    },
+                    "appearToClass": Object {
+                      "type": [Function],
+                    },
+                    "css": Object {
+                      "type": [Function],
+                    },
+                    "duration": Object {
+                      "type": Array [
+                        [Function],
+                        [Function],
+                        [Function],
+                      ],
+                    },
+                    "enterActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "enterClass": Object {
+                      "type": [Function],
+                    },
+                    "enterToClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveActiveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveClass": Object {
+                      "type": [Function],
+                    },
+                    "leaveToClass": Object {
+                      "type": [Function],
+                    },
+                    "moveClass": Object {
+                      "type": [Function],
+                    },
+                    "name": Object {
+                      "type": [Function],
+                    },
+                    "tag": Object {
+                      "type": [Function],
+                    },
+                    "type": Object {
+                      "type": [Function],
+                    },
+                  },
+                  "render": [Function],
+                  "updated": [Function],
+                },
+                "abstract": undefined,
+                "attrs": undefined,
+                "class": undefined,
+                "domProps": undefined,
+                "functional": undefined,
+                "key": undefined,
+                "model": undefined,
+                "name": undefined,
+                "nativeOn": undefined,
+                "normalizedStyle": undefined,
+                "on": undefined,
+                "props": Object {
+                  "appear": Object {
+                    "type": [Function],
+                  },
+                  "appearActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "appearClass": Object {
+                    "type": [Function],
+                  },
+                  "appearToClass": Object {
+                    "type": [Function],
+                  },
+                  "css": Object {
+                    "type": [Function],
+                  },
+                  "duration": Object {
+                    "type": Array [
+                      [Function],
+                      [Function],
+                      [Function],
+                    ],
+                  },
+                  "enterActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "enterClass": Object {
+                    "type": [Function],
+                  },
+                  "enterToClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveActiveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveClass": Object {
+                    "type": [Function],
+                  },
+                  "leaveToClass": Object {
+                    "type": [Function],
+                  },
+                  "moveClass": Object {
+                    "type": [Function],
+                  },
+                  "name": Object {
+                    "type": [Function],
+                  },
+                  "tag": Object {
+                    "type": [Function],
+                  },
+                  "type": Object {
+                    "type": [Function],
+                  },
+                },
+                "render": [Function],
+                "staticClass": undefined,
+                "staticStyle": undefined,
+                "style": undefined,
+              },
+            },
+            "data": [Function],
+            "directives": Object {},
+            "filters": Object {},
+            "methods": undefined,
+            "mocks": Object {
+              "$store": Object {
+                "getters": Object {},
+                "state": Object {},
+              },
+            },
+            "provide": [Function],
+            "render": [Function],
+            "shouldProxy": true,
+            "stubs": Object {
+              "transition": true,
+              "transition-group": true,
+            },
+          },
+          "$parent": undefined,
+          "$refs": Object {},
+          "$root": [Circular],
+          "$scopedSlots": Object {},
+          "$slots": Object {},
+          "$vnode": undefined,
+          "__emitted": Object {},
+          "__emittedByOrder": Array [],
+          "_c": [Function],
+          "_data": Object {
+            "vueTestUtils_childProps": Object {
+              "amount": 111,
+              "direction": "sent",
+              "hideFiat": true,
+              "highPrecision": false,
+              "large": false,
+              "noSymbol": true,
+            },
+          },
+          "_directInactive": false,
+          "_events": Object {},
+          "_hasHookEvent": false,
+          "_inactive": null,
+          "_isBeingDestroyed": false,
+          "_isDestroyed": false,
+          "_isMounted": true,
+          "_isVue": true,
+          "_provided": Object {},
+          "_renderProxy": [Circular],
+          "_self": [Circular],
+          "_staticTrees": null,
+          "_uid": 0,
+          "_vnode": [Circular],
+          "_watcher": Watcher {
+            "active": true,
+            "before": [Function],
+            "cb": [Function],
+            "deep": false,
+            "depIds": Set {
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+            },
+            "deps": Array [
+              Dep {
+                "id": 9,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 10,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 11,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 12,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 13,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 14,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 15,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 16,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+            ],
+            "dirty": false,
+            "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+            "getter": [Function],
+            "id": 1,
+            "lazy": false,
+            "newDepIds": Set {},
+            "newDeps": Array [],
+            "sync": false,
+            "user": false,
+            "value": undefined,
+            "vm": [Circular],
+          },
+          "_watchers": Array [
+            Watcher {
+              "active": true,
+              "before": [Function],
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                9,
+                10,
+                11,
+                12,
+                13,
+                14,
+                15,
+                16,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 9,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 10,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 11,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 12,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 13,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 14,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 15,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 16,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+              "getter": [Function],
+              "id": 1,
+              "lazy": false,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": undefined,
+              "vm": [Circular],
+            },
+          ],
+          "vueTestUtils_childProps": Object {
+            "amount": 111,
+            "direction": "sent",
+            "hideFiat": true,
+            "highPrecision": false,
+            "large": false,
+            "noSymbol": true,
+          },
+        },
+        "_self": [Circular],
+        "_staticTrees": null,
+        "_uid": 0,
+        "_vnode": [Circular],
+        "_watcher": Watcher {
+          "active": true,
+          "before": [Function],
+          "cb": [Function],
+          "deep": false,
+          "depIds": Set {
+            9,
+            10,
+            11,
+            12,
+            13,
+            14,
+            15,
+            16,
+          },
+          "deps": Array [
+            Dep {
+              "id": 9,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 10,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 11,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 12,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 13,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 14,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 15,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+            Dep {
+              "id": 16,
+              "subs": Array [
+                [Circular],
+              ],
+            },
+          ],
+          "dirty": false,
+          "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+          "getter": [Function],
+          "id": 1,
+          "lazy": false,
+          "newDepIds": Set {},
+          "newDeps": Array [],
+          "sync": false,
+          "user": false,
+          "value": undefined,
+          "vm": [Circular],
+        },
+        "_watchers": Array [
+          Watcher {
+            "active": true,
+            "before": [Function],
+            "cb": [Function],
+            "deep": false,
+            "depIds": Set {
+              9,
+              10,
+              11,
+              12,
+              13,
+              14,
+              15,
+              16,
+            },
+            "deps": Array [
+              Dep {
+                "id": 9,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 10,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 11,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 12,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 13,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 14,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 15,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 16,
+                "subs": Array [
+                  [Circular],
+                ],
+              },
+            ],
+            "dirty": false,
+            "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+            "getter": [Function],
+            "id": 1,
+            "lazy": false,
+            "newDepIds": Set {},
+            "newDeps": Array [],
+            "sync": false,
+            "user": false,
+            "value": undefined,
+            "vm": [Circular],
+          },
+        ],
+        "vueTestUtils_childProps": Object {
+          "amount": 111,
+          "direction": "sent",
+          "hideFiat": true,
+          "highPrecision": false,
+          "large": false,
+          "noSymbol": true,
+        },
+      },
+      "data": Object {
+        "attrs": Object {},
+        "hook": Object {
+          "destroy": [Function],
+          "init": [Function],
+          "insert": [Function],
+          "prepatch": [Function],
+        },
+        "on": undefined,
+        "pendingInsert": null,
+        "scopedSlots": Object {
+          "_normalized": Object {},
+        },
+      },
+      "elm": <span
+        class="token-amount sent"
+      >
+        
+  111
+  
+        <!---->
+         
+        <!---->
+      </span>,
+      "fnContext": undefined,
+      "fnOptions": undefined,
+      "fnScopeId": undefined,
+      "isAsyncPlaceholder": false,
+      "isCloned": false,
+      "isComment": false,
+      "isOnce": false,
+      "isRootInsert": true,
+      "isStatic": false,
+      "key": undefined,
+      "ns": undefined,
+      "parent": undefined,
+      "raw": false,
+      "tag": "vue-component-5",
+      "text": undefined,
+    },
+    "raw": false,
+    "tag": "span",
+    "text": undefined,
+  },
+  "_watcher": Watcher {
+    "active": true,
+    "before": [Function],
+    "cb": [Function],
+    "deep": false,
+    "depIds": Set {
+      24,
+      25,
+      19,
+      26,
+      23,
+      5,
+      4,
+      3,
+      2,
+    },
+    "deps": Array [
+      Dep {
+        "id": 24,
+        "subs": Array [
+          [Circular],
+        ],
+      },
+      Dep {
+        "id": 25,
+        "subs": Array [
+          [Circular],
+        ],
+      },
+      Dep {
+        "id": 19,
+        "subs": Array [
+          Watcher {
+            "active": true,
+            "before": undefined,
+            "cb": [Function],
+            "deep": false,
+            "depIds": Set {
+              19,
+            },
+            "deps": Array [
+              [Circular],
+            ],
+            "dirty": false,
+            "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+            "getter": [Function],
+            "id": 2,
+            "lazy": true,
+            "newDepIds": Set {},
+            "newDeps": Array [],
+            "sync": false,
+            "user": false,
+            "value": 111,
+            "vm": [Circular],
+          },
+          [Circular],
+        ],
+      },
+      Dep {
+        "id": 26,
+        "subs": Array [
+          [Circular],
+        ],
+      },
+      Dep {
+        "id": 23,
+        "subs": Array [
+          Watcher {
+            "active": true,
+            "before": undefined,
+            "cb": [Function],
+            "deep": false,
+            "depIds": Set {
+              2,
+              3,
+              4,
+              5,
+              23,
+            },
+            "deps": Array [
+              Dep {
+                "id": 2,
+                "subs": Array [
+                  [Circular],
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 3,
+                "subs": Array [
+                  [Circular],
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 4,
+                "subs": Array [
+                  [Circular],
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 5,
+                "subs": Array [
+                  [Circular],
+                  [Circular],
+                ],
+              },
+              [Circular],
+            ],
+            "dirty": false,
+            "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+            "getter": [Function],
+            "id": 3,
+            "lazy": true,
+            "newDepIds": Set {},
+            "newDeps": Array [],
+            "sync": false,
+            "user": false,
+            "value": "",
+            "vm": [Circular],
+          },
+          [Circular],
+        ],
+      },
+      Dep {
+        "id": 5,
+        "subs": Array [
+          Watcher {
+            "active": true,
+            "before": undefined,
+            "cb": [Function],
+            "deep": false,
+            "depIds": Set {
+              2,
+              3,
+              4,
+              5,
+              23,
+            },
+            "deps": Array [
+              Dep {
+                "id": 2,
+                "subs": Array [
+                  [Circular],
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 3,
+                "subs": Array [
+                  [Circular],
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 4,
+                "subs": Array [
+                  [Circular],
+                  [Circular],
+                ],
+              },
+              [Circular],
+              Dep {
+                "id": 23,
+                "subs": Array [
+                  [Circular],
+                  [Circular],
+                ],
+              },
+            ],
+            "dirty": false,
+            "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+            "getter": [Function],
+            "id": 3,
+            "lazy": true,
+            "newDepIds": Set {},
+            "newDeps": Array [],
+            "sync": false,
+            "user": false,
+            "value": "",
+            "vm": [Circular],
+          },
+          [Circular],
+        ],
+      },
+      Dep {
+        "id": 4,
+        "subs": Array [
+          Watcher {
+            "active": true,
+            "before": undefined,
+            "cb": [Function],
+            "deep": false,
+            "depIds": Set {
+              2,
+              3,
+              4,
+              5,
+              23,
+            },
+            "deps": Array [
+              Dep {
+                "id": 2,
+                "subs": Array [
+                  [Circular],
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 3,
+                "subs": Array [
+                  [Circular],
+                  [Circular],
+                ],
+              },
+              [Circular],
+              Dep {
+                "id": 5,
+                "subs": Array [
+                  [Circular],
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 23,
+                "subs": Array [
+                  [Circular],
+                  [Circular],
+                ],
+              },
+            ],
+            "dirty": false,
+            "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+            "getter": [Function],
+            "id": 3,
+            "lazy": true,
+            "newDepIds": Set {},
+            "newDeps": Array [],
+            "sync": false,
+            "user": false,
+            "value": "",
+            "vm": [Circular],
+          },
+          [Circular],
+        ],
+      },
+      Dep {
+        "id": 3,
+        "subs": Array [
+          Watcher {
+            "active": true,
+            "before": undefined,
+            "cb": [Function],
+            "deep": false,
+            "depIds": Set {
+              2,
+              3,
+              4,
+              5,
+              23,
+            },
+            "deps": Array [
+              Dep {
+                "id": 2,
+                "subs": Array [
+                  [Circular],
+                  [Circular],
+                ],
+              },
+              [Circular],
+              Dep {
+                "id": 4,
+                "subs": Array [
+                  [Circular],
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 5,
+                "subs": Array [
+                  [Circular],
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 23,
+                "subs": Array [
+                  [Circular],
+                  [Circular],
+                ],
+              },
+            ],
+            "dirty": false,
+            "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+            "getter": [Function],
+            "id": 3,
+            "lazy": true,
+            "newDepIds": Set {},
+            "newDeps": Array [],
+            "sync": false,
+            "user": false,
+            "value": "",
+            "vm": [Circular],
+          },
+          [Circular],
+        ],
+      },
+      Dep {
+        "id": 2,
+        "subs": Array [
+          Watcher {
+            "active": true,
+            "before": undefined,
+            "cb": [Function],
+            "deep": false,
+            "depIds": Set {
+              2,
+              3,
+              4,
+              5,
+              23,
+            },
+            "deps": Array [
+              [Circular],
+              Dep {
+                "id": 3,
+                "subs": Array [
+                  [Circular],
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 4,
+                "subs": Array [
+                  [Circular],
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 5,
+                "subs": Array [
+                  [Circular],
+                  [Circular],
+                ],
+              },
+              Dep {
+                "id": 23,
+                "subs": Array [
+                  [Circular],
+                  [Circular],
+                ],
+              },
+            ],
+            "dirty": false,
+            "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+            "getter": [Function],
+            "id": 3,
+            "lazy": true,
+            "newDepIds": Set {},
+            "newDeps": Array [],
+            "sync": false,
+            "user": false,
+            "value": "",
+            "vm": [Circular],
+          },
+          [Circular],
+        ],
+      },
+    ],
+    "dirty": false,
+    "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+    "getter": [Function],
+    "id": 4,
+    "lazy": false,
+    "newDepIds": Set {},
+    "newDeps": Array [],
+    "sync": false,
+    "user": false,
+    "value": undefined,
+    "vm": [Circular],
+  },
+  "_watchers": Array [
+    Watcher {
+      "active": true,
+      "before": undefined,
+      "cb": [Function],
+      "deep": false,
+      "depIds": Set {
+        19,
+      },
+      "deps": Array [
+        Dep {
+          "id": 19,
+          "subs": Array [
+            [Circular],
+            Watcher {
+              "active": true,
+              "before": [Function],
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                24,
+                25,
+                19,
+                26,
+                23,
+                5,
+                4,
+                3,
+                2,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 24,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 25,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                [Circular],
+                Dep {
+                  "id": 26,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 23,
+                  "subs": Array [
+                    Watcher {
+                      "active": true,
+                      "before": undefined,
+                      "cb": [Function],
+                      "deep": false,
+                      "depIds": Set {
+                        2,
+                        3,
+                        4,
+                        5,
+                        23,
+                      },
+                      "deps": Array [
+                        Dep {
+                          "id": 2,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        Dep {
+                          "id": 3,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        Dep {
+                          "id": 4,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        Dep {
+                          "id": 5,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        [Circular],
+                      ],
+                      "dirty": false,
+                      "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                      "getter": [Function],
+                      "id": 3,
+                      "lazy": true,
+                      "newDepIds": Set {},
+                      "newDeps": Array [],
+                      "sync": false,
+                      "user": false,
+                      "value": "",
+                      "vm": [Circular],
+                    },
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 5,
+                  "subs": Array [
+                    Watcher {
+                      "active": true,
+                      "before": undefined,
+                      "cb": [Function],
+                      "deep": false,
+                      "depIds": Set {
+                        2,
+                        3,
+                        4,
+                        5,
+                        23,
+                      },
+                      "deps": Array [
+                        Dep {
+                          "id": 2,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        Dep {
+                          "id": 3,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        Dep {
+                          "id": 4,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        [Circular],
+                        Dep {
+                          "id": 23,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                      ],
+                      "dirty": false,
+                      "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                      "getter": [Function],
+                      "id": 3,
+                      "lazy": true,
+                      "newDepIds": Set {},
+                      "newDeps": Array [],
+                      "sync": false,
+                      "user": false,
+                      "value": "",
+                      "vm": [Circular],
+                    },
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 4,
+                  "subs": Array [
+                    Watcher {
+                      "active": true,
+                      "before": undefined,
+                      "cb": [Function],
+                      "deep": false,
+                      "depIds": Set {
+                        2,
+                        3,
+                        4,
+                        5,
+                        23,
+                      },
+                      "deps": Array [
+                        Dep {
+                          "id": 2,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        Dep {
+                          "id": 3,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        [Circular],
+                        Dep {
+                          "id": 5,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        Dep {
+                          "id": 23,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                      ],
+                      "dirty": false,
+                      "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                      "getter": [Function],
+                      "id": 3,
+                      "lazy": true,
+                      "newDepIds": Set {},
+                      "newDeps": Array [],
+                      "sync": false,
+                      "user": false,
+                      "value": "",
+                      "vm": [Circular],
+                    },
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 3,
+                  "subs": Array [
+                    Watcher {
+                      "active": true,
+                      "before": undefined,
+                      "cb": [Function],
+                      "deep": false,
+                      "depIds": Set {
+                        2,
+                        3,
+                        4,
+                        5,
+                        23,
+                      },
+                      "deps": Array [
+                        Dep {
+                          "id": 2,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        [Circular],
+                        Dep {
+                          "id": 4,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        Dep {
+                          "id": 5,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        Dep {
+                          "id": 23,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                      ],
+                      "dirty": false,
+                      "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                      "getter": [Function],
+                      "id": 3,
+                      "lazy": true,
+                      "newDepIds": Set {},
+                      "newDeps": Array [],
+                      "sync": false,
+                      "user": false,
+                      "value": "",
+                      "vm": [Circular],
+                    },
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 2,
+                  "subs": Array [
+                    Watcher {
+                      "active": true,
+                      "before": undefined,
+                      "cb": [Function],
+                      "deep": false,
+                      "depIds": Set {
+                        2,
+                        3,
+                        4,
+                        5,
+                        23,
+                      },
+                      "deps": Array [
+                        [Circular],
+                        Dep {
+                          "id": 3,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        Dep {
+                          "id": 4,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        Dep {
+                          "id": 5,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                        Dep {
+                          "id": 23,
+                          "subs": Array [
+                            [Circular],
+                            [Circular],
+                          ],
+                        },
+                      ],
+                      "dirty": false,
+                      "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+                      "getter": [Function],
+                      "id": 3,
+                      "lazy": true,
+                      "newDepIds": Set {},
+                      "newDeps": Array [],
+                      "sync": false,
+                      "user": false,
+                      "value": "",
+                      "vm": [Circular],
+                    },
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+              "getter": [Function],
+              "id": 4,
+              "lazy": false,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": undefined,
+              "vm": [Circular],
+            },
+          ],
+        },
+      ],
+      "dirty": false,
+      "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+      "getter": [Function],
+      "id": 2,
+      "lazy": true,
+      "newDepIds": Set {},
+      "newDeps": Array [],
+      "sync": false,
+      "user": false,
+      "value": 111,
+      "vm": [Circular],
+    },
+    Watcher {
+      "active": true,
+      "before": undefined,
+      "cb": [Function],
+      "deep": false,
+      "depIds": Set {
+        2,
+        3,
+        4,
+        5,
+        23,
+      },
+      "deps": Array [
+        Dep {
+          "id": 2,
+          "subs": Array [
+            [Circular],
+            Watcher {
+              "active": true,
+              "before": [Function],
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                24,
+                25,
+                19,
+                26,
+                23,
+                5,
+                4,
+                3,
+                2,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 24,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 25,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 19,
+                  "subs": Array [
+                    Watcher {
+                      "active": true,
+                      "before": undefined,
+                      "cb": [Function],
+                      "deep": false,
+                      "depIds": Set {
+                        19,
+                      },
+                      "deps": Array [
+                        [Circular],
+                      ],
+                      "dirty": false,
+                      "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+                      "getter": [Function],
+                      "id": 2,
+                      "lazy": true,
+                      "newDepIds": Set {},
+                      "newDeps": Array [],
+                      "sync": false,
+                      "user": false,
+                      "value": 111,
+                      "vm": [Circular],
+                    },
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 26,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 23,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 5,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 4,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 3,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                [Circular],
+              ],
+              "dirty": false,
+              "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+              "getter": [Function],
+              "id": 4,
+              "lazy": false,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": undefined,
+              "vm": [Circular],
+            },
+          ],
+        },
+        Dep {
+          "id": 3,
+          "subs": Array [
+            [Circular],
+            Watcher {
+              "active": true,
+              "before": [Function],
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                24,
+                25,
+                19,
+                26,
+                23,
+                5,
+                4,
+                3,
+                2,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 24,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 25,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 19,
+                  "subs": Array [
+                    Watcher {
+                      "active": true,
+                      "before": undefined,
+                      "cb": [Function],
+                      "deep": false,
+                      "depIds": Set {
+                        19,
+                      },
+                      "deps": Array [
+                        [Circular],
+                      ],
+                      "dirty": false,
+                      "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+                      "getter": [Function],
+                      "id": 2,
+                      "lazy": true,
+                      "newDepIds": Set {},
+                      "newDeps": Array [],
+                      "sync": false,
+                      "user": false,
+                      "value": 111,
+                      "vm": [Circular],
+                    },
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 26,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 23,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 5,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 4,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                [Circular],
+                Dep {
+                  "id": 2,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+              "getter": [Function],
+              "id": 4,
+              "lazy": false,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": undefined,
+              "vm": [Circular],
+            },
+          ],
+        },
+        Dep {
+          "id": 4,
+          "subs": Array [
+            [Circular],
+            Watcher {
+              "active": true,
+              "before": [Function],
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                24,
+                25,
+                19,
+                26,
+                23,
+                5,
+                4,
+                3,
+                2,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 24,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 25,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 19,
+                  "subs": Array [
+                    Watcher {
+                      "active": true,
+                      "before": undefined,
+                      "cb": [Function],
+                      "deep": false,
+                      "depIds": Set {
+                        19,
+                      },
+                      "deps": Array [
+                        [Circular],
+                      ],
+                      "dirty": false,
+                      "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+                      "getter": [Function],
+                      "id": 2,
+                      "lazy": true,
+                      "newDepIds": Set {},
+                      "newDeps": Array [],
+                      "sync": false,
+                      "user": false,
+                      "value": 111,
+                      "vm": [Circular],
+                    },
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 26,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 23,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 5,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                [Circular],
+                Dep {
+                  "id": 3,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 2,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+              "getter": [Function],
+              "id": 4,
+              "lazy": false,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": undefined,
+              "vm": [Circular],
+            },
+          ],
+        },
+        Dep {
+          "id": 5,
+          "subs": Array [
+            [Circular],
+            Watcher {
+              "active": true,
+              "before": [Function],
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                24,
+                25,
+                19,
+                26,
+                23,
+                5,
+                4,
+                3,
+                2,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 24,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 25,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 19,
+                  "subs": Array [
+                    Watcher {
+                      "active": true,
+                      "before": undefined,
+                      "cb": [Function],
+                      "deep": false,
+                      "depIds": Set {
+                        19,
+                      },
+                      "deps": Array [
+                        [Circular],
+                      ],
+                      "dirty": false,
+                      "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+                      "getter": [Function],
+                      "id": 2,
+                      "lazy": true,
+                      "newDepIds": Set {},
+                      "newDeps": Array [],
+                      "sync": false,
+                      "user": false,
+                      "value": 111,
+                      "vm": [Circular],
+                    },
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 26,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 23,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                [Circular],
+                Dep {
+                  "id": 4,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 3,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 2,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+              "getter": [Function],
+              "id": 4,
+              "lazy": false,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": undefined,
+              "vm": [Circular],
+            },
+          ],
+        },
+        Dep {
+          "id": 23,
+          "subs": Array [
+            [Circular],
+            Watcher {
+              "active": true,
+              "before": [Function],
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                24,
+                25,
+                19,
+                26,
+                23,
+                5,
+                4,
+                3,
+                2,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 24,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 25,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 19,
+                  "subs": Array [
+                    Watcher {
+                      "active": true,
+                      "before": undefined,
+                      "cb": [Function],
+                      "deep": false,
+                      "depIds": Set {
+                        19,
+                      },
+                      "deps": Array [
+                        [Circular],
+                      ],
+                      "dirty": false,
+                      "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+                      "getter": [Function],
+                      "id": 2,
+                      "lazy": true,
+                      "newDepIds": Set {},
+                      "newDeps": Array [],
+                      "sync": false,
+                      "user": false,
+                      "value": 111,
+                      "vm": [Circular],
+                    },
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 26,
+                  "subs": Array [
+                    [Circular],
+                  ],
+                },
+                [Circular],
+                Dep {
+                  "id": 5,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 4,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 3,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 2,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+              "getter": [Function],
+              "id": 4,
+              "lazy": false,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": undefined,
+              "vm": [Circular],
+            },
+          ],
+        },
+      ],
+      "dirty": false,
+      "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+      "getter": [Function],
+      "id": 3,
+      "lazy": true,
+      "newDepIds": Set {},
+      "newDeps": Array [],
+      "sync": false,
+      "user": false,
+      "value": "",
+      "vm": [Circular],
+    },
+    Watcher {
+      "active": true,
+      "before": [Function],
+      "cb": [Function],
+      "deep": false,
+      "depIds": Set {
+        24,
+        25,
+        19,
+        26,
+        23,
+        5,
+        4,
+        3,
+        2,
+      },
+      "deps": Array [
+        Dep {
+          "id": 24,
+          "subs": Array [
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 25,
+          "subs": Array [
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 19,
+          "subs": Array [
+            Watcher {
+              "active": true,
+              "before": undefined,
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                19,
+              },
+              "deps": Array [
+                [Circular],
+              ],
+              "dirty": false,
+              "expression": "function amountRounded() {
+        /* istanbul ignore next */
+        cov_1oekfcity.f[2]++;
+        cov_1oekfcity.s[12]++;
+
+        if (Number.isInteger(this.amount)) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[0][0]++;
+          cov_1oekfcity.s[13]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[0][1]++;
+        }
+
+        cov_1oekfcity.s[14]++;
+
+        if (this.amount === 0) {
+          /* istanbul ignore next */
+          cov_1oekfcity.b[1][0]++;
+          cov_1oekfcity.s[15]++;
+          return this.amount;
+        } else
+        /* istanbul ignore next */
+        {
+          cov_1oekfcity.b[1][1]++;
+        }
+
+        cov_1oekfcity.s[16]++;
+        return this.amount.toFixed(
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][0]++, this.highPrecision) ||
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[3][1]++, this.amount < 0.01) ?
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][0]++, 9) :
+        /* istanbul ignore next */
+        (cov_1oekfcity.b[2][1]++, 2));
+      }",
+              "getter": [Function],
+              "id": 2,
+              "lazy": true,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": 111,
+              "vm": [Circular],
+            },
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 26,
+          "subs": Array [
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 23,
+          "subs": Array [
+            Watcher {
+              "active": true,
+              "before": undefined,
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                2,
+                3,
+                4,
+                5,
+                23,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 2,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 3,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 4,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 5,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                [Circular],
+              ],
+              "dirty": false,
+              "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+              "getter": [Function],
+              "id": 3,
+              "lazy": true,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": "",
+              "vm": [Circular],
+            },
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 5,
+          "subs": Array [
+            Watcher {
+              "active": true,
+              "before": undefined,
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                2,
+                3,
+                4,
+                5,
+                23,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 2,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 3,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 4,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                [Circular],
+                Dep {
+                  "id": 23,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+              "getter": [Function],
+              "id": 3,
+              "lazy": true,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": "",
+              "vm": [Circular],
+            },
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 4,
+          "subs": Array [
+            Watcher {
+              "active": true,
+              "before": undefined,
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                2,
+                3,
+                4,
+                5,
+                23,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 2,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 3,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                [Circular],
+                Dep {
+                  "id": 5,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 23,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+              "getter": [Function],
+              "id": 3,
+              "lazy": true,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": "",
+              "vm": [Circular],
+            },
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 3,
+          "subs": Array [
+            Watcher {
+              "active": true,
+              "before": undefined,
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                2,
+                3,
+                4,
+                5,
+                23,
+              },
+              "deps": Array [
+                Dep {
+                  "id": 2,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                [Circular],
+                Dep {
+                  "id": 4,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 5,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 23,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+              "getter": [Function],
+              "id": 3,
+              "lazy": true,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": "",
+              "vm": [Circular],
+            },
+            [Circular],
+          ],
+        },
+        Dep {
+          "id": 2,
+          "subs": Array [
+            Watcher {
+              "active": true,
+              "before": undefined,
+              "cb": [Function],
+              "deep": false,
+              "depIds": Set {
+                2,
+                3,
+                4,
+                5,
+                23,
+              },
+              "deps": Array [
+                [Circular],
+                Dep {
+                  "id": 3,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 4,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 5,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+                Dep {
+                  "id": 23,
+                  "subs": Array [
+                    [Circular],
+                    [Circular],
+                  ],
+                },
+              ],
+              "dirty": false,
+              "expression": "function mappedState () {
+      var state = this.$store.state;
+      var getters = this.$store.getters;
+      if (namespace) {
+        var module = getModuleByNamespace(this.$store, 'mapState', namespace);
+        if (!module) {
+          return
+        }
+        state = module.context.state;
+        getters = module.context.getters;
+      }
+      return typeof val === 'function'
+        ? val.call(this, state, getters)
+        : state[val]
+    }",
+              "getter": [Function],
+              "id": 3,
+              "lazy": true,
+              "newDepIds": Set {},
+              "newDeps": Array [],
+              "sync": false,
+              "user": false,
+              "value": "",
+              "vm": [Circular],
+            },
+            [Circular],
+          ],
+        },
+      ],
+      "dirty": false,
+      "expression": "function () {
+      vm._update(vm._render(), hydrating);
+    }",
+      "getter": [Function],
+      "id": 4,
+      "lazy": false,
+      "newDepIds": Set {},
+      "newDeps": Array [],
+      "sync": false,
+      "user": false,
+      "value": undefined,
+      "vm": [Circular],
+    },
+  ],
+}
+`;


### PR DESCRIPTION
I've added testcases for Tokens & TotalAmount Components which have increased code coverage of those components.

Before PR:

![Before PR](https://user-images.githubusercontent.com/16476523/193611961-fd75afed-0022-4842-b08b-5a2e7063cdd9.PNG)

After PR:

![After PR](https://user-images.githubusercontent.com/16476523/193612018-d82c533d-dcfe-4ed5-bbaa-5ae59df629e5.PNG)

![After PR -2](https://user-images.githubusercontent.com/16476523/193612074-fa2c2103-443d-4920-8f81-61bde59c20f4.PNG)
