### PR TITLE
[SW-699] fix: show asset selector correctly on firefox

### DIFF
--- a/src/popup/components/FungibleTokens/TokensListItem.vue
+++ b/src/popup/components/FungibleTokens/TokensListItem.vue
@@ -8,6 +8,7 @@
         id: tokenData.contractId,
       },
     }"
+    :extend="preventNavigation"
     :selected="selected"
     v-on="$listeners"
   >

--- a/src/popup/components/Modals/AssetSelector.vue
+++ b/src/popup/components/Modals/AssetSelector.vue
@@ -128,6 +128,8 @@ export default defineComponent({
   }
 
   .appearing-element {
+    position: fixed;
+    width: 100%;
     opacity: 0;
     z-index: -1;
     transition: opacity 0.25s ease-in-out;


### PR DESCRIPTION
missed in #1790 