### PR TITLE
fix: issue with network sync

### DIFF
--- a/src/store/plugins/sdk.js
+++ b/src/store/plugins/sdk.js
@@ -178,12 +178,13 @@ export default (store) => {
   });
 
   store.watch(
-    (state, getters) => getters.activeNetwork,
+    (state) => state.current.network,
     async (network, oldNetwork) => {
+      const { activeNetwork } = store.getters;
       if (isEqual(network, oldNetwork)) return;
       await watchUntilTruthy(() => store.getters['sdkPlugin/sdk']);
-      sdk.pool.delete(network.name);
-      sdk.addNode(network.name, await Node({ url: network.url }), true);
+      sdk.pool.delete(activeNetwork.name);
+      sdk.addNode(activeNetwork.name, await Node({ url: activeNetwork.url }), true);
     },
   );
 


### PR DESCRIPTION
`getters.activeNetwork` was never calling the watcher cb.
I'm not sure if this is an issue with the new Vue or Vuex version but it seems the SDK (or Vuex) is behaving problematic now.
This is more of a workaround than a permanent fix but since we are planning to replace both the store and old version of the SDK I believe this should be ok.