### PR TITLE
fix: translation issues on pluralization

### DIFF
--- a/src/popup/utils/utils.ts
+++ b/src/popup/utils/utils.ts
@@ -17,6 +17,7 @@ import {
 import { AeSdkWallet } from '@aeternity/aepp-sdk-13';
 import { mnemonicToSeed } from '@aeternity/bip39';
 import { derivePathFromKey, getKeyPair } from '@aeternity/hd-wallet/src/hd-key';
+import { useI18n } from 'vue-i18n';
 import { testAccount, txParams } from './testsConfig';
 import {
   ADDRESS_TYPES,
@@ -242,19 +243,20 @@ export function escapeSpecialChars(str = '') {
 }
 
 export function secondsToRelativeTime(seconds: number) {
+  const { t } = useI18n();
   const secondsPerMinute = 60;
   const secondsPerHour = secondsPerMinute * 60;
   const secondsPerDay = secondsPerHour * 24;
   if (seconds < secondsPerMinute) {
-    return i18n.global.rt('common.seconds', Math.round(seconds));
+    return t('common.seconds', Math.round(seconds));
   }
   if (seconds < secondsPerHour) {
-    return i18n.global.rt('common.minutes', Math.round(seconds / secondsPerMinute));
+    return t('common.minutes', Math.round(seconds / secondsPerMinute));
   }
   if (seconds < secondsPerDay) {
-    return i18n.global.rt('common.hours', Math.round(seconds / secondsPerHour));
+    return t('common.hours', Math.round(seconds / secondsPerHour));
   }
-  return i18n.global.rt('common.days', Math.round(seconds / secondsPerDay));
+  return t('common.days', Math.round(seconds / secondsPerDay));
 }
 
 export function blocksToRelativeTime(blocks: number) {


### PR DESCRIPTION
In vue-i18n @ 9 pluralization with .tc is working only on legacy API mode which we are not using. So changed to use useI18n hook. 
For more read [here](https://vue-i18n.intlify.dev/guide/essentials/pluralization.html)
