### PR TITLE
[SW-905] fix: do not save warnings in develop mode

### DIFF
--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -21,16 +21,14 @@ export default class Logger {
 
     if (!background) {
       Vue.config.errorHandler = (error, vm, info) => {
-        console.error(info);
-        console.error(error);
+        console.error(error, info);
         if (error && error instanceof RejectedByUserError) {
           Logger.write({ message: error.toString(), info, type: 'vue-error' });
         }
       };
 
       Vue.config.warnHandler = (message, vm, info) => {
-        console.warn(message);
-        console.warn(info);
+        console.warn(message, info);
       };
     }
 

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -29,13 +29,8 @@ export default class Logger {
       };
 
       Vue.config.warnHandler = (message, vm, info) => {
-        console.error(message);
-        console.error(info);
-        Logger.write({
-          message,
-          stack: info,
-          type: 'vue-warn',
-        });
+        console.warn(message);
+        console.warn(info);
       };
     }
 


### PR DESCRIPTION
part of #1799 
- `warnHandler` is ignored in production mode, saving logs in the dev mode is pointless https://vuejs.org/api/application.html#app-config-warnhandler
- current implementation of `warnHandler` function results in infinite loop of warnings and saving them to the logs (which cause 100% core usage)