### PR TITLE
Refactor: adjust button variants and colours to new style guide

### DIFF
--- a/src/popup/components/InviteItem.vue
+++ b/src/popup/components/InviteItem.vue
@@ -24,7 +24,7 @@
       <BtnMain
         v-else
         class="button"
-        variant="secondary"
+        variant="muted"
         @click="deleteItem"
       >
         {{ $t('pages.invite.delete') }}
@@ -46,7 +46,7 @@
       />
       <div class="centered-buttons">
         <BtnMain
-          variant="secondary"
+          variant="muted"
           @click="resetTopUpChanges"
         >
           {{ $t('pages.invite.collapse') }}

--- a/src/popup/components/Modals/Confirm.vue
+++ b/src/popup/components/Modals/Confirm.vue
@@ -10,7 +10,7 @@
     </template>
     <template #footer>
       <BtnMain
-        variant="secondary"
+        variant="muted"
         @click="cancel"
       >
         {{ $t('modals.cancel') }}

--- a/src/popup/components/Modals/ConfirmRawSign.vue
+++ b/src/popup/components/Modals/ConfirmRawSign.vue
@@ -40,7 +40,7 @@
     <template #footer>
       <BtnMain
         third
-        variant="secondary"
+        variant="muted"
         @click="cancel"
       >
         {{ $t('modals.cancel') }}

--- a/src/popup/components/Modals/ConfirmTransactionSign.vue
+++ b/src/popup/components/Modals/ConfirmTransactionSign.vue
@@ -99,7 +99,7 @@
     <template #footer>
       <BtnMain
         third
-        variant="secondary"
+        variant="muted"
         data-cy="deny"
         @click="cancel()"
       >

--- a/src/popup/components/Modals/ErrorLog.vue
+++ b/src/popup/components/Modals/ErrorLog.vue
@@ -17,7 +17,7 @@
 
     <template #footer>
       <BtnMain
-        variant="secondary"
+        variant="muted"
         @click="cancel"
       >
         {{ $t('modals.cancel') }}

--- a/src/popup/components/Modals/ResetWallet.vue
+++ b/src/popup/components/Modals/ResetWallet.vue
@@ -20,7 +20,7 @@
     </div>
     <template #footer>
       <BtnMain
-        variant="secondary"
+        variant="muted"
         @click="reject"
       >
         {{ $t('pages.reset-wallet.cancel') }}

--- a/src/popup/components/Modals/SpendSuccess.vue
+++ b/src/popup/components/Modals/SpendSuccess.vue
@@ -38,7 +38,7 @@
     </div>
     <template #footer>
       <BtnMain
-        variant="secondary"
+        variant="muted"
         extend
         nowrap
         has-icon
@@ -67,8 +67,7 @@ import AvatarWithChainName from '../AvatarWithChainName.vue';
 import ModalHeader from '../ModalHeader.vue';
 import Pending from '../../../icons/animated-pending.svg?vue-component';
 import ExternalLink from '../../../icons/external-link-big.svg?vue-component';
