### PR TITLE
[SW-586] Enable withdraw test

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -10,7 +10,6 @@
   "ignoreTestFiles": [
     "tip.js",
     "transaction-details.js",
-    "transactions.js",
-    "withdraw.js"
+    "transactions.js"
   ]
 }

--- a/src/popup/components/Modals/SpendSuccess.vue
+++ b/src/popup/components/Modals/SpendSuccess.vue
@@ -5,6 +5,7 @@
     from-bottom
     centered
     :body-without-padding-bottom="hasPayload"
+    data-cy="spend-success"
     @close="resolve"
   >
     <ModalHeader

--- a/src/popup/components/Modals/TransferSend.vue
+++ b/src/popup/components/Modals/TransferSend.vue
@@ -25,8 +25,9 @@
       <BtnMain
         v-if="showEditButton"
         variant="muted"
-        text="Edit"
+        :text="$t('pages.send.edit')"
         class="button-action-secondary"
+        data-cy="edit"
         @click="editTransfer"
       />
       <BtnMain
@@ -34,6 +35,7 @@
         :disabled="error || !isConnected || !transferData.address || !transferData.amount"
         :has-icon="showSendButton"
         :text="showSendButton ? $t('pages.send.send') : $t('modals.send.next')"
+        data-cy="next-step-button"
         @click="proceedToNextStep"
       >
         {{ showSendButton ? $t('pages.send.send') : $t('modals.send.next') }}

--- a/src/popup/components/TransferReview.vue
+++ b/src/popup/components/TransferReview.vue
@@ -46,7 +46,6 @@
     >
       <template #value>
         <TokenAmount
-          data-cy="review-total"
           :amount="+transferData.amount"
           :symbol="tokenSymbol"
           :hide-fiat="isSelectedAssetAex9"
@@ -80,7 +79,7 @@
           symbol="AE"
           hide-fiat
           high-precision
-          data-cy="review-fee"
+          data-cy="review-total"
         />
       </template>
     </DetailsItem>

--- a/src/popup/components/TransferSendForm.vue
+++ b/src/popup/components/TransferSendForm.vue
@@ -46,6 +46,7 @@
         min_tip_amount: isTipUrl,
       }"
       name="amount"
+      data-cy="amount"
       class="amount-input"
       show-tokens-with-balance
       :message="errors.first('amount')"

--- a/src/popup/locales/en.json
+++ b/src/popup/locales/en.json
@@ -247,6 +247,7 @@
       "successTitle": "Transaction successfully submitted",
       "recipientLabel": "Recipient",
       "recipientPlaceholder": "Enter address, .chain name or URL",
+      "edit": "Edit",
       "next": "Next",
       "payload": "Payload"
     },

--- a/src/popup/pages/Dashboard.vue
+++ b/src/popup/pages/Dashboard.vue
@@ -21,6 +21,7 @@
           :disabled="!isConnected"
           clickable
           dense
+          data-cy="send"
           @click="openTransferSendModal()"
         >
           <template #icon>

--- a/src/popup/utils/config.js
+++ b/src/popup/utils/config.js
@@ -6,6 +6,10 @@ export const testAccount = {
   address: 'ak_2fxchiLvnj9VADMAXHBiKPsaCEsTFehAspcmWJ3ZzF3pFK1hB5',
 };
 
