### PR TITLE
[SW-969] perf: initialize tipping contracts only if needed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,6 @@
         "lodash-es": "^4.17.21",
         "qr-code-styling": "github:aeternity/qr-code-styling",
         "swiper": "^5.4.5",
-        "tipping-contract": "github:aeternity/tipping-contract#v3.1.0-alpha2",
         "ts-jest": "26.5.6",
         "uuid": "^8.3.2",
         "validator": "^13.7.0",
@@ -37022,50 +37021,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/tipping-contract": {
-      "version": "1.0.0",
-      "resolved": "git+https://git@github.com/aeternity/tipping-contract.git#26a4dbb6a0ac7329d88874d6d390fa2dcb54677e",
-      "hasInstallScript": true,
-      "license": "ISC",
-      "dependencies": {
-        "@aeternity/aepp-sdk": "8.1.0",
-        "bignumber.js": "^9.0.1",
-        "esm": "^3.2.25",
-        "prompts": "^2.4.1"
-      }
-    },
-    "node_modules/tipping-contract/node_modules/@aeternity/aepp-sdk": {
-      "version": "8.1.0",
-      "license": "ISC",
-      "dependencies": {
-        "@aeternity/bip39": "^0.1.0",
-        "@aeternity/json-bigint": "^0.3.1",
-        "@babel/runtime-corejs3": "^7.13.17",
-        "@stamp/it": "^1.1.0",
-        "@stamp/required": "^1.0.1",
-        "aes-js": "^3.1.2",
-        "bignumber.js": "^9.0.1",
-        "bip32-path": "^0.4.2",
-        "blakejs": "^1.1.0",
-        "bs58check": "^2.1.2",
-        "buffer": "^6.0.3",
-        "cross-fetch": "^3.1.4",
-        "crypto-browserify": "^3.12.0",
-        "ed2curve": "^0.3.0",
-        "joi-browser": "^13.4.0",
-        "libsodium-wrappers-sumo": "0.7.9",
-        "path-browserify": "^1.0.1",
-        "ramda": "^0.27.1",
-        "rlp": "2.2.6",
-        "sha.js": "^2.4.11",
-        "stream-browserify": "^3.0.0",
-        "swagger-client": "^3.13.2",
-        "tweetnacl": "^1.0.3",
-        "tweetnacl-auth": "^1.0.1",
-        "uuid": "^8.3.2",
-        "websocket": "^1.0.34"
-      }
-    },
     "node_modules/tmp": {
       "version": "0.2.1",
       "dev": true,
@@ -67429,49 +67384,6 @@
     "timsort": {
       "version": "0.3.0",
       "dev": true
-    },
-    "tipping-contract": {
-      "version": "git+https://git@github.com/aeternity/tipping-contract.git#26a4dbb6a0ac7329d88874d6d390fa2dcb54677e",
-      "from": "tipping-contract@github:aeternity/tipping-contract#v3.1.0-alpha2",
-      "requires": {
-        "@aeternity/aepp-sdk": "8.1.0",
-        "bignumber.js": "^9.0.1",
-        "esm": "^3.2.25",
-        "prompts": "^2.4.1"
-      },
-      "dependencies": {
-        "@aeternity/aepp-sdk": {
-          "version": "8.1.0",
-          "requires": {
-            "@aeternity/bip39": "^0.1.0",
-            "@aeternity/json-bigint": "^0.3.1",
-            "@babel/runtime-corejs3": "^7.13.17",
-            "@stamp/it": "^1.1.0",
-            "@stamp/required": "^1.0.1",
-            "aes-js": "^3.1.2",
-            "bignumber.js": "^9.0.1",
-            "bip32-path": "^0.4.2",
-            "blakejs": "^1.1.0",
-            "bs58check": "^2.1.2",
-            "buffer": "^6.0.3",
-            "cross-fetch": "^3.1.4",
-            "crypto-browserify": "^3.12.0",
-            "ed2curve": "^0.3.0",
-            "joi-browser": "^13.4.0",
-            "libsodium-wrappers-sumo": "0.7.9",
-            "path-browserify": "^1.0.1",
-            "ramda": "^0.27.1",
-            "rlp": "2.2.6",
-            "sha.js": "^2.4.11",
-            "stream-browserify": "^3.0.0",
-            "swagger-client": "^3.13.2",
-            "tweetnacl": "^1.0.3",
-            "tweetnacl-auth": "^1.0.1",
-            "uuid": "^8.3.2",
-            "websocket": "^1.0.34"
-          }
-        }
-      }
     },
     "tmp": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "lodash-es": "^4.17.21",
     "qr-code-styling": "github:aeternity/qr-code-styling",
     "swiper": "^5.4.5",
-    "tipping-contract": "github:aeternity/tipping-contract#v3.1.0-alpha2",
     "ts-jest": "26.5.6",
     "uuid": "^8.3.2",
     "validator": "^13.7.0",

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -15,6 +15,7 @@ export * from './notifications';
 export * from './pendingMultisigTransaction';
 export * from './sdk';
 export * from './sdk13';
+export * from './tippingContracts';
 export * from './tokensList';
 export * from './topHeader';
 export * from './transactionTx';

--- a/src/composables/sdk13.ts
+++ b/src/composables/sdk13.ts
@@ -121,8 +121,6 @@ export function useSdk13({ store }: IDefaultComposableOptions) {
 
     connectFrames(sdk);
 
-    store.dispatch('initTippingContractInstances');
-
     sdkBlocked = false;
   }
 

--- a/src/composables/tippingContracts.ts
+++ b/src/composables/tippingContracts.ts
@@ -1,0 +1,66 @@
+import { computed, ref } from '@vue/composition-api';
+import TIPPING_V1_INTERFACE from 'tipping-contract/Tipping_v1_Interface.aes';
+import TIPPING_V2_INTERFACE from 'tipping-contract/Tipping_v2_Interface.aes';
+
+import { useSdk } from './sdk';
+import { watchUntilTruthy } from '../popup/utils';
+import {
+  IDefaultComposableOptions,
+  INetwork,
+} from '../types';
+
+const tippingV1 = ref<any>(null);
+const tippingV2 = ref<any>(null);
+const initializing = ref(false);
+
+export function useTippingContracts({ store }: IDefaultComposableOptions) {
+  const { getSdk } = useSdk({ store });
+
+  const activeNetwork = computed<INetwork>(() => store.getters.activeNetwork);
+  const tippingSupported = computed(() => store.getters.tippingSupported);
+
+  async function initTippingContracts() {
+    if (!tippingSupported && !process.env.RUNNING_IN_TESTS) {
+      return;
+    }
+    initializing.value = true;
+    const sdk = await getSdk();
+
+    const [
+      contractInstanceV1,
+      contractInstanceV2,
+    ] = await Promise.all([
+      sdk.getContractInstance({
+        source: TIPPING_V1_INTERFACE,
+        contractAddress: activeNetwork.value.tipContractV1,
+      }),
+      activeNetwork.value.tipContractV2
+        ? sdk.getContractInstance({
+          source: TIPPING_V2_INTERFACE,
+          contractAddress: activeNetwork.value.tipContractV2,
+        })
+        : null,
+    ]);
+    tippingV1.value = contractInstanceV1;
+    tippingV2.value = contractInstanceV2;
+
+    initializing.value = false;
+  }
+
+  async function getTippingContracts(): Promise<any> {
+    if (
+      !tippingV1.value
+      || tippingV1.value.deployInfo.address !== activeNetwork.value.tipContractV1
+    ) {
+      await initTippingContracts();
+    } else if (initializing.value) {
+      await watchUntilTruthy(tippingV1);
+    }
+    return { tippingV1, tippingV2 };
+  }
+
+  return {
+    initTippingContracts,
+    getTippingContracts,
+  };
+}

--- a/src/composables/tippingContracts.ts
+++ b/src/composables/tippingContracts.ts
@@ -1,8 +1,8 @@
 import { computed, ref } from '@vue/composition-api';
-import TIPPING_V1_INTERFACE from 'tipping-contract/Tipping_v1_Interface.aes';
-import TIPPING_V2_INTERFACE from 'tipping-contract/Tipping_v2_Interface.aes';
 import { Contract } from '@aeternity/aepp-sdk-13';
 
+import TippingV1ACI from '../lib/contracts/TippingV1ACI.json';
+import TippingV2ACI from '../lib/contracts/TippingV2ACI.json';
 import { RUNNING_IN_TESTS } from '../lib/environment';
 import { useSdk13 } from './sdk13';
 import { watchUntilTruthy } from '../popup/utils';
@@ -39,12 +39,12 @@ export function useTippingContracts({ store }: IDefaultComposableOptions) {
       tippingV2,
     ] = await Promise.all([
       sdk.initializeContract<TippingV1ContractApi>({
-        sourceCode: TIPPING_V1_INTERFACE,
+        aci: TippingV1ACI,
         address: activeNetwork.value.tipContractV1,
       }),
       activeNetwork.value.tipContractV2
         ? sdk.initializeContract<TippingV2ContractApi>({
-          sourceCode: TIPPING_V2_INTERFACE,
+          aci: TippingV2ACI,
           address: activeNetwork.value.tipContractV2,
         })
         : undefined,

--- a/src/composables/tippingContracts.ts
+++ b/src/composables/tippingContracts.ts
@@ -1,66 +1,74 @@
 import { computed, ref } from '@vue/composition-api';
 import TIPPING_V1_INTERFACE from 'tipping-contract/Tipping_v1_Interface.aes';
 import TIPPING_V2_INTERFACE from 'tipping-contract/Tipping_v2_Interface.aes';
+import { Contract } from '@aeternity/aepp-sdk-13';
 
-import { useSdk } from './sdk';
+import { RUNNING_IN_TESTS } from '../lib/environment';
+import { useSdk13 } from './sdk13';
 import { watchUntilTruthy } from '../popup/utils';
 import {
   IDefaultComposableOptions,
   INetwork,
+  TippingV1ContractApi,
+  TippingV2ContractApi,
 } from '../types';
 
-const tippingV1 = ref<any>(null);
-const tippingV2 = ref<any>(null);
+interface TippingContracts {
+  tippingV1: Contract<TippingV1ContractApi>;
+  tippingV2?: Contract<TippingV2ContractApi>;
+}
+
+let tippingV1: Contract<TippingV1ContractApi> | undefined;
+let tippingV2: Contract<TippingV2ContractApi> | undefined;
 const initializing = ref(false);
 
 export function useTippingContracts({ store }: IDefaultComposableOptions) {
-  const { getSdk } = useSdk({ store });
+  const { getSdk } = useSdk13({ store });
 
   const activeNetwork = computed<INetwork>(() => store.getters.activeNetwork);
-  const tippingSupported = computed(() => store.getters.tippingSupported);
 
   async function initTippingContracts() {
-    if (!tippingSupported && !process.env.RUNNING_IN_TESTS) {
+    if (!store.getters.tippingSupported && !RUNNING_IN_TESTS) {
       return;
     }
     initializing.value = true;
     const sdk = await getSdk();
 
-    const [
-      contractInstanceV1,
-      contractInstanceV2,
+    [
+      tippingV1,
+      tippingV2,
     ] = await Promise.all([
-      sdk.getContractInstance({
-        source: TIPPING_V1_INTERFACE,
-        contractAddress: activeNetwork.value.tipContractV1,
+      sdk.initializeContract<TippingV1ContractApi>({
+        sourceCode: TIPPING_V1_INTERFACE,
+        address: activeNetwork.value.tipContractV1,
       }),
       activeNetwork.value.tipContractV2
-        ? sdk.getContractInstance({
-          source: TIPPING_V2_INTERFACE,
-          contractAddress: activeNetwork.value.tipContractV2,
+        ? sdk.initializeContract<TippingV2ContractApi>({
+          sourceCode: TIPPING_V2_INTERFACE,
+          address: activeNetwork.value.tipContractV2,
         })
-        : null,
+        : undefined,
     ]);
-    tippingV1.value = contractInstanceV1;
-    tippingV2.value = contractInstanceV2;
 
     initializing.value = false;
   }
 
-  async function getTippingContracts(): Promise<any> {
+  async function getTippingContracts(): Promise<TippingContracts> {
     if (
-      !tippingV1.value
-      || tippingV1.value.deployInfo.address !== activeNetwork.value.tipContractV1
+      !tippingV1
+      || tippingV1.$options.address !== activeNetwork.value.tipContractV1
     ) {
       await initTippingContracts();
     } else if (initializing.value) {
-      await watchUntilTruthy(tippingV1);
+      await watchUntilTruthy(() => !initializing.value);
+    }
+    if (!tippingV1) {
+      throw Error('failed to initialize tipping contract');
     }
     return { tippingV1, tippingV2 };
   }
 
   return {
-    initTippingContracts,
     getTippingContracts,
   };
 }

--- a/src/lib/contracts/TippingV1ACI.json
+++ b/src/lib/contracts/TippingV1ACI.json
@@ -1,0 +1,433 @@
+[
+  {
+      "namespace": {
+          "name": "ListInternal",
+          "typedefs": []
+      }
+  },
+  {
+      "contract": {
+          "functions": [
+              {
+                  "arguments": [
+                      {
+                          "name": "_1",
+                          "type": "string"
+                      },
+                      {
+                          "name": "_2",
+                          "type": "address"
+                      },
+                      {
+                          "name": "_3",
+                          "type": "bool"
+                      }
+                  ],
+                  "name": "check_persist_claim",
+                  "payable": false,
+                  "returns": "OracleService.success_claim",
+                  "stateful": true
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "_1",
+                          "type": "string"
+                      },
+                      {
+                          "name": "_2",
+                          "type": "address"
+                      }
+                  ],
+                  "name": "query_oracle",
+                  "payable": true,
+                  "returns": "unit",
+                  "stateful": true
+              }
+          ],
+          "kind": "contract_interface",
+          "name": "OracleService",
+          "payable": false,
+          "typedefs": [
+              {
+                  "name": "success_claim",
+                  "typedef": {
+                      "record": [
+                          {
+                              "name": "success",
+                              "type": "bool"
+                          },
+                          {
+                              "name": "caller",
+                              "type": "address"
+                          },
+                          {
+                              "name": "percentage",
+                              "type": "int"
+                          }
+                      ]
+                  },
+                  "vars": []
+              }
+          ]
+      }
+  },
+  {
+      "contract": {
+          "event": {
+              "variant": [
+                  {
+                      "TipReceived": [
+                          "address",
+                          "int",
+                          "Tipping.url"
+                      ]
+                  },
+                  {
+                      "ReTipReceived": [
+                          "address",
+                          "int",
+                          "Tipping.url"
+                      ]
+                  },
+                  {
+                      "TipWithdrawn": [
+                          "address",
+                          "int",
+                          "Tipping.url"
+                      ]
+                  }
+              ]
+          },
+          "functions": [
+              {
+                  "arguments": [
+                      {
+                          "name": "oracle_service",
+                          "type": "OracleService"
+                      },
+                      {
+                          "name": "owner",
+                          "type": "address"
+                      }
+                  ],
+                  "name": "init",
+                  "payable": false,
+                  "returns": "Tipping.state",
+                  "stateful": false
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "oracle_service",
+                          "type": "OracleService"
+                      }
+                  ],
+                  "name": "change_oracle_service",
+                  "payable": false,
+                  "returns": {
+                      "tuple": []
+                  },
+                  "stateful": true
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "url",
+                          "type": "string"
+                      },
+                      {
+                          "name": "title",
+                          "type": "string"
+                      }
+                  ],
+                  "name": "tip",
+                  "payable": true,
+                  "returns": "unit",
+                  "stateful": true
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "tip_id",
+                          "type": "Tipping.tip_id"
+                      }
+                  ],
+                  "name": "retip",
+                  "payable": true,
+                  "returns": "unit",
+                  "stateful": true
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "url",
+                          "type": "string"
+                      },
+                      {
+                          "name": "expected_account",
+                          "type": "address"
+                      }
+                  ],
+                  "name": "pre_claim",
+                  "payable": true,
+                  "returns": {
+                      "tuple": []
+                  },
+                  "stateful": true
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "url",
+                          "type": "string"
+                      },
+                      {
+                          "name": "account",
+                          "type": "address"
+                      },
+                      {
+                          "name": "recheck",
+                          "type": "bool"
+                      }
+                  ],
+                  "name": "claim",
+                  "payable": false,
+                  "returns": {
+                      "tuple": []
+                  },
+                  "stateful": true
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "new_contract",
+                          "type": "address"
+                      }
+                  ],
+                  "name": "migrate_balance",
+                  "payable": false,
+                  "returns": {
+                      "tuple": []
+                  },
+                  "stateful": true
+              },
+              {
+                  "arguments": [],
+                  "name": "get_state",
+                  "payable": false,
+                  "returns": "Tipping.state",
+                  "stateful": false
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "url",
+                          "type": "string"
+                      }
+                  ],
+                  "name": "tips_for_url",
+                  "payable": false,
+                  "returns": {
+                      "list": [
+                          "Tipping.tip"
+                      ]
+                  },
+                  "stateful": false
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "tip_id",
+                          "type": "Tipping.tip_id"
+                      }
+                  ],
+                  "name": "retips_for_tip",
+                  "payable": false,
+                  "returns": {
+                      "list": [
+                          "Tipping.retip"
+                      ]
+                  },
+                  "stateful": false
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "url",
+                          "type": "string"
+                      }
+                  ],
+                  "name": "unclaimed_for_url",
+                  "payable": false,
+                  "returns": "int",
+                  "stateful": false
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "url",
+                          "type": "string"
+                      },
+                      {
+                          "name": "expected_account",
+                          "type": "address"
+                      }
+                  ],
+                  "name": "check_claim",
+                  "payable": false,
+                  "returns": "OracleService.success_claim",
+                  "stateful": false
+              }
+          ],
+          "kind": "contract_main",
+          "name": "Tipping",
+          "payable": false,
+          "state": {
+              "record": [
+                  {
+                      "name": "urls",
+                      "type": {
+                          "map": [
+                              "Tipping.url",
+                              "Tipping.url_id"
+                          ]
+                      }
+                  },
+                  {
+                      "name": "claims",
+                      "type": {
+                          "map": [
+                              "Tipping.url_id",
+                              {
+                                  "tuple": [
+                                      "Tipping.claim_gen",
+                                      "int"
+                                  ]
+                              }
+                          ]
+                      }
+                  },
+                  {
+                      "name": "url_index",
+                      "type": {
+                          "map": [
+                              "Tipping.url_id",
+                              "Tipping.url"
+                          ]
+                      }
+                  },
+                  {
+                      "name": "tips",
+                      "type": {
+                          "map": [
+                              "Tipping.tip_id",
+                              "Tipping.tip"
+                          ]
+                      }
+                  },
+                  {
+                      "name": "retips",
+                      "type": {
+                          "map": [
+                              "Tipping.retip_id",
+                              "Tipping.retip"
+                          ]
+                      }
+                  },
+                  {
+                      "name": "owner",
+                      "type": "address"
+                  },
+                  {
+                      "name": "oracle_service",
+                      "type": "OracleService"
+                  }
+              ]
+          },
+          "typedefs": [
+              {
+                  "name": "tip_id",
+                  "typedef": "int",
+                  "vars": []
+              },
+              {
+                  "name": "url_id",
+                  "typedef": "int",
+                  "vars": []
+              },
+              {
+                  "name": "retip_id",
+                  "typedef": "int",
+                  "vars": []
+              },
+              {
+                  "name": "url",
+                  "typedef": "string",
+                  "vars": []
+              },
+              {
+                  "name": "claim_gen",
+                  "typedef": "int",
+                  "vars": []
+              },
+              {
+                  "name": "tip",
+                  "typedef": {
+                      "record": [
+                          {
+                              "name": "sender",
+                              "type": "address"
+                          },
+                          {
+                              "name": "title",
+                              "type": "string"
+                          },
+                          {
+                              "name": "claim_gen",
+                              "type": "Tipping.claim_gen"
+                          },
+                          {
+                              "name": "timestamp",
+                              "type": "int"
+                          },
+                          {
+                              "name": "url_id",
+                              "type": "Tipping.url_id"
+                          },
+                          {
+                              "name": "amount",
+                              "type": "int"
+                          }
+                      ]
+                  },
+                  "vars": []
+              },
+              {
+                  "name": "retip",
+                  "typedef": {
+                      "record": [
+                          {
+                              "name": "sender",
+                              "type": "address"
+                          },
+                          {
+                              "name": "amount",
+                              "type": "int"
+                          },
+                          {
+                              "name": "claim_gen",
+                              "type": "Tipping.claim_gen"
+                          },
+                          {
+                              "name": "tip_id",
+                              "type": "Tipping.tip_id"
+                          }
+                      ]
+                  },
+                  "vars": []
+              }
+          ]
+      }
+  }
+]

