### PR TITLE
[SW-946] refactor: remove splash screen preferences from config file

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -106,12 +106,7 @@
         <splash height="480" src="resources/ios/splash/Default~iphone.png" width="320" />
         <splash height="2732" src="resources/ios/splash/Default@2x~universal~anyany.png" width="2732" />
     </platform>
-    <preference name="SplashScreen" value="screen" />
-    <preference name="ShowSplashScreenSpinner" value="false" />
     <preference name="StatusBarOverlaysWebView" value="false" />
     <preference name="StatusBarBackgroundColor" value="#141414" />
     <preference name="BackgroundColor" value="0xff141414" />
-    <feature name="SplashScreen">
-        <param name="onload" value="true" />
-    </feature>
 </widget>


### PR DESCRIPTION
Removed preferences from `config.xml` . Already added new configuration at initial commit of `feature/migrate-to-ionic` branch