-import { AETERNITY_SYMBOL } from '../../utils/constants';
-import { watchUntilTruthy } from '../../utils';
+import { AETERNITY_SYMBOL, watchUntilTruthy } from '../../utils';
 
 export default {
   components: {

--- a/src/popup/components/Modals/TransferSend.vue
+++ b/src/popup/components/Modals/TransferSend.vue
@@ -22,7 +22,7 @@
     <template #footer>
       <BtnMain
         v-if="showEditButton"
-        variant="secondary"
+        variant="muted"
         text="Edit"
         class="button-action-secondary"
         @click="editTransfer"
@@ -43,8 +43,7 @@
 
 <script>
 import { mapState, mapGetters } from 'vuex';
-import { MODAL_TRANSFER_SEND } from '../../utils/constants';
-import { validateTipUrl } from '../../utils/helper';
+import { MODAL_TRANSFER_SEND, validateTipUrl } from '../../utils';
 import Modal from '../Modal.vue';
 import BtnMain from '../buttons/BtnMain.vue';
 import TransferSendForm from '../TransferSendForm.vue';

--- a/src/popup/components/buttons/BtnMain.vue
+++ b/src/popup/components/buttons/BtnMain.vue
@@ -34,6 +34,7 @@ export default defineComponent({
       validator: (value: string) => [
         'primary',
         'secondary',
+        'muted',
         'alternative',
         'danger',
         'purple',
@@ -130,6 +131,10 @@ export default defineComponent({
   }
 
   &.secondary {
+    --color: #{variables.$color-secondary};
+  }
+
+  &.muted {
     --color: #{variables.$color-grey-medium};
 
     padding: 8px 32px;

--- a/src/popup/pages/Dashboard.vue
+++ b/src/popup/pages/Dashboard.vue
@@ -42,7 +42,7 @@
           </template>
           <BtnMain
             class="card-button"
-            variant="danger"
+            variant="secondary"
             inline
             :text="$t('dashboard.back-up-card.button')"
             :to="{ name: 'settings-seed-phrase' }"
@@ -63,7 +63,7 @@
             class="card-button"
             :text="$t('dashboard.buy-card.button')"
             :href="simplexLink"
-            variant="danger"
+            variant="secondary"
             inline
           />
         </Card>

--- a/src/popup/pages/DonateError.vue
+++ b/src/popup/pages/DonateError.vue
@@ -23,7 +23,7 @@
       {{ error.stack }}
     </p>
     <BtnMain
-      variant="secondary"
+      variant="muted"
       inline
       to="/"
     >

--- a/src/popup/pages/Index.vue
+++ b/src/popup/pages/Index.vue
@@ -86,7 +86,7 @@ import {
 import CheckBox from '../components/CheckBox.vue';
 import BtnSubheader from '../components/buttons/BtnSubheader.vue';
 import Platforms from '../components/Platforms.vue';
-import { MODAL_ACCOUNT_IMPORT } from '../utils/constants';
+import { MODAL_ACCOUNT_IMPORT } from '../utils';
 import SuperheroLogoIcon from '../../icons/logo.svg?vue-component';
 import PlusCircleIcon from '../../icons/plus-circle-fill.svg?vue-component';
 import CheckCircleIcon from '../../icons/check-circle-fill.svg?vue-component';
@@ -191,7 +191,7 @@ export default {
         }
 
         .aeternity-name {
-          color: variables.$color-danger;
+          color: variables.$color-secondary;
         }
       }
     }

--- a/src/popup/pages/NetworkForm.vue
+++ b/src/popup/pages/NetworkForm.vue
@@ -22,7 +22,7 @@
     <div class="button-wrapper">
       <BtnMain
         data-cy="cancel"
-        variant="secondary"
+        variant="muted"
         class="cancel-button"
         @click="goBack"
       >
@@ -52,7 +52,7 @@ import { mapActions, mapGetters } from 'vuex';
 import BtnMain from '../components/buttons/BtnMain.vue';
 import InputField from '../components/InputField.vue';
 import PlusCircleIcon from '../../icons/plus-circle.svg?vue-component';
-import { defaultNetwork } from '../utils/constants';
+import { defaultNetwork } from '../utils';
 
 export const NETWORK_PROPS = {
   url: null,

--- a/src/popup/pages/Networks.vue
+++ b/src/popup/pages/Networks.vue
@@ -18,7 +18,7 @@
 
     <BtnMain
       extend
-      variant="secondary"
+      variant="muted"
       class="add-custom-network"
       data-cy="to-add"
       has-icon

--- a/src/popup/pages/PermissionManager.vue
+++ b/src/popup/pages/PermissionManager.vue
@@ -102,7 +102,7 @@
         <BtnMain
           class="btn"
           extend
-          variant="secondary"
+          variant="muted"
           :to="{ name: 'permissions-settings' }"
         >
           {{ $t('pages.permissions.cancel') }}
@@ -120,7 +120,7 @@
         v-if="editView"
         extend
         has-icon
-        variant="secondary"
+        variant="muted"
         @click="onRemovePermission"
       >
         <DeleteIcon />

--- a/src/popup/pages/PermissionsSettings.vue
+++ b/src/popup/pages/PermissionsSettings.vue
@@ -26,7 +26,7 @@
     <BtnMain
       has-icon
       extend
-      variant="secondary"
+      variant="muted"
       :to="{ name: 'permissions-add' }"
     >
       <PlusIcon />

--- a/src/popup/pages/Popups/Connect.vue
+++ b/src/popup/pages/Popups/Connect.vue
@@ -39,7 +39,7 @@
 
     <template #footer>
       <BtnMain
-        variant="secondary"
+        variant="muted"
         data-cy="deny"
         @click="cancel()"
       >
@@ -61,12 +61,12 @@ import { mapState, mapGetters } from 'vuex';
 import {
   POPUP_CONNECT_ADDRESS_PERMISSION,
   POPUP_CONNECT_TRANSACTIONS_PERMISSION,
-} from '../../utils/constants';
+} from '../../utils';
+import mixin from './mixin';
 import Modal from '../../components/Modal.vue';
 import BtnMain from '../../components/buttons/BtnMain.vue';
 import TransactionInfo from '../../components/TransactionInfo.vue';
 import CheckMark from '../../../icons/check-mark.svg?vue-component';
-import mixin from './mixin';
 
 export default {
   components: {

--- a/src/popup/pages/Popups/MessageSign.vue
+++ b/src/popup/pages/Popups/MessageSign.vue
@@ -29,7 +29,7 @@
 
     <template #footer>
       <BtnMain
-        variant="secondary"
+        variant="muted"
         data-cy="deny"
         @click="cancel()"
       >

--- a/src/popup/pages/SeedPhraseDetailsSettings.vue
+++ b/src/popup/pages/SeedPhraseDetailsSettings.vue
@@ -50,7 +50,7 @@
         {{ $t('pages.seedPhrase.verifySeed') }}
       </BtnMain>
       <BtnMain
-        variant="secondary"
+        variant="muted"
         extend
         @click="setBackedUpSeed"
       >

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -21,6 +21,7 @@ $color-white: #fff;
 $color-black: #000;
 $color-primary: #1161fe;
 $color-primary-hover: #0e52d8;
+$color-secondary: #ff2b5e;
 $color-grey-light: #babac0;
 $color-grey-medium: #373737;
 $color-grey-dark: #787878;
@@ -44,7 +45,7 @@ $color-success: #00ff9d;
 $color-success-dark: #00d3a1;
 $color-success-hover: #00dc87;
 $color-warning: #ffb422;
-$color-danger: #ff2b5e;
+$color-danger: #ff4746;
 
 $color-bg-app: #141414;
 $color-bg-modal: $color-bg-4;


### PR DESCRIPTION
As mentioned in a [comment](https://github.com/aeternity/superhero-wallet/pull/1730#discussion_r1046891038) in PR related to [SW-42](https://github.com/aeternity/superhero-wallet/pull/1730):
- Newly introduced color (`#ff4746`) will be used as `$color-danger`. So from now on all "danger" places will use it.
- The color that we actually use as the "danger" (`#ff2b5e`) should be moved to the new variable `$color-secondary.`
- The `BtnMain` `variant="secondary"` should use instead of gray the color `$color-secondary` (the pink).
- The old secondary variant of `BtnMain` should be replaced with muted. Please remember to align every occurance of the `BtnMain` with `variant="secondary"` prop.