+export const STUB_CURRENCY = [{
+  id: 'aeternity', symbol: 'ae', name: 'Aeternity', image: 'https://assets.coingecko.com/coins/images/1091/large/aeternity.png?1547035060', current_price: 0.076783, market_cap: 31487891, market_cap_rank: 523, fully_diluted_valuation: null, total_volume: 217034, high_24h: 0.078539, low_24h: 0.076793, price_change_24h: -0.001092194951687525, price_change_percentage_24h: -1.4025, market_cap_change_24h: -429134.39267925173, market_cap_change_percentage_24h: -1.34453, circulating_supply: 409885828.49932, total_supply: 536306702.0, max_supply: null, ath: 5.69, ath_change_percentage: -98.65091, ath_date: '2018-04-29T03:50:39.593Z', atl: 0.059135, atl_change_percentage: 29.84246, atl_date: '2020-03-13T02:29:11.856Z', roi: { times: -0.725775445642378, currency: 'usd', percentage: -72.57754456423778 }, last_updated: '2023-01-17T11:38:23.610Z',
+}];
+
 export const popupProps = {
   connectConfirm: {
     type: 'connectConfirm',

--- a/tests/e2e/integration/withdraw.js
+++ b/tests/e2e/integration/withdraw.js
@@ -1,4 +1,7 @@
+import BigNumber from 'bignumber.js';
+
 const address = 'ak_2fxchiLvnj9VADMAXHBiKPsaCEsTFehAspcmWJ3ZzF3pFK1hB5';
+const amount = 0.1;
 
 describe('Test cases for Withdraw Page', () => {
   it('Opens Withdraw page, uses scan button, validates entered amount, reviews and sends ', () => {
@@ -9,26 +12,26 @@ describe('Test cases for Withdraw Page', () => {
       .click()
       .get('.qr-code-reader video')
       .should('be.visible')
-      .get('.modal .button-plain.close')
+      .get('.modal.qr-code-reader [data-cy=btn-close]')
       .click()
 
-      .enterInputAmount(0.2)
-      .get('[data-cy=input-wrapper]')
+      .enterInputAmount(amount)
+      .get('[data-cy=amount]')
       .should('not.have.class', 'error')
       .enterAddress('asd')
-      .inputShouldHaveError('[data-cy=address] [data-cy=input-wrapper]')
+      .inputShouldHaveError('[data-cy=address]')
       .enterAddress(0)
-      .inputShouldHaveError('[data-cy=address] [data-cy=input-wrapper]')
+      .inputShouldHaveError('[data-cy=address]')
       .enterAddress('test.chain')
       .should('not.have.class', 'error')
       .enterAddress('ak_wMHNCzQJ4HUL3TZ1fi6nQsHg6TjmHLs1bPXSp8iQ1VmxGNAZ4')
-      .get('[data-cy=address] [data-cy=input-wrapper]')
+      .get('[data-cy=address]')
       .should('not.have.class', 'error')
 
-      .get('[data-cy=review-withdraw]')
+      .get('[data-cy=next-step-button]')
       .should('not.have.class', 'disabled')
       .click()
-      .get('div.review-buttons')
+      .get('[data-cy=next-step-button]')
       .should('be.visible')
 
       // check on step2 if everything is OK
@@ -43,23 +46,31 @@ describe('Test cases for Withdraw Page', () => {
         const n1 = getNum(total);
         cy.get('[data-cy=review-fee]').invoke('text').then((fee) => {
           const n2 = getNum(fee);
-          cy.expect(n1 - n2).to.eq(0.2);
+          cy.expect(BigNumber(n1).minus(n2).toNumber()).to.eq(amount);
         });
       })
 
-      // edit sending address to .chain name
-      .get('[data-cy=reivew-editTxDetails-button]')
+      // edit, sending to your own account
+      .get('[data-cy=edit]')
       .click()
-      .enterAddress('test.chain')
-      .get('[data-cy=review-withdraw]')
+      .enterAddress(address)
+      .get('[data-cy=address]')
+      .should('have.class', 'warning')
+      .get('[data-cy=next-step-button]')
+      .should('not.have.class', 'disabled')
       .click()
       .get('[data-cy=review-recipient] > .value')
-      .should('contain', 'test.chain')
+      .should('contain', address)
 
       // send
-      .get('[data-cy="review-send-button"]')
+      .get('[data-cy=edit] + [data-cy=next-step-button]')
       .should('be.visible')
       .click()
+      .get('[data-cy=spend-success]', { timeout: 10000 })
+      .should('be.visible')
+      .get('[data-cy=btn-close]')
+      .click()
+      .openTransactions()
       .get('[data-cy=pending-txs]')
       .should('be.visible');
   });

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -139,7 +139,7 @@ Cypress.Commands.add('pendingTx', (tx = {}) => {
 });
 
 Cypress.Commands.add('enterInputAmount', (amount = 0) => {
-  cy.get('[data-cy=input-number]').clear().type(amount);
+  cy.get('[data-cy=amount] [data-cy=input]').clear().type(amount);
 });
 
 Cypress.Commands.add('goBack', () => {
@@ -147,7 +147,7 @@ Cypress.Commands.add('goBack', () => {
 });
 
 Cypress.Commands.add('enterAddress', (address) => {
-  cy.get('[data-cy=address] input').clear().type(address);
+  cy.get('[data-cy=address] [data-cy=input]').clear().type(address);
 });
 
 Cypress.Commands.add(

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -1,7 +1,14 @@
 import '../../../src/lib/initPolyfills';
 import { v4 as uuid } from 'uuid';
 import { ROUTE_ACCOUNT_DETAILS_TRANSACTIONS } from '../../../src/popup/router/routeNames';
-import { formatDate, formatTime, getLoginState } from '../../../src/popup/utils';
+import { STUB_CURRENCY } from '../../../src/popup/utils/config';
+import {
+  formatDate,
+  formatTime,
+  getLoginState,
+  CURRENCY_URL,
+  CURRENCIES_URL,
+} from '../../../src/popup/utils';
 
 Cypress.Commands.add('openPopup', (onBeforeLoad, route) => {
   cy.visit(`${route ? `#${route}` : ''}`, { onBeforeLoad });
@@ -41,7 +48,13 @@ Cypress.Commands.add('shouldHasErrorMessage', (el) => {
   cy.get(el).should('exist').should('be.visible');
 });
 
-Cypress.Commands.add('login', (options = {}, route) => {
+Cypress.Commands.add('mockExternalRequests', () => {
+  cy.intercept('GET', CURRENCY_URL, STUB_CURRENCY);
+  cy.intercept('GET', CURRENCIES_URL, { aeternity: { usd: 0.05 } });
+});
+
+Cypress.Commands.add('login', (options = {}, route, isMockingExternalRequests = true) => {
+  if (isMockingExternalRequests) cy.mockExternalRequests();
   cy.openPopup(async (contentWindow) => {
     /* eslint-disable-next-line no-param-reassign */
     contentWindow.localStorage.state = JSON.stringify(await getLoginState(options));


### PR DESCRIPTION
- on reviewing #1727, found out an error that could've been intercepted by this disabled test,
- our automated tests were overloading `api.coingecko` and it was throwing `429 (Too Many Requests)`, which resulting in a broken `balances` composable (#1782)