--- a/src/lib/contracts/TippingV2ACI.json
+++ b/src/lib/contracts/TippingV2ACI.json
@@ -1,0 +1,647 @@
+[
+  {
+      "namespace": {
+          "name": "ListInternal",
+          "typedefs": []
+      }
+  },
+  {
+      "contract": {
+          "functions": [
+              {
+                  "arguments": [
+                      {
+                          "name": "_1",
+                          "type": "address"
+                      },
+                      {
+                          "name": "_2",
+                          "type": "address"
+                      },
+                      {
+                          "name": "_3",
+                          "type": "int"
+                      }
+                  ],
+                  "name": "transfer_allowance",
+                  "payable": false,
+                  "returns": "unit",
+                  "stateful": true
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "_1",
+                          "type": "address"
+                      },
+                      {
+                          "name": "_2",
+                          "type": "int"
+                      }
+                  ],
+                  "name": "transfer",
+                  "payable": false,
+                  "returns": "unit",
+                  "stateful": true
+              }
+          ],
+          "kind": "contract_interface",
+          "name": "TokenContract",
+          "payable": false,
+          "typedefs": []
+      }
+  },
+  {
+      "contract": {
+          "functions": [
+              {
+                  "arguments": [
+                      {
+                          "name": "_1",
+                          "type": "string"
+                      },
+                      {
+                          "name": "_2",
+                          "type": "address"
+                      },
+                      {
+                          "name": "_3",
+                          "type": "bool"
+                      }
+                  ],
+                  "name": "check_persist_claim",
+                  "payable": false,
+                  "returns": "OracleService.success_claim",
+                  "stateful": true
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "_1",
+                          "type": "string"
+                      },
+                      {
+                          "name": "_2",
+                          "type": "address"
+                      }
+                  ],
+                  "name": "query_oracle",
+                  "payable": true,
+                  "returns": "unit",
+                  "stateful": true
+              }
+          ],
+          "kind": "contract_interface",
+          "name": "OracleService",
+          "payable": false,
+          "typedefs": [
+              {
+                  "name": "success_claim",
+                  "typedef": {
+                      "record": [
+                          {
+                              "name": "success",
+                              "type": "bool"
+                          },
+                          {
+                              "name": "account",
+                              "type": "address"
+                          },
+                          {
+                              "name": "percentage",
+                              "type": "int"
+                          }
+                      ]
+                  },
+                  "vars": []
+              }
+          ]
+      }
+  },
+  {
+      "contract": {
+          "event": {
+              "variant": [
+                  {
+                      "TipReceived": [
+                          "address",
+                          "Tipping.amount",
+                          "Tipping.url"
+                      ]
+                  },
+                  {
+                      "ReTipReceived": [
+                          "address",
+                          "Tipping.amount",
+                          "Tipping.url"
+                      ]
+                  },
+                  {
+                      "TipWithdrawn": [
+                          "address",
+                          "Tipping.amount",
+                          "Tipping.url"
+                      ]
+                  },
+                  {
+                      "TipTokenReceived": [
+                          "address",
+                          "Tipping.amount",
+                          "Tipping.url",
+                          "TokenContract"
+                      ]
+                  },
+                  {
+                      "ReTipTokenReceived": [
+                          "address",
+                          "Tipping.amount",
+                          "Tipping.url",
+                          "TokenContract"
+                      ]
+                  },
+                  {
+                      "TipDirectReceived": [
+                          "address",
+                          "Tipping.amount",
+                          "Tipping.receiver_str"
+                      ]
+                  },
+                  {
+                      "TipDirectTokenReceived": [
+                          "address",
+                          "Tipping.amount",
+                          "Tipping.receiver_str",
+                          "TokenContract"
+                      ]
+                  }
+              ]
+          },
+          "functions": [
+              {
+                  "arguments": [
+                      {
+                          "name": "oracle_service",
+                          "type": "OracleService"
+                      }
+                  ],
+                  "name": "init",
+                  "payable": false,
+                  "returns": "Tipping.state",
+                  "stateful": false
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "url",
+                          "type": "Tipping.url"
+                      },
+                      {
+                          "name": "title",
+                          "type": "string"
+                      }
+                  ],
+                  "name": "tip",
+                  "payable": true,
+                  "returns": "int",
+                  "stateful": true
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "url",
+                          "type": "Tipping.url"
+                      },
+                      {
+                          "name": "title",
+                          "type": "string"
+                      },
+                      {
+                          "name": "token",
+                          "type": "TokenContract"
+                      },
+                      {
+                          "name": "token_amount",
+                          "type": "int"
+                      }
+                  ],
+                  "name": "tip_token",
+                  "payable": false,
+                  "returns": "int",
+                  "stateful": true
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "receiver",
+                          "type": "Tipping.receiver"
+                      },
+                      {
+                          "name": "title",
+                          "type": "string"
+                      }
+                  ],
+                  "name": "tip_direct",
+                  "payable": true,
+                  "returns": "int",
+                  "stateful": true
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "receiver",
+                          "type": "Tipping.receiver"
+                      },
+                      {
+                          "name": "title",
+                          "type": "string"
+                      },
+                      {
+                          "name": "token",
+                          "type": "TokenContract"
+                      },
+                      {
+                          "name": "token_amount",
+                          "type": "int"
+                      }
+                  ],
+                  "name": "tip_token_direct",
+                  "payable": false,
+                  "returns": "int",
+                  "stateful": true
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "tip_id",
+                          "type": "Tipping.tip_id"
+                      }
+                  ],
+                  "name": "retip",
+                  "payable": true,
+                  "returns": "int",
+                  "stateful": true
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "tip_id",
+                          "type": "Tipping.tip_id"
+                      },
+                      {
+                          "name": "token",
+                          "type": "TokenContract"
+                      },
+                      {
+                          "name": "token_amount",
+                          "type": "int"
+                      }
+                  ],
+                  "name": "retip_token",
+                  "payable": false,
+                  "returns": "int",
+                  "stateful": true
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "url",
+                          "type": "Tipping.url"
+                      },
+                      {
+                          "name": "expected_account",
+                          "type": "address"
+                      }
+                  ],
+                  "name": "pre_claim",
+                  "payable": true,
+                  "returns": {
+                      "tuple": []
+                  },
+                  "stateful": true
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "url",
+                          "type": "Tipping.url"
+                      },
+                      {
+                          "name": "account",
+                          "type": "address"
+                      },
+                      {
+                          "name": "recheck",
+                          "type": "bool"
+                      }
+                  ],
+                  "name": "claim",
+                  "payable": false,
+                  "returns": {
+                      "tuple": []
+                  },
+                  "stateful": true
+              },
+              {
+                  "arguments": [],
+                  "name": "get_state",
+                  "payable": false,
+                  "returns": "Tipping.state",
+                  "stateful": false
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "url",
+                          "type": "Tipping.url"
+                      }
+                  ],
+                  "name": "tips_for_url",
+                  "payable": false,
+                  "returns": {
+                      "list": [
+                          "Tipping.tip"
+                      ]
+                  },
+                  "stateful": false
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "tip_id",
+                          "type": "Tipping.tip_id"
+                      }
+                  ],
+                  "name": "retips_for_tip",
+                  "payable": false,
+                  "returns": {
+                      "list": [
+                          "Tipping.retip"
+                      ]
+                  },
+                  "stateful": false
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "url",
+                          "type": "Tipping.url"
+                      }
+                  ],
+                  "name": "unclaimed_for_url",
+                  "payable": false,
+                  "returns": {
+                      "tuple": [
+                          "int",
+                          {
+                              "map": [
+                                  "TokenContract",
+                                  "int"
+                              ]
+                          }
+                      ]
+                  },
+                  "stateful": false
+              },
+              {
+                  "arguments": [
+                      {
+                          "name": "url",
+                          "type": "Tipping.url"
+                      },
+                      {
+                          "name": "expected_account",
+                          "type": "address"
+                      }
+                  ],
+                  "name": "check_claim",
+                  "payable": false,
+                  "returns": "OracleService.success_claim",
+                  "stateful": false
+              }
+          ],
+          "kind": "contract_main",
+          "name": "Tipping",
+          "payable": false,
+          "state": {
+              "record": [
+                  {
+                      "name": "urls",
+                      "type": {
+                          "map": [
+                              "Tipping.url",
+                              "Tipping.url_id"
+                          ]
+                      }
+                  },
+                  {
+                      "name": "claims",
+                      "type": {
+                          "map": [
+                              "Tipping.url_id",
+                              {
+                                  "tuple": [
+                                      "Tipping.claim_gen",
+                                      "int",
+                                      {
+                                          "map": [
+                                              "TokenContract",
+                                              "int"
+                                          ]
+                                      }
+                                  ]
+                              }
+                          ]
+                      }
+                  },
+                  {
+                      "name": "url_index",
+                      "type": {
+                          "map": [
+                              "Tipping.url_id",
+                              "Tipping.url"
+                          ]
+                      }
+                  },
+                  {
+                      "name": "tips",
+                      "type": {
+                          "map": [
+                              "Tipping.tip_id",
+                              "Tipping.tip"
+                          ]
+                      }
+                  },
+                  {
+                      "name": "retips",
+                      "type": {
+                          "map": [
+                              "Tipping.retip_id",
+                              "Tipping.retip"
+                          ]
+                      }
+                  },
+                  {
+                      "name": "oracle_service",
+                      "type": "OracleService"
+                  },
+                  {
+                      "name": "version",
+                      "type": "string"
+                  }
+              ]
+          },
+          "typedefs": [
+              {
+                  "name": "tip_id",
+                  "typedef": "int",
+                  "vars": []
+              },
+              {
+                  "name": "url_id",
+                  "typedef": "int",
+                  "vars": []
+              },
+              {
+                  "name": "retip_id",
+                  "typedef": "int",
+                  "vars": []
+              },
+              {
+                  "name": "url",
+                  "typedef": "string",
+                  "vars": []
+              },
+              {
+                  "name": "claim_gen",
+                  "typedef": "int",
+                  "vars": []
+              },
+              {
+                  "name": "amount",
+                  "typedef": "int",
+                  "vars": []
+              },
+              {
+                  "name": "receiver",
+                  "typedef": "address",
+                  "vars": []
+              },
+              {
+                  "name": "receiver_str",
+                  "typedef": "string",
+                  "vars": []
+              },
+              {
+                  "name": "tip",
+                  "typedef": {
+                      "variant": [
+                          {
+                              "AeTip": [
+                                  "Tipping.tip_meta",
+                                  "Tipping.url_id",
+                                  "Tipping.amount",
+                                  "Tipping.claim_gen"
+                              ]
+                          },
+                          {
+                              "TokenTip": [
+                                  "Tipping.tip_meta",
+                                  "Tipping.url_id",
+                                  "Tipping.tip_token_data",
+                                  "Tipping.claim_gen"
+                              ]
+                          },
+                          {
+                              "DirectAeTip": [
+                                  "Tipping.tip_meta",
+                                  "Tipping.receiver",
+                                  "Tipping.amount"
+                              ]
+                          },
+                          {
+                              "DirectTokenTip": [
+                                  "Tipping.tip_meta",
+                                  "Tipping.receiver",
+                                  "Tipping.tip_token_data"
+                              ]
+                          }
+                      ]
+                  },
+                  "vars": []
+              },
+              {
+                  "name": "tip_token_data",
+                  "typedef": {
+                      "record": [
+                          {
+                              "name": "token",
+                              "type": "TokenContract"
+                          },
+                          {
+                              "name": "amount",
+                              "type": "int"
+                          }
+                      ]
+                  },
+                  "vars": []
+              },
+              {
+                  "name": "tip_meta",
+                  "typedef": {
+                      "record": [
+                          {
+                              "name": "sender",
+                              "type": "address"
+                          },
+                          {
+                              "name": "title",
+                              "type": "string"
+                          },
+                          {
+                              "name": "timestamp",
+                              "type": "int"
+                          }
+                      ]
+                  },
+                  "vars": []
+              },
+              {
+                  "name": "retip",
+                  "typedef": {
+                      "record": [
+                          {
+                              "name": "sender",
+                              "type": "address"
+                          },
+                          {
+                              "name": "amount",
+                              "type": "int"
+                          },
+                          {
+                              "name": "token_amount",
+                              "type": "int"
+                          },
+                          {
+                              "name": "claim_gen",
+                              "type": "Tipping.claim_gen"
+                          },
+                          {
+                              "name": "token",
+                              "type": {
+                                  "option": [
+                                      "TokenContract"
+                                  ]
+                              }
+                          },
+                          {
+                              "name": "tip_id",
+                              "type": "Tipping.tip_id"
+                          }
+                      ]
+                  },
+                  "vars": []
+              }
+          ]
+      }
+  }
+]

