### PR TITLE
fix: webpack error with watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:web": "cross-env PLATFORM=web vue-cli-service build",
     "build-zip": "node scripts/build-zip.js",
     "serve": "cross-env PLATFORM=web vue-cli-service serve",
-    "watch": "npm run build:extension -- --watch",
+    "watch": "npm run build:extension -- --watch --mode production",
     "test:unit": "vue-cli-service test:unit",
     "test:e2e": "cross-env PLATFORM=web RUNNING_IN_TESTS=true vue-cli-service test:e2e",
     "test": "npm run test:unit && npm run test:e2e -- --headless",


### PR DESCRIPTION
`npm run watch` wasn't working after updating to `webpack@5.x` because when run in development mode it uses `eval` for source-maps. 
Building & rebuilding with this command is now slower as it builds for production.
Configuring webpack `devtool` to not use `eval` for source-maps is equally slow.