### PR TITLE
[SW-896] fix: show auctions for an existing name correctly

### DIFF
--- a/src/popup/pages/Names/Auction.vue
+++ b/src/popup/pages/Names/Auction.vue
@@ -52,7 +52,7 @@ export default defineComponent({
       const middleware = await getMiddleware();
       try {
         const res = await middleware.getNameById(props.name);
-        const { auctionEnd, bids } = res.info;
+        const { auctionEnd, bids } = res.auction ?? res.info;
         const loadedBids = await Promise.all(bids.map(async (txId: number) => {
           const { tx } = await middleware.getTxByIndex(txId);
           return {


### PR DESCRIPTION
In order to check this PR you need to find, or to start auction for a name that expired. Now it is easy to check on `ae86.chain` name on mainnet.

https://github.com/aeternity/ae_mdw/issues/1294