### PR TITLE
Fix claim tip transaction info

### DIFF
--- a/src/popup/pages/TransactionDetailsContent.vue
+++ b/src/popup/pages/TransactionDetailsContent.vue
@@ -239,7 +239,7 @@ export default defineComponent({
 
     const isPool = computed(() => FUNCTION_TYPE_DEX.pool.includes(props.transaction?.tx?.function || ''));
 
-    const tipLink = computed(() => /^http[s]*:\/\//.test(tipUrl.value) ? tipUrl : `http://${tipUrl.value}`);
+    const tipLink = computed(() => /^http[s]*:\/\//.test(tipUrl.value) ? tipUrl.value : `http://${tipUrl.value}`);
 
     return {
       AETERNITY_SYMBOL,

--- a/src/popup/pages/TransactionDetailsContent.vue
+++ b/src/popup/pages/TransactionDetailsContent.vue
@@ -348,6 +348,10 @@ export default defineComponent({
       .tip-url {
         width: 100%;
 
+        .copy-text {
+          width: 100%;
+        }
+
         .link-button {
           display: block;
         }

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -67,15 +67,19 @@ export default {
       `${getters.activeNetwork.backendUrl}/cache/events/?address=${address}&event=TipWithdrawn`,
     );
     if (response.message) return [];
-    const tipWithdrawnTransactions = (uniqBy(response, 'hash').map(({ amount, ...t }) => ({
+    const tipWithdrawnTransactions = (uniqBy(response, 'hash').map(({
+      amount, contract, height, data: { tx }, ...t
+    }) => ({
       tx: {
+        ...tx,
         address,
         amount,
-        contractId: t.contract,
+        contractId: contract,
         type: SCHEMA.TX_TYPE.contractCall,
       },
       ...t,
       microTime: new Date(t.createdAt).getTime(),
+      blockHeight: height,
       claim: true,
     })));
     commit('setTipWithdrawnTransactions', tipWithdrawnTransactions);


### PR DESCRIPTION
This PR:
- adding missing calim tip transaction info: `nonce`, `block height`
- using a proper type for a `to` prop in `LinkButton` using `tipUrl`

- Also handling a long tipUrl correcrtly 
  |Before|After|
  |--|--|
  |![image](https://user-images.githubusercontent.com/9008074/204574264-6d5128f8-41bc-459a-88d7-ce2c1e609c61.png)|![image](https://user-images.githubusercontent.com/9008074/204574448-1afad2ab-6976-4352-84fe-f95a9a292ed8.png)|
