### PR TITLE
[SW-719] firefox & safari input validation

### DIFF
--- a/src/popup/components/InputField.vue
+++ b/src/popup/components/InputField.vue
@@ -59,7 +59,6 @@
             autocomplete="off"
             step="any"
             data-cy="input"
-            :type="type"
             :value="value"
             :disabled="readonly"
             :maxlength="textLimit"


### PR DESCRIPTION
Needed to remove the native browser input validation cause it's causing issues for Safari & Firefox

we already have custom logic for validating number withing `<InputField` `checkIfNumber` so this removal is safe