### PR TITLE
[SW-947] feature/remove cordova headercolor plugin

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -20,7 +20,6 @@
     <platform name="android">
         <allow-intent href="market:*" />
         <preference name="SplashMaintainAspectRatio" value="true" />
-        <preference name="HeaderColor" value="#141414" />
         <preference name="android-targetSdkVersion" value="30" />
         <resource-file src="resources/values/colors.xml" target="/app/src/main/res/values/colors.xml" />
         <icon background="@color/background" density="ldpi" foreground="resources/android/icon/ldpi-foreground.png" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "camelcase-keys-deep": "^0.1.0",
         "cordova-clipboard": "^1.3.0",
         "cordova-ios": "^6.2.0",
-        "cordova-plugin-headercolor": "^1.0.0",
         "cordova-plugin-network-information": "^3.0.0",
         "cordova-plugin-x-socialsharing": "^6.0.4",
         "dayjs": "^1.11.7",
@@ -16125,10 +16124,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
-    },
-    "node_modules/cordova-plugin-headercolor": {
-      "version": "1.0.0",
-      "license": "MIT"
     },
     "node_modules/cordova-plugin-network-information": {
       "version": "3.0.0",
@@ -55080,9 +55075,6 @@
           "dev": true
         }
       }
-    },
-    "cordova-plugin-headercolor": {
-      "version": "1.0.0"
     },
     "cordova-plugin-network-information": {
       "version": "3.0.0"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "camelcase-keys-deep": "^0.1.0",
     "cordova-clipboard": "^1.3.0",
     "cordova-ios": "^6.2.0",
-    "cordova-plugin-headercolor": "^1.0.0",
     "cordova-plugin-network-information": "^3.0.0",
     "cordova-plugin-x-socialsharing": "^6.0.4",
     "dayjs": "^1.11.7",


### PR DESCRIPTION
This plugin seems to be obsolete in "newer" android versions (iOS was never supported). Check its functionality [here](https://github.com/tomloprod/cordova-plugin-headercolor)
Also, there is no capacitor replacement for this plugin 