### PR TITLE
[SW-636] Improve multisig performance

### DIFF
--- a/src/composables/multisigAccounts.ts
+++ b/src/composables/multisigAccounts.ts
@@ -112,7 +112,9 @@ export function useMultisigAccounts({ store }: IDefaultComposableOptions) {
               )
                 ? contractInstance.methods.get_nonce()
                 : { decodedResult: currentAccount.nonce },
-              contractInstance.methods.get_signers(),
+              currentAccount?.signers
+                ? { decodedResult: currentAccount.signers }
+                : contractInstance.methods.get_signers(),
               contractInstance.methods.get_consensus_info(),
               gaAccountId ? sdk.balance(gaAccountId) : 0,
             ]);

--- a/src/popup/pages/MultisigDetails.vue
+++ b/src/popup/pages/MultisigDetails.vue
@@ -71,7 +71,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent } from '@vue/composition-api';
+import { defineComponent, onMounted, onBeforeUnmount } from '@vue/composition-api';
 import { useGetter } from '../../composables/vuex';
 import { useMultisigAccounts } from '../../composables';
 
@@ -96,7 +96,11 @@ export default defineComponent({
   setup(props, { root }) {
     const getExplorerPath = useGetter('getExplorerPath');
 
-    const { activeMultisigAccount } = useMultisigAccounts({ store: root.$store });
+    const {
+      activeMultisigAccount,
+      fetchAdditionalInfo,
+      stopFetchingAdditionalInfo,
+    } = useMultisigAccounts({ store: root.$store });
 
     const {
       multisigAccountId,
@@ -106,6 +110,10 @@ export default defineComponent({
       signers,
       consensusLabel,
     } = activeMultisigAccount.value || {} as IMultisigAccount;
+
+    onMounted(fetchAdditionalInfo);
+
+    onBeforeUnmount(stopFetchingAdditionalInfo);
 
     return {
       multisigAccountId,

--- a/src/popup/pages/MultisigProposalDetails.vue
+++ b/src/popup/pages/MultisigProposalDetails.vue
@@ -252,6 +252,7 @@ import {
   defineComponent,
   ref,
   onMounted,
+  onBeforeUnmount,
 } from '@vue/composition-api';
 import { SCHEMA } from '@aeternity/aepp-sdk';
 import {
@@ -315,6 +316,8 @@ export default defineComponent({
     const {
       activeMultisigAccount,
       updateMultisigAccounts,
+      fetchAdditionalInfo,
+      stopFetchingAdditionalInfo,
     } = useMultisigAccounts({ store: root.$store });
 
     const {
@@ -440,8 +443,11 @@ export default defineComponent({
     onMounted(async () => {
       if (activeMultisigAccount.value) {
         getTransactionDetails();
+        fetchAdditionalInfo();
       }
     });
+
+    onBeforeUnmount(stopFetchingAdditionalInfo);
 
     return {
       AETERNITY_SYMBOL,


### PR DESCRIPTION
Table of dry runs called every 7 seconds

**with additional info** means that some pages demand additional info (`MultisigDetails`, `MultisigProposalDetails`), but we will have one more dry-run and only for active account
|Multisig info|Before|After (with additional info)|After (without additional info)|
|---|---|---|---|
|1 visible vault|**3** dry-runs | **2** dry-runs|**1** dry-run|
|10 visible vaults|**30** dry-runs | **11** dry-runs|**10** dry-runs|