### PR TITLE
Fetch confirmed transactions on load

### DIFF
--- a/src/composables/latestTransactionList.ts
+++ b/src/composables/latestTransactionList.ts
@@ -110,6 +110,7 @@ export function useLatestTransactionList({ store }: IDefaultComposableOptions) {
         setTimeout(() => updateTransactionListData(), MDW_TO_NODE_APPROX_DELAY_TIME);
       }
     },
+    { immediate: true },
   );
 
   watch(

--- a/src/popup/components/TransactionListItem.vue
+++ b/src/popup/components/TransactionListItem.vue
@@ -2,7 +2,7 @@
   <ListItemWrapper
     class="transaction-item"
     :to="redirectRoute"
-    :data-cy="transaction.pending && 'pending-txs'"
+    :data-cy="currentTransaction.pending && 'pending-txs'"
   >
     <div class="body">
       <TransactionTokenRows


### PR DESCRIPTION
I see the latest transaction widget is not shown when there is no pending transaction or there is no balance/network change. 
The wallet doesn't show confirmed past transactions. Hence on load, fetch past transactions once.