### PR TITLE
feat(send-modal): handle payload in query

### DIFF
--- a/src/popup/components/TransferSendForm.vue
+++ b/src/popup/components/TransferSendForm.vue
@@ -362,6 +362,7 @@ export default defineComponent({
         || aeternityToken.value;
       if (query.account) formModel.value.address = query.account;
       if (query.amount) formModel.value.amount = query.amount;
+      if (query.payload) formModel.value.payload = query.payload;
     }
 
     function setMaxValue() {


### PR DESCRIPTION
Functionality that is requested in #2041, #2042 can be implemented in this way. So we would be able get `payload` from query same as other parameters: `amount`, `token`, `account`.
https://feature-handle-payload-in-send-modal-query.wallet.z52da5wt.xyz/account?account=ak_zmzmiPdG7mgppzh2Kb9wpm8MWgJTpdarRtF8EYhsPG7UbQ3Yh&token=AE&amount=11&payload=test