### PR TITLE
[SW-901] Add popup for aepps requesting all account addreseses

### DIFF
--- a/src/popup/components/TransactionInfo.vue
+++ b/src/popup/components/TransactionInfo.vue
@@ -27,6 +27,11 @@
           v-if="recipient.aens"
           class="icon"
         />
+        <SHLogo
+          v-if="recipient.wallet"
+          class="icon logo"
+        />
+
         <ActionIcon
           v-else
           class="icon"
@@ -57,6 +62,7 @@ import type { IAccountOverview } from '../../types';
 import TriangleRight from '../../icons/triangle-right.svg?vue-component';
 import ActionIcon from '../../icons/action.svg?vue-component';
 import AensIcon from '../../icons/aens.svg?vue-component';
+import SHLogo from '../../icons/logo-small.svg?vue-component';
 
 import Avatar from './Avatar.vue';
 import TransactionInfoDetailsParty from './TransactionInfoDetailsParty.vue';
@@ -71,6 +77,7 @@ export default defineComponent({
     ActionIcon,
     AensIcon,
     Avatar,
+    SHLogo,
   },
   props: {
     sender: { type: Object as PropType<IAccountOverview>, required: true },
@@ -100,6 +107,10 @@ export default defineComponent({
       width: 36px;
       height: 36px;
       color: variables.$color-white;
+    }
+
+    .logo {
+      color: variables.$color-primary;
     }
 
     .mid {

--- a/src/popup/components/TransactionInfoDetailsParty.vue
+++ b/src/popup/components/TransactionInfoDetailsParty.vue
@@ -15,6 +15,12 @@
       />
     </a>
     <span
+      v-else-if="txParty.wallet"
+      class="wallet"
+    >
+      {{ $t('common.title') }}
+    </span>
+    <span
       v-else
       class="name"
       :class="{ aens: txParty.aens }"
@@ -76,12 +82,14 @@ export default defineComponent({
     padding-left: $padding-middle;
     padding-right: $padding-edge;
 
-    .name {
+    .name,
+    .wallet {
       text-align: right;
     }
   }
 
-  .name {
+  .name,
+  .wallet {
     @extend %face-sans-15-medium;
 
     display: block;

--- a/src/popup/locales/cn.json
+++ b/src/popup/locales/cn.json
@@ -252,7 +252,7 @@
       "remaining-time": "剩余时间"
     },
     "connectConfirm": {
-      "websiteRequestconnect": "想要连接到你的帐户",
+      "websiteRequestConnect": "想要连接到你的帐户",
       "websiteRequest": "网站请求查看你的当前地址。请确认当前网站可信。 ",
       "cancelButton": "拒绝",
       "confirmButton": "接受",

--- a/src/popup/locales/de.json
+++ b/src/popup/locales/de.json
@@ -194,7 +194,7 @@
       "remaining-time": "Verbleibende Zeit"
     },
     "connectConfirm": {
-      "websiteRequestconnect": "möchte Ihr Konto verbinden",
+      "websiteRequestConnect": "möchte Ihr Konto verbinden",
       "websiteRequest": "Diese Webseite fordert Zugriff Ihr Girokonto-Adresse anzuzeigen. Achten Sie stets darauf, die Website vertrauen Sie wirken mit.",
       "cancelButton": "Stornieren",
       "confirmButton": "Bestätigen",

--- a/src/popup/locales/en.json
+++ b/src/popup/locales/en.json
@@ -33,6 +33,7 @@
     "send": "Send",
     "smartContract": "Smart contract",
     "swap": "Swap",
+    "title": "Superhero wallet",
     "total": "Total",
     "totalMultisig": "Total in multisig vaults",
     "tx": "Tx",
@@ -558,9 +559,14 @@
       "remaining-time": "Remaining Time",
       "ending-height": "Ending height"
     },
+    "accountListConfirm": {
+      "websiteRequestConnect": "would like to connect to your Superhero wallet.",
+      "addressesRequest": "This aepp is requesting access to view all of your account addresses.",
+      "message": "Make sure you trust the aepp provider before accepting the request."
+    },
     "connectConfirm": {
       "title": "Allow access",
-      "websiteRequestconnect": "would like to connect to your account.",
+      "websiteRequestConnect": "would like to connect to your account.",
       "websiteRequest": "This website is requesting access to view your current account address. Always make sure you trust the website you interact with. ",
       "cancelButton": "Deny",
       "confirmButton": "Accept",
@@ -1086,6 +1092,7 @@
     "permissions": {
       "login": "Don't ask for login requests",
       "message-sign": "Auto-sign messages",
+      "addressList": "Don't ask for list of all addresses",
       "daily-spending-limit": "Daily spending limit without asking",
       "transaction-sign": "Limit for spending without asking per day",
       "spent-today": "Spent today",

--- a/src/popup/locales/es.json
+++ b/src/popup/locales/es.json
@@ -245,7 +245,7 @@
       "remaining-time": "Tiempo restante"
     },
     "connectConfirm": {
-      "websiteRequestconnect": "le gustaría conectarse a su cuenta",
+      "websiteRequestConnect": "le gustaría conectarse a su cuenta",
       "websiteRequest": "Este sitio web está solicitando acceso para ver tu dirección de cuenta actual. Siempre asegúrate que confías en el sitio web con el que interactúas. ",
       "cancelButton": "Denegar",
       "confirmButton": "Aceptar",

--- a/src/popup/locales/fr.json
+++ b/src/popup/locales/fr.json
@@ -199,7 +199,7 @@
       "remaining-time": "Temps restant"
     },
     "connectConfirm": {
-      "websiteRequestconnect": "souhaite se connecter à votre compte",
+      "websiteRequestConnect": "souhaite se connecter à votre compte",
       "websiteRequest": "Ce site demande l'accès pour afficher votre adresse de compte courant. Assurez-vous toujours confiance au site Web vous interagissez avec. ",
       "cancelButton": "Annuler",
       "confirmButton": "Confirmer",

--- a/src/popup/locales/it.json
+++ b/src/popup/locales/it.json
@@ -196,7 +196,7 @@
       "remaining-time": "Tempo rimanente"
     },
     "connectConfirm": {
-      "websiteRequestconnect": "vorrebbe connettersi al proprio account",
+      "websiteRequestConnect": "vorrebbe connettersi al proprio account",
       "websiteRequest": "Questo sito richiede l'accesso per visualizzare l'indirizzo del conto corrente. Assicurarsi sempre di fiducia il sito web che interagiscono con. ",
       "cancelButton": "Annulla",
       "confirmButton": "Confermare",

--- a/src/popup/locales/ru.json
+++ b/src/popup/locales/ru.json
@@ -180,7 +180,7 @@
       "remaining-time": "Remaining Time"
     },
     "connectConfirm": {
-      "websiteRequestconnect": "would like to connect to your account",
+      "websiteRequestConnect": "would like to connect to your account",
       "websiteRequest": "This website is requesting access to view your current account address. Always make sure you trust the website you interact with. ",
       "cancelButton": "Deny",
       "confirmButton": "Accept",

--- a/src/popup/pages/PermissionManager.vue
+++ b/src/popup/pages/PermissionManager.vue
@@ -56,6 +56,13 @@
 
     <div class="permission-row switch">
       <SwitchButton
+        v-model="permission.addressList"
+        :label="$t('pages.permissions.addressList')"
+      />
+    </div>
+
+    <div class="permission-row switch">
+      <SwitchButton
         v-model="permission.messageSign"
         :label="$t('pages.permissions.message-sign')"
       />

--- a/src/popup/pages/Popups/AccountList.vue
+++ b/src/popup/pages/Popups/AccountList.vue
@@ -2,13 +2,13 @@
   <Modal
     show
     full-screen
-    class="connect"
+    class="account-list"
     data-cy="popup-aex2"
   >
     <TransactionInfo
       :custom-title="$t('pages.connectConfirm.title')"
       :sender="sender"
-      :recipient="activeAccountExtended"
+      :recipient="recipient"
     />
 
     <div
@@ -16,7 +16,7 @@
       data-cy="aepp"
     >
       <span class="app-name">{{ sender.name }}</span>
-      ({{ sender.address }}) {{ $t('pages.connectConfirm.websiteRequestConnect') }}
+      ({{ sender.address }}) {{ $t('pages.accountListConfirm.websiteRequestConnect') }}
     </div>
 
     <div class="permissions">
@@ -24,17 +24,14 @@
         <span class="title">
           <CheckMark class="icon" /> {{ $t('common.address') }}
         </span>
-        <span class="description">
-          {{ $t('pages.connectConfirm.addressRequest') }}
-        </span>
-      </template>
-      <template v-if="access.includes(POPUP_CONNECT_TRANSACTIONS_PERMISSION)">
-        <span class="title">
-          <CheckMark class="icon" /> {{ $t('pages.connectConfirm.transactionLabel') }}
-        </span>
-        <span class="description">
-          {{ $t('pages.connectConfirm.transactionRequest') }}
-        </span>
+        <div class="description">
+          <p>
+            {{ $t('pages.accountListConfirm.addressesRequest') }}
+          </p>
+          <p class="color-warning">
+            {{ $t('pages.accountListConfirm.message') }}
+          </p>
+        </div>
       </template>
     </div>
 
@@ -63,15 +60,14 @@ import {
   onUnmounted,
 } from 'vue';
 import { useStore } from 'vuex';
-import type { IPermission } from '../../../types';
+import type { IAccountOverview, IPermission } from '../../../types';
 import { RejectedByUserError } from '../../../lib/errors';
 import {
   PERMISSION_DEFAULTS,
   POPUP_CONNECT_ADDRESS_PERMISSION,
-  POPUP_CONNECT_TRANSACTIONS_PERMISSION,
 } from '../../utils';
 import { useState } from '../../../composables/vuex';
-import { useAccounts, usePopupProps } from '../../../composables';
+import { usePopupProps } from '../../../composables';
 
 import Modal from '../../components/Modal.vue';
 import BtnMain from '../../components/buttons/BtnMain.vue';
@@ -90,19 +86,21 @@ export default defineComponent({
       type: Array,
       default: () => ([
         POPUP_CONNECT_ADDRESS_PERMISSION,
-        POPUP_CONNECT_TRANSACTIONS_PERMISSION,
       ]),
     },
   },
   setup() {
     const store = useStore();
 
-    const { activeAccountExtended } = useAccounts({ store });
     const { popupProps, sender, setPopupProps } = usePopupProps();
 
     const permission = useState<IPermission>('permissions', popupProps.value?.app?.host);
 
     const appName = computed(() => permission.value?.name || popupProps.value?.app?.name);
+
+    const recipient: IAccountOverview = {
+      wallet: 'Superhero Wallet',
+    };
 
     function confirm() {
       store.commit('permissions/addPermission', {
@@ -127,21 +125,20 @@ export default defineComponent({
 
     return {
       POPUP_CONNECT_ADDRESS_PERMISSION,
-      POPUP_CONNECT_TRANSACTIONS_PERMISSION,
-      activeAccountExtended,
       sender,
       confirm,
       cancel,
+      recipient,
     };
   },
 });
 </script>
 
 <style lang="scss" scoped>
-@use '../../../styles/variables';
+@use '../../../styles/variables' as *;
 @use '../../../styles/typography';
 
-.connect {
+.account-list {
   .transaction-info {
     margin-bottom: 16px;
   }
@@ -151,11 +148,11 @@ export default defineComponent({
 
     margin-top: 24px;
     margin-bottom: 16px;
-    color: variables.$color-grey-light;
+    color: $color-grey-light;
     text-align: center;
 
     .app-name {
-      color: variables.$color-white;
+      color: $color-white;
     }
   }
 
@@ -168,12 +165,12 @@ export default defineComponent({
       display: flex;
       align-items: center;
       padding-bottom: 4px;
-      color: variables.$color-grey-dark;
+      color: $color-grey-dark;
 
       .icon {
         width: 24px;
         height: 24px;
-        color: variables.$color-success;
+        color: $color-success;
         padding-right: 4px;
       }
     }
@@ -183,7 +180,7 @@ export default defineComponent({
 
       display: block;
       padding-bottom: 16px;
-      color: variables.$color-white;
+      color: $color-white;
       text-align: left;
     }
   }

--- a/src/popup/router/index.ts
+++ b/src/popup/router/index.ts
@@ -16,12 +16,13 @@ import store from '../../store';
 import initSdk from '../../lib/wallet';
 import {
   APP_LINK_WEB,
+  watchUntilTruthy,
   POPUP_TYPE_CONNECT,
   POPUP_TYPE_SIGN,
   POPUP_TYPE_MESSAGE_SIGN,
   POPUP_TYPE_RAW_SIGN,
-  watchUntilTruthy,
   POPUP_TYPE_TX_SIGN,
+  POPUP_TYPE_ACCOUNT_LIST,
 } from '../utils';
 import {
   RUNNING_IN_POPUP,
@@ -78,6 +79,7 @@ router.beforeEach(async (to, from, next) => {
   if (RUNNING_IN_POPUP && to.name !== ROUTE_NOT_FOUND) {
     const name = {
       [POPUP_TYPE_CONNECT]: 'connect',
+      [POPUP_TYPE_ACCOUNT_LIST]: 'account-list',
       [POPUP_TYPE_SIGN]: 'popup-sign-tx',
       [POPUP_TYPE_RAW_SIGN]: 'popup-raw-sign',
       [POPUP_TYPE_MESSAGE_SIGN]: 'message-sign',

--- a/src/popup/router/modals.ts
+++ b/src/popup/router/modals.ts
@@ -8,6 +8,7 @@ import {
   MODAL_CONFIRM_TRANSACTION_SIGN,
   MODAL_CONFIRM_RAW_SIGN,
   MODAL_CONFIRM_CONNECT,
+  MODAL_CONFIRM_ACCOUNT_LIST,
   MODAL_ERROR_LOG,
   MODAL_FORM_SELECT_OPTIONS,
   MODAL_HELP,
@@ -89,6 +90,9 @@ export default () => {
     showInPopupIfWebFrame: true,
   });
   registerModal(MODAL_CONFIRM_CONNECT, {
+    showInPopupIfWebFrame: true,
+  });
+  registerModal(MODAL_CONFIRM_ACCOUNT_LIST, {
     showInPopupIfWebFrame: true,
   });
   registerModal(MODAL_MESSAGE_SIGN, {

--- a/src/popup/router/routes.ts
+++ b/src/popup/router/routes.ts
@@ -67,6 +67,7 @@ import ErrorLogSettings from '../pages/ErrorLogSettings.vue';
 import PermissionsSettings from '../pages/PermissionsSettings.vue';
 import PermissionManager from '../pages/PermissionManager.vue';
 import PopupConnect from '../pages/Popups/Connect.vue';
+import PopupAccountList from '../pages/Popups/AccountList.vue';
 import PopupMessageSign from '../pages/Popups/MessageSign.vue';
 import PrivacyPolicy from '../pages/PrivacyPolicy.vue';
 import Retip from '../pages/Retip.vue';
@@ -314,6 +315,15 @@ export const routes: WalletAppRouteConfig[] = [
     name: 'message-sign',
     path: '/message-sign',
     component: PopupMessageSign,
+    props: true,
+    meta: {
+      notPersist: true,
+    },
+  },
+  {
+    name: 'account-list',
+    path: '/account-list',
+    component: PopupAccountList,
     props: true,
     meta: {
       notPersist: true,

--- a/src/popup/router/webIframePopups.ts
+++ b/src/popup/router/webIframePopups.ts
@@ -5,6 +5,7 @@ import { IN_POPUP, IS_WEB } from '../../lib/environment';
 import { RejectedByUserError } from '../../lib/errors';
 import {
   MODAL_CONFIRM_CONNECT,
+  MODAL_CONFIRM_ACCOUNT_LIST,
   MODAL_CONFIRM_RAW_SIGN,
   MODAL_CONFIRM_TRANSACTION_SIGN,
   MODAL_MESSAGE_SIGN,
@@ -12,6 +13,7 @@ import {
 import { ROUTE_WEB_IFRAME_POPUP } from './routeNames';
 
 import ConfirmConnect from '../pages/Popups/Connect.vue';
+import ConfirmAccountList from '../pages/Popups/AccountList.vue';
 import ConfirmRawSign from '../components/Modals/ConfirmRawSign.vue';
 import ConfirmTransactionSign from '../components/Modals/ConfirmTransactionSign.vue';
 import MessageSign from '../pages/Popups/MessageSign.vue';
@@ -46,6 +48,7 @@ const createIframeComponent = (component: Component | VNode) => {
 const webIframePopups: WalletAppRouteConfig[] = (IS_WEB && IN_POPUP)
   ? [
     { name: MODAL_CONFIRM_CONNECT, component: ConfirmConnect },
+    { name: MODAL_CONFIRM_ACCOUNT_LIST, component: ConfirmAccountList },
     { name: MODAL_CONFIRM_RAW_SIGN, component: ConfirmRawSign },
     { name: MODAL_CONFIRM_TRANSACTION_SIGN, component: ConfirmTransactionSign },
     { name: MODAL_MESSAGE_SIGN, component: MessageSign },

--- a/src/popup/utils/constants.ts
+++ b/src/popup/utils/constants.ts
@@ -458,6 +458,7 @@ export const MODAL_CONFIRM = 'confirm';
 export const MODAL_CONFIRM_TRANSACTION_SIGN = 'confirm-transaction-sign';
 export const MODAL_CONFIRM_RAW_SIGN = 'confirm-raw-sign';
 export const MODAL_CONFIRM_CONNECT = 'confirm-connect';
+export const MODAL_CONFIRM_ACCOUNT_LIST = 'confirm-account-list';
 export const MODAL_MESSAGE_SIGN = 'confirm-message-sign';
 export const MODAL_ERROR_LOG = 'error-log';
 export const MODAL_HELP = 'help';
@@ -543,6 +544,7 @@ export const DEX_TRANSACTION_TAGS: Record<TxFunctionRaw, string> = {
 } as const;
 
 export const POPUP_TYPE_CONNECT = 'connectConfirm';
+export const POPUP_TYPE_ACCOUNT_LIST = 'account-list';
 export const POPUP_TYPE_SIGN = 'sign';
 export const POPUP_TYPE_MESSAGE_SIGN = 'messageSign';
 export const POPUP_TYPE_RAW_SIGN = 'rawSign';
@@ -550,6 +552,7 @@ export const POPUP_TYPE_TX_SIGN = METHODS.sign;
 
 export const POPUP_TYPES = [
   POPUP_TYPE_CONNECT,
+  POPUP_TYPE_ACCOUNT_LIST,
   POPUP_TYPE_SIGN,
   POPUP_TYPE_MESSAGE_SIGN,
   POPUP_TYPE_RAW_SIGN,
@@ -563,6 +566,7 @@ export const PERMISSION_DEFAULTS: IPermission = {
   host: '',
   name: '',
   address: false,
+  addressList: false,
   messageSign: false,
   dailySpendLimit: false,
   transactionSignLimit: 0,

--- a/src/popup/utils/testsConfig.ts
+++ b/src/popup/utils/testsConfig.ts
@@ -18,6 +18,7 @@ import {
   STUB_CONTRACT_ADDRESS,
   STUB_TOKEN_CONTRACT_ADDRESS,
   AETERNITY_COIN_ID,
+  POPUP_TYPE_ACCOUNT_LIST,
 } from './constants';
 import { CoinGeckoMarketResponse } from '../../lib/CoinGecko';
 
@@ -36,6 +37,15 @@ export const STUB_CURRENCY: CoinGeckoMarketResponse = {
 export const popupProps: Record<string, IPopupConfig> = {
   [POPUP_TYPE_CONNECT]: {
     type: POPUP_TYPE_CONNECT,
+    app: {
+      url: 'http://localhost:5000/aepp/aepp',
+      name: 'AEPP',
+      protocol: 'http:',
+      host: 'localhost',
+    },
+  },
+  [POPUP_TYPE_ACCOUNT_LIST]: {
+    type: POPUP_TYPE_ACCOUNT_LIST,
     app: {
       url: 'http://localhost:5000/aepp/aepp',
       name: 'AEPP',

--- a/src/store/modules/permissions.js
+++ b/src/store/modules/permissions.js
@@ -78,6 +78,7 @@ export default {
         'connection.open': 'address',
         'address.subscribe': 'address',
         'message.sign': 'messageSign',
+        'address.get': 'addressList',
       };
       return state[host]?.[permissionsMethods[method]];
     },
@@ -86,6 +87,18 @@ export default {
       connectionPopupCb,
     }) {
       if (await dispatch('checkPermissions', { host, method: 'connection.open' })) return true;
+      try {
+        await connectionPopupCb();
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    async requestAllAddressesForHost({ dispatch }, {
+      host,
+      connectionPopupCb,
+    }) {
+      if (await dispatch('checkPermissions', { host, method: 'address.get' })) return true;
       try {
         await connectionPopupCb();
         return true;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -170,6 +170,7 @@ export interface IAccountOverview extends Partial<Omit<IAccount, 'address'>> {
   contractCreate?: boolean;
   aens?: boolean;
   label?: TranslateResult;
+  wallet?: string; // Is the whole Wallet is being accessed by an Aepp
 }
 
 export interface IMultisigConsensus {
@@ -241,6 +242,7 @@ export interface INetwork extends INetworkBase {
 
 export interface IPermission {
   address: boolean
+  addressList: boolean,
   host: string
   messageSign: boolean
   name: string
@@ -406,15 +408,6 @@ export interface IStoreTransactions {
 
 export interface IDashboardTransaction extends ITransaction {
   direction?: 'received' | 'send'
-}
-
-export interface IAccountOverView extends Partial<Omit<IAccount, 'address'>> {
-  // TODO: use a proper type for a address since it can be a url
-  address?: Encoded.AccountAddress | string;
-  url?: string;
-  contractCreate?: boolean;
-  aens?: boolean;
-  label?: TranslateResult;
 }
 
 export interface IActiveMultisigTransaction extends IMultisigAccount {

--- a/tests/e2e/integration/aex2-popups.js
+++ b/tests/e2e/integration/aex2-popups.js
@@ -5,11 +5,17 @@ import {
   POPUP_TYPE_SIGN,
   POPUP_TYPE_RAW_SIGN,
   POPUP_TYPE_MESSAGE_SIGN,
+  POPUP_TYPE_ACCOUNT_LIST,
 } from '../../../src/popup/utils';
 import { popupProps, txParams } from '../../../src/popup/utils/testsConfig';
 import locale from '../../../src/popup/locales/en.json';
 
-const popups = [POPUP_TYPE_CONNECT, POPUP_TYPE_SIGN, POPUP_TYPE_MESSAGE_SIGN];
+const popups = [
+  POPUP_TYPE_CONNECT,
+  POPUP_TYPE_SIGN,
+  POPUP_TYPE_MESSAGE_SIGN,
+  POPUP_TYPE_ACCOUNT_LIST,
+];
 
 const txTags = [
   Tag.SpendTx,
@@ -22,7 +28,7 @@ describe('Tests cases for AEX-2 popups', () => {
     cy.login();
   });
 
-  it('Sign Message popup, Connect, Raw Sign display correct data', () => {
+  it('Sign Message popup, Connect, Account list, Raw Sign display correct data', () => {
     const props = popupProps[POPUP_TYPE_MESSAGE_SIGN];
     cy.openAex2Popup(POPUP_TYPE_MESSAGE_SIGN)
       .get('[data-cy=aepp]')
@@ -50,6 +56,13 @@ describe('Tests cases for AEX-2 popups', () => {
       .get('[data-cy=sender]')
       .should('be.visible')
       .should('contain', props2.app.host);
+
+    const props3 = popupProps[POPUP_TYPE_ACCOUNT_LIST];
+    cy.openAex2Popup(POPUP_TYPE_ACCOUNT_LIST)
+      .get('[data-cy=aepp]')
+      .should('be.visible')
+      .should('contain', props3.app.name)
+      .should('contain', props3.app.host);
   });
 
   it('Opens connectConfirm, sign, messageSign popups and send accept/deny action', () => {


### PR DESCRIPTION
You need an aepp requesting all account addresses to test this. I have deployed one.
1. use the extension from this artifact
2. visit aepp https://subhod-i.github.io/ 
3. click 'Connect', First aepp will request for typical connection popup and then the second popup is where it is requesting all the account addresses. See if it is according to the design and test by toggling the new permission settings.