--- a/src/lib/wallet.js
+++ b/src/lib/wallet.js
@@ -78,10 +78,7 @@ export default async function initSdk() {
       );
     }
 
-    await Promise.all([
-      store.dispatch('initTippingContractInstances'),
-      getMiddleware(),
-    ]);
+    await getMiddleware();
     store.commit('setNodeStatus', NODE_STATUS_CONNECTED);
 
     store.watch(

--- a/src/popup/components/TransferReview.vue
+++ b/src/popup/components/TransferReview.vue
@@ -135,6 +135,7 @@ import {
   useMultisigAccounts,
   useMultisigTransactions,
   useSdk13,
+  useTippingContracts,
 } from '../../composables';
 import {
   AETERNITY_CONTRACT_ID,
@@ -186,16 +187,14 @@ export default defineComponent({
       addTransactionToPendingMultisigAccount,
       updateMultisigAccounts,
     } = useMultisigAccounts({ store: root.$store });
+    const { getTippingContracts } = useTippingContracts({ store: root.$store });
 
     const loading = ref<boolean>(false);
-    const tippingV1 = computed(() => root.$store.state.tippingV1);
-    const tippingV2 = computed(() => root.$store.state.tippingV2);
     const { getSdk } = useSdk13({ store: root.$store });
     const isRecipientName = computed(
       () => props.recipientAddress && checkAensName(props.recipientAddress),
     );
     const tokenSymbol = computed(() => props.transferData.selectedAsset?.symbol || '-');
-    const tippingContract = computed(() => tippingV2.value || tippingV1.value);
     const isSelectedAssetAex9 = computed(() => (
       !!props.transferData.selectedAsset
       && props.transferData.selectedAsset.contractId !== AETERNITY_CONTRACT_ID
@@ -290,6 +289,8 @@ export default defineComponent({
       loading.value = true;
       try {
         let txResult = null;
+        const { tippingV1, tippingV2 } = await getTippingContracts();
+        const tippingContract = computed(() => tippingV2.value || tippingV1.value);
         if (selectedAsset.contractId !== AETERNITY_CONTRACT_ID) {
           await root.$store.dispatch('fungibleTokens/createOrChangeAllowance', [
             selectedAsset.contractId,

--- a/src/popup/pages/Retip.vue
+++ b/src/popup/pages/Retip.vue
@@ -69,7 +69,7 @@ import {
   ISdk,
 } from '../../types';
 import { AETERNITY_COIN_PRECISION, AETERNITY_CONTRACT_ID } from '../utils/constants';
-import { convertToken, watchUntilTruthy } from '../utils';
+import { convertToken } from '../utils';
 import {
   useDeepLinkApi,
   useMaxAmount,
@@ -77,8 +77,9 @@ import {
   useBalances,
   useModals,
   useAccounts,
+  useTippingContracts,
 } from '../../composables';
-import { useGetter, useState } from '../../composables/vuex';
+import { useGetter } from '../../composables/vuex';
 import InputAmount from '../components/InputAmount.vue';
 import UrlStatus from '../components/UrlStatus.vue';
 import BtnMain from '../components/buttons/BtnMain.vue';
@@ -102,6 +103,7 @@ export default defineComponent({
     const { openCallbackOrGoHome } = useDeepLinkApi({ router: root.$router });
     const { balance, aeternityCoin } = useBalances({ store: root.$store });
     const { max, fee } = useMaxAmount({ formModel, store: root.$store });
+    const { getTippingContracts } = useTippingContracts({ store: root.$store });
 
     const tipId = root.$route.query.id;
     const tip = ref<{ url: string, id: string }>({
@@ -111,22 +113,15 @@ export default defineComponent({
 
     const loading = ref<boolean>(false);
     const sdk = useGetter<ISdk>('sdkPlugin/sdk');
-    const tippingV1 = useState('tippingV1');
-    const tippingV2 = useState('tippingV2');
     const tippingSupported = useGetter('tippingSupported');
     const urlStatus = (useGetter('tipUrl/status') as any)[tip.value.url];
-    const tippingContract = computed(
-      () => tipId.includes('_v2') || tipId.includes('_v3')
-        ? tippingV2.value
-        : tippingV1.value,
-    );
 
     const numericBalance = computed<number>(() => balance.value.toNumber());
 
     const validationStatus = computed<{
       error: boolean, msg?: string | VueI18n.TranslateResult
     }>(() => {
-      if (!sdk.value || !tippingContract.value) {
+      if (!sdk.value || !tippingSupported.value) {
         return { error: true };
       }
       return { error: false };
@@ -140,8 +135,13 @@ export default defineComponent({
           : AETERNITY_COIN_PRECISION,
       ).toNumber();
       loading.value = true;
-      await watchUntilTruthy(() => tippingV1.value);
       try {
+        const { tippingV1, tippingV2 } = await getTippingContracts();
+        const tippingContract = computed(
+          () => (tipId.includes('_v2') || tipId.includes('_v3'))
+            ? tippingV2.value
+            : tippingV1.value,
+        );
         let retipResponse = null;
         if (formModel.value.selectedAsset?.contractId !== AETERNITY_CONTRACT_ID) {
           await root.$store.dispatch(

--- a/src/popup/pages/TipsClaim.vue
+++ b/src/popup/pages/TipsClaim.vue
@@ -26,7 +26,7 @@
     </div>
 
     <InputField
-      v-model="url"
+      v-model="tipUrl"
       :label="$t('pages.claimTips.urlToClaim')"
       :error="!normalizedUrl"
     />
@@ -43,25 +43,26 @@
   </div>
 </template>
 
-<script>
-import { mapGetters, mapState } from 'vuex';
+<script lang="ts">
+import {
+  defineComponent, computed, ref, onMounted,
+} from '@vue/composition-api';
 import {
   BLOG_CLAIM_TIP_URL,
   MODAL_CLAIM_SUCCESS,
   aettosToAe,
   toURL,
   validateTipUrl,
-  watchUntilTruthy,
 } from '../utils';
 import { IS_EXTENSION } from '../../lib/environment';
-import { useAccounts, useModals } from '../../composables';
+import { useAccounts, useModals, useTippingContracts } from '../../composables';
 import { ROUTE_ACCOUNT } from '../router/routeNames';
 import InputField from '../components/InputField.vue';
 import BtnMain from '../components/buttons/BtnMain.vue';
 import BtnHelp from '../components/buttons/BtnHelp.vue';
 import AccountInfo from '../components/AccountInfo.vue';
 
-export default {
+export default defineComponent({
   components: {
     InputField,
     BtnMain,
@@ -70,83 +71,87 @@ export default {
   },
   setup(props, { root }) {
     const { activeAccount } = useAccounts({ store: root.$store });
+    const { openModal, openDefaultModal } = useModals();
+    const { getTippingContracts } = useTippingContracts({ store: root.$store });
 
-    return {
-      activeAccount,
-    };
-  },
-  data: () => ({
-    url: '',
-    loading: false,
-    BLOG_CLAIM_TIP_URL,
-  }),
-  computed: {
-    ...mapState(['tippingV1']),
-    ...mapGetters('sdkPlugin', ['sdk']),
-    ...mapGetters(['tippingSupported']),
-    normalizedUrl() {
-      if (!validateTipUrl(this.url)) return '';
-      return toURL(this.url).toString();
-    },
-  },
-  async mounted() {
-    if (IS_EXTENSION) {
-      const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
-      if (tab && validateTipUrl(tab.url)) {
-        this.url = tab.url;
-      }
-    }
-  },
-  methods: {
-    async claimTips() {
-      const { openModal, openDefaultModal } = useModals();
-      const { activeAccount } = useAccounts({ store: this.$store });
+    const tipUrl = ref('');
+    const loading = ref(false);
+    const tippingSupported = computed(() => root.$store.getters.tippingSupported);
 
-      const url = this.normalizedUrl;
-      this.loading = true;
-      await watchUntilTruthy(() => this.sdk && this.tippingV1);
+    const normalizedUrl = computed(() => (
+      validateTipUrl(tipUrl.value)) ? toURL(tipUrl.value).toString() : '');
+
+    async function claimTips() {
+      const url = normalizedUrl.value;
+      loading.value = true;
+      const { tippingV1 } = await getTippingContracts();
       try {
         const claimAmount = parseFloat(
           aettosToAe(
-            await this.tippingV1.methods
+            await tippingV1.value.methods
               .unclaimed_for_url(url)
-              .then((r) => r.decodedResult)
+              .then((r: any) => r.decodedResult)
               .catch(() => 1),
           ),
         );
         if (!claimAmount) {
           throw new Error('NO_ZERO_AMOUNT_PAYOUT');
         }
-        await this.$store.dispatch('claimTips', { url, address: activeAccount.value.address });
-        await this.$store.dispatch('cacheInvalidateOracle');
-        await this.$store.dispatch('cacheInvalidateTips');
+        await root.$store.dispatch('claimTips', { url, address: activeAccount.value.address });
+        await root.$store.dispatch('cacheInvalidateOracle');
+        await root.$store.dispatch('cacheInvalidateTips');
 
         openModal(MODAL_CLAIM_SUCCESS, { url, claimAmount });
 
-        this.$router.push({ name: ROUTE_ACCOUNT });
-      } catch (e) {
-        const { error = '' } = e.response ? e.response.data : {};
+        root.$router.push({ name: ROUTE_ACCOUNT });
+      } catch (error: any) {
+        const { error: errorMessage = '' } = error.response ? error.response.data : {};
         let msg;
-        if (error.includes('MORE_ORACLES_NEEDED')) msg = this.$t('pages.claim.moreOracles');
-        else if (error.includes('URL_NOT_EXISTING')) msg = this.$t('pages.claim.urlNotExisting');
-        else if (
-          error.includes('NO_ZERO_AMOUNT_PAYOUT')
-          || e.message.includes('NO_ZERO_AMOUNT_PAYOUT')
-        ) msg = this.$t('pages.claim.noZeroClaim');
-        else if (error.includes('ORACLE_SEVICE_CHECK_CLAIM_FAILED')) msg = this.$t('pages.claim.oracleFailed');
-        else if (error) msg = error;
+        if (errorMessage.includes('MORE_ORACLES_NEEDED')) {
+          msg = root.$t('pages.claim.moreOracles');
+        } else if (errorMessage.includes('URL_NOT_EXISTING')) {
+          msg = root.$t('pages.claim.urlNotExisting');
+        } else if (
+          errorMessage.includes('NO_ZERO_AMOUNT_PAYOUT')
+          || error.message.includes('NO_ZERO_AMOUNT_PAYOUT')
+        ) {
+          msg = root.$t('pages.claim.noZeroClaim');
+        } else if (errorMessage.includes('ORACLE_SEVICE_CHECK_CLAIM_FAILED')) {
+          msg = root.$t('pages.claim.oracleFailed');
+        } else if (errorMessage) {
+          msg = errorMessage;
+        }
         if (msg) {
           openDefaultModal({ msg });
         } else {
-          e.payload = { url };
-          throw e;
+          error.payload = { url };
+          throw error;
         }
       } finally {
-        this.loading = false;
+        loading.value = false;
       }
-    },
+    }
+
+    onMounted(async () => {
+      if (IS_EXTENSION && browser) {
+        const [tab] = await browser.tabs.query({ active: true, currentWindow: true });
+        if (tab && validateTipUrl(tab.url)) {
+          tipUrl.value = tab.url;
+        }
+      }
+    });
+
+    return {
+      activeAccount,
+      claimTips,
+      loading,
+      normalizedUrl,
+      tipUrl,
+      tippingSupported,
+      BLOG_CLAIM_TIP_URL,
+    };
   },
-};
+});
 </script>
 
 <style lang="scss" scoped>

--- a/src/popup/pages/TipsClaim.vue
+++ b/src/popup/pages/TipsClaim.vue
@@ -45,7 +45,10 @@
 
 <script lang="ts">
 import {
-  defineComponent, computed, ref, onMounted,
+  defineComponent,
+  computed,
+  ref,
+  onMounted,
 } from '@vue/composition-api';
 import {
   BLOG_CLAIM_TIP_URL,
@@ -78,19 +81,19 @@ export default defineComponent({
     const loading = ref(false);
     const tippingSupported = computed(() => root.$store.getters.tippingSupported);
 
-    const normalizedUrl = computed(() => (
-      validateTipUrl(tipUrl.value)) ? toURL(tipUrl.value).toString() : '');
+    const normalizedUrl = computed(
+      () => validateTipUrl(tipUrl.value) ? toURL(tipUrl.value).toString() : '',
+    );
 
     async function claimTips() {
       const url = normalizedUrl.value;
       loading.value = true;
-      const { tippingV1 } = await getTippingContracts();
       try {
+        const { tippingV1 } = await getTippingContracts();
         const claimAmount = parseFloat(
           aettosToAe(
-            await tippingV1.value.methods
-              .unclaimed_for_url(url)
-              .then((r: any) => r.decodedResult)
+            await tippingV1.unclaimed_for_url(url)
+              .then((r) => r.decodedResult)
               .catch(() => 1),
           ),
         );

--- a/src/popup/pages/TipsClaim.vue
+++ b/src/popup/pages/TipsClaim.vue
@@ -101,8 +101,10 @@ export default defineComponent({
           throw new Error('NO_ZERO_AMOUNT_PAYOUT');
         }
         await root.$store.dispatch('claimTips', { url, address: activeAccount.value.address });
-        await root.$store.dispatch('cacheInvalidateOracle');
-        await root.$store.dispatch('cacheInvalidateTips');
+        await Promise.all([
+          root.$store.dispatch('cacheInvalidateOracle'),
+          root.$store.dispatch('cacheInvalidateTips'),
+        ]);
 
         openModal(MODAL_CLAIM_SUCCESS, { url, claimAmount });
 

--- a/src/popup/pages/TipsClaim.vue
+++ b/src/popup/pages/TipsClaim.vue
@@ -121,7 +121,7 @@ export default defineComponent({
           || error.message.includes('NO_ZERO_AMOUNT_PAYOUT')
         ) {
           msg = root.$t('pages.claim.noZeroClaim');
-        } else if (errorMessage.includes('ORACLE_SEVICE_CHECK_CLAIM_FAILED')) {
+        } else if (errorMessage.includes('ORACLE_SERVICE_CHECK_CLAIM_FAILED')) {
           msg = root.$t('pages.claim.oracleFailed');
         } else if (errorMessage) {
           msg = errorMessage;

--- a/src/popup/utils/constants.ts
+++ b/src/popup/utils/constants.ts
@@ -1,4 +1,5 @@
 import { SCHEMA } from '@aeternity/aepp-sdk';
+import { Encoded } from '@aeternity/aepp-sdk-13';
 import BigNumber from 'bignumber.js';
 import type {
   TxFunctionRaw,
@@ -111,7 +112,7 @@ export const NETWORK_MAINNET: INetwork = {
   explorerUrl: 'https://explorer.aeternity.io',
   compilerUrl: 'https://compiler.aepps.com',
   backendUrl: 'https://raendom-backend.z52da5wt.xyz',
-  tipContractV1: 'ct_2AfnEfCSZCTEkxL5Yoi4Yfq6fF7YapHRaFKDJK3THMXMBspp5z',
+  tipContractV1: 'ct_2AfnEfCSZCTEkxL5Yoi4Yfq6fF7YapHRaFKDJK3THMXMBspp5z' as Encoded.ContractAddress,
   multisigBackendUrl: 'https://ga-multisig-backend-mainnet.prd.aepps.com',
   name: 'Mainnet',
 };
@@ -123,8 +124,8 @@ export const NETWORK_TESTNET: INetwork = {
   explorerUrl: 'https://explorer.testnet.aeternity.io',
   compilerUrl: 'https://latest.compiler.aepps.com',
   backendUrl: 'https://testnet.superhero.aeternity.art',
-  tipContractV1: 'ct_2Cvbf3NYZ5DLoaNYAU71t67DdXLHeSXhodkSNifhgd7Xsw28Xd',
-  tipContractV2: 'ct_2ZEoCKcqXkbz2uahRrsWeaPooZs9SdCv6pmC4kc55rD4MhqYSu',
+  tipContractV1: 'ct_2Cvbf3NYZ5DLoaNYAU71t67DdXLHeSXhodkSNifhgd7Xsw28Xd' as Encoded.ContractAddress,
+  tipContractV2: 'ct_2ZEoCKcqXkbz2uahRrsWeaPooZs9SdCv6pmC4kc55rD4MhqYSu' as Encoded.ContractAddress,
   multisigBackendUrl: 'https://ga-multisig-backend-testnet.prd.aepps.com',
   name: 'Testnet',
 };

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -1,6 +1,4 @@
 import { uniqBy, orderBy } from 'lodash-es';
-import TIPPING_V1_INTERFACE from 'tipping-contract/Tipping_v1_Interface.aes';
-import TIPPING_V2_INTERFACE from 'tipping-contract/Tipping_v2_Interface.aes';
 import { SCHEMA } from '@aeternity/aepp-sdk';
 import {
   AEX9_TRANSFER_EVENT,
@@ -192,30 +190,6 @@ export default {
   },
   async getCacheTip({ getters: { activeNetwork } }, id) {
     return fetchJson(`${activeNetwork.backendUrl}/tips/single/${id}`);
-  },
-  async initTippingContractInstances({
-    getters: { 'sdkPlugin/sdk': sdk, activeNetwork, tippingSupported },
-    commit,
-  }) {
-    if (!tippingSupported && !process.env.RUNNING_IN_TESTS) return;
-
-    const [
-      contractInstanceV1,
-      contractInstanceV2,
-    ] = await Promise.all([
-      sdk.getContractInstance({
-        source: TIPPING_V1_INTERFACE,
-        contractAddress: activeNetwork.tipContractV1,
-      }),
-      activeNetwork.tipContractV2
-        ? sdk.getContractInstance({
-          source: TIPPING_V2_INTERFACE,
-          contractAddress: activeNetwork.tipContractV2,
-        })
-        : null,
-    ]);
-
-    commit('setTipping', [contractInstanceV1, contractInstanceV2]);
   },
   async share(_, options) {
     await (process.env.IS_CORDOVA

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -35,8 +35,6 @@ export default new Vuex.Store({
       pending: {},
       tipWithdrawnTransactions: [],
     },
-    tippingV1: null,
-    tippingV2: null,
     nodeStatus: NODE_STATUS_CONNECTING,
     notificationSettings: [],
     chainNames: null,

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -50,10 +50,6 @@ export default {
   deleteUserNetwork(state, index) {
     state.userNetworks = state.userNetworks.filter((el, idx) => idx !== index);
   },
-  setTipping(state, [tippingV1, tippingV2]) {
-    state.tippingV1 = tippingV1 || null;
-    state.tippingV2 = tippingV2 || null;
-  },
   setNodeStatus(state, payload) {
     state.nodeStatus = payload;
   },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ import { RawLocation } from 'vue-router';
 import { LocaleMessages, TranslateResult } from 'vue-i18n';
 import BigNumber from 'bignumber.js';
 import { Store } from 'vuex';
+import { ContractMethodsBase, Encoded } from '@aeternity/aepp-sdk-13';
 import type { CoinGeckoMarketResponse } from '../lib/CoinGecko';
 import {
   POPUP_TYPES,
@@ -215,8 +216,8 @@ export interface INetworkBase {
 
 export interface INetwork extends INetworkBase {
   explorerUrl: string
-  tipContractV1: string
-  tipContractV2?: string
+  tipContractV1: Encoded.ContractAddress
+  tipContractV2?: Encoded.ContractAddress
   multisigBackendUrl: string
 }
 
@@ -674,3 +675,23 @@ export interface IDefaultComposableOptions {
 }
 
 export type StatusIconType = typeof ALLOWED_ICON_STATUSES[number];
+
+export interface TippingV1ContractApi extends ContractMethodsBase {
+  unclaimed_for_url: (url: string) => string;
+  tip: (recipientId: Encoded.AccountAddress, note: string) => void;
+  retip: (tipId: number) => void;
+}
+
+export interface TippingV2ContractApi extends TippingV1ContractApi {
+  tip_token: (
+    recipientId: Encoded.AccountAddress,
+    note: string,
+    contacttId: Encoded.ContractAddress,
+    amount: string
+  ) => Encoded.TxHash;
+  retip_token: (
+    id: number,
+    contactId: Encoded.ContractAddress,
+    amount: number
+  ) => Encoded.TxHash;
+}


### PR DESCRIPTION
- also it slightly speeds up e2e tests, `other` in particular.
- fix spelling error https://github.com/aeternity/tipping-contract/pull/11, https://github.com/aeternity/tipping-contract/pull/11/commits/9d5df2c89ed81947dd423ed250511acf745a1ec2
