### PR TITLE
[SW-1078] Rename aepp-sdk instances to aeSdk standard

### DIFF
--- a/src/composables/balances.ts
+++ b/src/composables/balances.ts
@@ -22,7 +22,7 @@ import {
 } from './composablesHelpers';
 import { useCurrencies } from './currencies';
 import { useAccounts } from './accounts';
-import { useSdk } from './sdk';
+import { useAeSdk } from './aeSdk';
 
 type Balances = Record<string, Balance>;
 
@@ -44,7 +44,7 @@ const { useStorageRef } = createStorageRef<Balances>({}, LOCAL_STORAGE_BALANCES_
  * to live update the values. If no components are using it the polling stops.
  */
 export function useBalances({ store }: IDefaultComposableOptions) {
-  const { getSdk } = useSdk({ store });
+  const { getAeSdk } = useAeSdk({ store });
   const { aeternityData } = useCurrencies();
   const { activeAccount, accounts } = useAccounts({ store });
 
@@ -69,10 +69,10 @@ export function useBalances({ store }: IDefaultComposableOptions) {
   }
 
   async function updateBalances() {
-    const sdk = await getSdk();
+    const aeSdk = await getAeSdk();
     const balancesPromises = accounts.value.map(
       // TODO - type address in IAccount interface
-      ({ address }) => sdk.getBalance(address as Encoded.AccountAddress).catch((error) => {
+      ({ address }) => aeSdk.getBalance(address as Encoded.AccountAddress).catch((error) => {
         if (!isNotFoundError(error)) {
           handleUnknownError(error);
         }

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -13,7 +13,7 @@ export * from './multisigAccountCreate';
 export * from './multisigTransactions';
 export * from './notifications';
 export * from './pendingMultisigTransaction';
-export * from './sdk';
+export * from './aeSdk';
 export * from './tippingContracts';
 export * from './tokensList';
 export * from './topHeader';

--- a/src/composables/latestTransactionList.ts
+++ b/src/composables/latestTransactionList.ts
@@ -19,7 +19,7 @@ import { useAccounts } from './accounts';
 import { useBalances } from './balances';
 import { createNetworkWatcher } from './composablesHelpers';
 import { useTransactionTx } from './transactionTx';
-import { useSdk } from './sdk';
+import { useAeSdk } from './aeSdk';
 
 const isTransactionListLoading = ref(false);
 const fetchedTransactions = ref<ITransaction[]>([]);
@@ -35,7 +35,7 @@ const { onNetworkChange } = createNetworkWatcher();
 export function useLatestTransactionList({ store }: IDefaultComposableOptions) {
   const { accounts } = useAccounts({ store });
   const { balancesTotal } = useBalances({ store });
-  const { nodeNetworkId } = useSdk({ store });
+  const { nodeNetworkId } = useAeSdk({ store });
 
   const tokens = computed(() => store.state.fungibleTokens.tokens);
 

--- a/src/composables/maxAmount.ts
+++ b/src/composables/maxAmount.ts
@@ -32,7 +32,7 @@ import {
   checkAensName,
   handleUnknownError,
 } from '../popup/utils';
-import { useSdk } from './sdk';
+import { useAeSdk } from './aeSdk';
 import { useBalances } from './balances';
 import { useAccounts } from './accounts';
 
@@ -51,7 +51,7 @@ export interface MaxAmountOptions extends IDefaultComposableOptions {
  * considering the fee that needs to be paid.
  */
 export function useMaxAmount({ store, formModel }: MaxAmountOptions) {
-  const { getSdk } = useSdk({ store });
+  const { getAeSdk } = useAeSdk({ store });
   const { balance } = useBalances({ store });
   const { activeAccount } = useAccounts({ store });
 
@@ -75,14 +75,14 @@ export function useMaxAmount({ store, formModel }: MaxAmountOptions) {
     () => formModel.value,
     async (val) => {
       if (!val?.selectedAsset) return;
-      const sdk = await getSdk();
+      const aeSdk = await getAeSdk();
 
       if (val.selectedAsset.contractId !== AETERNITY_CONTRACT_ID) {
         if (
           !tokenInstance
           || tokenInstance.$options.address !== val.selectedAsset.contractId
         ) {
-          tokenInstance = await sdk.initializeContract({
+          tokenInstance = await aeSdk.initializeContract({
             aci: FungibleTokenFullInterfaceACI,
             address: val.selectedAsset.contractId,
           });
@@ -150,16 +150,16 @@ export function useMaxAmount({ store, formModel }: MaxAmountOptions) {
   onMounted(() => {
     updateTokenBalanceInterval = executeAndSetInterval(async () => {
       if (!tokenInstance) return;
-      await getSdk();
+      await getAeSdk();
       selectedTokenBalance.value = new BigNumber(
         (await tokenInstance.balance(activeAccount.value.address)).decodedResult ?? 0,
       ).shiftedBy(-selectedAssetDecimals.value);
     }, 1000);
 
     updateNonceInterval = executeAndSetInterval(async () => {
-      const sdk = await getSdk();
+      const aeSdk = await getAeSdk();
       try {
-        nonce.value = (await sdk.api
+        nonce.value = (await aeSdk.api
           .getAccountByPubkey(activeAccount.value.address))?.nonce;
       } catch (error: any) {
         if (!error.message.includes('Account not found')) handleUnknownError(error);

--- a/src/composables/multisigAccounts.ts
+++ b/src/composables/multisigAccounts.ts
@@ -21,7 +21,7 @@ import type {
   IMultisigConsensus,
   IMultisigAccountResponse,
 } from '../types';
-import { useSdk } from './sdk';
+import { useAeSdk } from './aeSdk';
 import { AeScan } from '../lib/AeScan';
 import { useAccounts } from './accounts';
 
@@ -60,7 +60,7 @@ const isAdditionalInfoNeeded = ref(false);
 const initPollingWatcher = createPollingBasedOnMountedComponents(POLLING_INTERVAL);
 
 export function useMultisigAccounts({ store, pollOnce = false }: MultisigAccountsOptions) {
-  const { nodeNetworkId, getSdk } = useSdk({ store });
+  const { nodeNetworkId, getAeSdk } = useAeSdk({ store });
   const { accounts } = useAccounts({ store });
 
   const activeNetwork = computed<INetwork>(() => store.getters.activeNetwork);
@@ -83,7 +83,7 @@ export function useMultisigAccounts({ store, pollOnce = false }: MultisigAccount
 
   // Get initial data for currently used network
   (async () => {
-    await getSdk(); // Ensure we are connected
+    await getAeSdk(); // Ensure we are connected
     if (
       !multisigAccounts.value.length
       || activeMultisigNetworkId.value !== nodeNetworkId.value
@@ -157,7 +157,7 @@ export function useMultisigAccounts({ store, pollOnce = false }: MultisigAccount
    * Refresh the list of the multisig accounts.
    */
   async function updateMultisigAccounts() {
-    const sdk = await getSdk();
+    const aeSdk = await getAeSdk();
 
     /**
      * Establish the list of multisig accounts used by the regular accounts
@@ -197,7 +197,7 @@ export function useMultisigAccounts({ store, pollOnce = false }: MultisigAccount
           ...otherMultisigData
         }): Promise<IMultisigAccount> => {
           try {
-            const contractInstance = await sdk.initializeContract({
+            const contractInstance = await aeSdk.initializeContract({
               aci: SimpleGAMultiSigAci,
               address: contractId,
             });
@@ -221,7 +221,7 @@ export function useMultisigAccounts({ store, pollOnce = false }: MultisigAccount
                 ? { decodedResult: currentAccount.signers }
                 : contractInstance.get_signers(),
               contractInstance.get_consensus_info(),
-              gaAccountId ? sdk.getBalance(gaAccountId) : 0,
+              gaAccountId ? aeSdk.getBalance(gaAccountId) : 0,
             ]));
 
             const decodedConsensus = consensusResult.decodedResult;

--- a/src/composables/notifications.ts
+++ b/src/composables/notifications.ts
@@ -17,7 +17,7 @@ import {
 } from '../popup/utils';
 import { useAccounts } from './accounts';
 import { createPollingBasedOnMountedComponents } from './composablesHelpers';
-import { useSdk } from './sdk';
+import { useAeSdk } from './aeSdk';
 
 export interface UseNotificationsOptions extends IDefaultComposableOptions {
   requirePolling?: boolean
@@ -35,7 +35,7 @@ export function useNotifications({
   requirePolling = false,
   store,
 }: UseNotificationsOptions) {
-  const { fetchRespondChallenge } = useSdk({ store });
+  const { fetchRespondChallenge } = useAeSdk({ store });
   const { activeAccount } = useAccounts({ store });
 
   const canLoadMore = ref(true);

--- a/src/composables/tippingContracts.ts
+++ b/src/composables/tippingContracts.ts
@@ -3,7 +3,7 @@ import { Contract } from '@aeternity/aepp-sdk';
 
 import TippingV1ACI from '../lib/contracts/TippingV1ACI.json';
 import TippingV2ACI from '../lib/contracts/TippingV2ACI.json';
-import { useSdk } from './sdk';
+import { useAeSdk } from './aeSdk';
 import { watchUntilTruthy } from '../popup/utils';
 import {
   IDefaultComposableOptions,
@@ -22,7 +22,7 @@ let tippingV2: Contract<TippingV2ContractApi> | undefined;
 const initializing = ref(false);
 
 export function useTippingContracts({ store }: IDefaultComposableOptions) {
-  const { getSdk, isTippingSupported } = useSdk({ store });
+  const { getAeSdk, isTippingSupported } = useAeSdk({ store });
 
   const activeNetwork = computed<INetwork>(() => store.getters.activeNetwork);
 
@@ -31,18 +31,18 @@ export function useTippingContracts({ store }: IDefaultComposableOptions) {
       return;
     }
     initializing.value = true;
-    const sdk = await getSdk();
+    const aeSdk = await getAeSdk();
 
     [
       tippingV1,
       tippingV2,
     ] = await Promise.all([
-      sdk.initializeContract<TippingV1ContractApi>({
+      aeSdk.initializeContract<TippingV1ContractApi>({
         aci: TippingV1ACI,
         address: activeNetwork.value.tipContractV1,
       }),
       activeNetwork.value.tipContractV2
-        ? sdk.initializeContract<TippingV2ContractApi>({
+        ? aeSdk.initializeContract<TippingV2ContractApi>({
           aci: TippingV2ACI,
           address: activeNetwork.value.tipContractV2,
         })

--- a/src/composables/topHeader.ts
+++ b/src/composables/topHeader.ts
@@ -3,7 +3,7 @@ import {
   createNetworkWatcher,
   createPollingBasedOnMountedComponents,
 } from './composablesHelpers';
-import { useSdk } from './sdk';
+import { useAeSdk } from './aeSdk';
 
 import type { ITopHeader, IDefaultComposableOptions } from '../types';
 
@@ -17,13 +17,13 @@ const { onNetworkChange } = createNetworkWatcher();
  * Composable that provides the information about the last block of the blockchain.
  */
 export function useTopHeaderData({ store }: IDefaultComposableOptions) {
-  const { getSdk } = useSdk({ store });
+  const { getAeSdk } = useAeSdk({ store });
 
   const topBlockHeight = computed(() => topHeaderData.value?.height || 0);
 
   async function updateTopHeaderData() {
-    const sdk = await getSdk();
-    topHeaderData.value = await sdk.api.getTopHeader();
+    const aeSdk = await getAeSdk();
+    topHeaderData.value = await aeSdk.api.getTopHeader();
   }
 
   async function fetchCurrentTopBlockHeight() {

--- a/src/composables/transactionTx.ts
+++ b/src/composables/transactionTx.ts
@@ -32,7 +32,7 @@ import {
   isTxFunctionDexPool,
 } from '../popup/utils';
 import { useAccounts } from './accounts';
-import { useSdk } from './sdk';
+import { useAeSdk } from './aeSdk';
 
 interface UseTransactionOptions extends IDefaultComposableOptions {
   tx?: ITx;
@@ -44,7 +44,7 @@ export function useTransactionTx({
   tx,
   externalAddress,
 }: UseTransactionOptions) {
-  const { dexContracts } = useSdk({ store });
+  const { dexContracts } = useAeSdk({ store });
   const { accounts, activeAccount, activeAccountExtended } = useAccounts({ store });
 
   const outerTx = ref<ITx | undefined>(tx);

--- a/src/lib/AeSdkSupehero.ts
+++ b/src/lib/AeSdkSupehero.ts
@@ -20,7 +20,11 @@ type ISpendOptions = Omit<Parameters<typeof spend>[2], 'onAccount' | 'onNode'>
     payload?: Encoded.Any,
   }
 
-export class ShSdkWallet extends AeSdkWallet {
+/**
+ * Class extends `AeSdkWallet` from aepp-sdk-js
+ * provides flexibility to manage the accounts the way wallet would like to handle
+ */
+export class AeSdkSupehero extends AeSdkWallet {
   store: Store<any>;
 
   constructor(store: Store<any>, options: any) {

--- a/src/lib/FramesConnection.ts
+++ b/src/lib/FramesConnection.ts
@@ -1,7 +1,7 @@
 import { times } from 'lodash-es';
-import { AeSdkWallet, BrowserWindowMessageConnection } from '@aeternity/aepp-sdk';
-import { ISdk } from '../types';
+import { BrowserWindowMessageConnection } from '@aeternity/aepp-sdk';
 import { executeAndSetInterval, handleUnknownError } from '../popup/utils';
+import { AeSdkSupehero } from './AeSdkSupehero';
 
 const POLLING_INTERVAL = 3000;
 
@@ -21,7 +21,7 @@ export const FramesConnection = (() => {
     ];
   }
 
-  function init(sdk: ISdk | AeSdkWallet) {
+  function init(aeSdk: AeSdkSupehero) {
     initialized = true;
     clearInterval(baseIntervalId);
 
@@ -49,14 +49,14 @@ export const FramesConnection = (() => {
               }, () => {});
             };
 
-            const clientId = sdk.addRpcClient(connection);
+            const clientId = aeSdk.addRpcClient(connection);
 
             intervalId = executeAndSetInterval(() => {
               if (!getArrayOfAvailableFrames().includes(target)) {
                 clearInterval(intervalId);
                 return;
               }
-              sdk.shareWalletInfo(clientId);
+              aeSdk.shareWalletInfo(clientId);
             }, 3000);
           }),
         POLLING_INTERVAL,

--- a/src/lib/swagger.js
+++ b/src/lib/swagger.js
@@ -1,7 +1,7 @@
 import SwaggerClient from 'swagger-client';
 import JsonBig from './json-big';
 
-// TODO: remove this file in favor of sdk 13's built-in way of wrapping middleware calls
+// TODO: remove this file in favor of aeSdk 13's built-in way of wrapping middleware calls
 
 let warnedAboutInternalApiUsage = false;
 
@@ -93,7 +93,7 @@ export async function genSwaggerClient(
         // eslint-disable-next-line no-console
         console.warn(
           'SDK\'s wrapper of aeternity node internal API is deprecated, please use external '
-          + 'equivalent (for example, "sdk.api.protectedDryRunTxs" instead of "sdk.api.dryRunTxs") '
+          + 'equivalent (for example, "aeSdk.api.protectedDryRunTxs" instead of "aeSdk.api.dryRunTxs") '
           + 'or create a wrapper of internal API by yourself (using "genSwaggerClient")',
         );
         warnedAboutInternalApiUsage = true;

--- a/src/popup/components/InviteItem.vue
+++ b/src/popup/components/InviteItem.vue
@@ -93,7 +93,7 @@ import {
   IFormModel,
   useBalances,
   useMaxAmount,
-  useSdk,
+  useAeSdk,
 } from '../../composables';
 
 import TokenAmount from './TokenAmount.vue';
@@ -117,7 +117,7 @@ export default defineComponent({
     const store = useStore();
     const router = useRouter();
 
-    const { getSdk } = useSdk({ store });
+    const { getAeSdk } = useAeSdk({ store });
     const { aeternityCoin } = useBalances({ store });
 
     const formModel = ref<IFormModel>({
@@ -147,9 +147,9 @@ export default defineComponent({
     }
 
     async function updateBalance() {
-      const sdk = await getSdk();
+      const aeSdk = await getAeSdk();
       inviteLinkBalance.value = parseFloat(
-        (await sdk
+        (await aeSdk
           .getBalance(address.value, { format: AE_AMOUNT_FORMATS.AE })
           .catch(() => 0)
         )
@@ -183,9 +183,9 @@ export default defineComponent({
 
     async function sendTopUp() {
       emit('loading', true);
-      const sdk = await getSdk();
+      const aeSdk = await getAeSdk();
       try {
-        await sdk.spend(
+        await aeSdk.spend(
           formModel.value.amount!, // validateAll method confirms the presence of the amount field
           address.value,
           // @ts-ignore

--- a/src/popup/components/Modals/ConfirmTransactionSign.vue
+++ b/src/popup/components/Modals/ConfirmTransactionSign.vue
@@ -138,7 +138,7 @@ import type {
   TxFunctionRaw,
 } from '../../../types';
 import { transactionTokenInfoResolvers } from '../../utils/transactionTokenInfoResolvers';
-import { usePopupProps, useSdk, useTransactionTx } from '../../../composables';
+import { usePopupProps, useAeSdk, useTransactionTx } from '../../../composables';
 import { useGetter, useState } from '../../../composables/vuex';
 
 import Modal from '../Modal.vue';
@@ -179,7 +179,7 @@ export default defineComponent({
   setup() {
     const store = useStore();
     const { t } = useI18n();
-    const { getSdk } = useSdk({ store });
+    const { getAeSdk } = useAeSdk({ store });
 
     const { popupProps, setPopupProps } = usePopupProps();
 
@@ -331,8 +331,8 @@ export default defineComponent({
             { bytecode },
           ] = await Promise.all([
             fetchJson(`${activeNetwork.value.url}/v3/contracts/${popupProps.value.tx.contractId}/code`),
-            // SDK is needed to establish the `networkId` and the dex contracts for the network
-            getSdk(),
+            // aeSdk is needed to establish the `networkId` and the dex contracts for the network
+            getAeSdk(),
           ]);
 
           const txParams: ITx = await postJson(

--- a/src/popup/components/MultisigVaultCreateReview.vue
+++ b/src/popup/components/MultisigVaultCreateReview.vue
@@ -108,7 +108,7 @@ import {
   useAccounts,
   useModals,
   useMultisigAccountCreate,
-  useSdk,
+  useAeSdk,
 } from '../../composables';
 
 import AccountSelector from './AccountSelector.vue';
@@ -149,7 +149,7 @@ export default defineComponent({
     } = useMultisigAccountCreate({ store });
     const { isLocalAccountAddress } = useAccounts({ store });
 
-    const { getSdk } = useSdk({ store });
+    const { getAeSdk } = useAeSdk({ store });
 
     const { openModal } = useModals();
 
@@ -169,9 +169,9 @@ export default defineComponent({
     watch(creatorAddress, async (val, oldVal) => {
       if (val !== oldVal) {
         creatorAccountFetched.value = undefined;
-        const sdk = await getSdk();
+        const aeSdk = await getAeSdk();
         try {
-          const rawAccount = await sdk.api.getAccountByPubkey(val);
+          const rawAccount = await aeSdk.api.getAccountByPubkey(val);
           creatorAccountFetched.value = {
             ...rawAccount,
             balance: rawAccount.balance.toString(),

--- a/src/popup/components/NetworkButton.vue
+++ b/src/popup/components/NetworkButton.vue
@@ -22,7 +22,7 @@ import { defineComponent } from 'vue';
 import { useStore } from 'vuex';
 import type { INetwork } from '../../types';
 import { useGetter } from '../../composables/vuex';
-import { useConnection, useSdk } from '../../composables';
+import { useConnection, useAeSdk } from '../../composables';
 import { ROUTE_NETWORK_SETTINGS } from '../router/routeNames';
 
 import BtnPill from './buttons/BtnPill.vue';
@@ -34,7 +34,7 @@ export default defineComponent({
   setup() {
     const store = useStore();
     const { isOnline } = useConnection();
-    const { isNodeReady, isNodeError } = useSdk({ store });
+    const { isNodeReady, isNodeError } = useAeSdk({ store });
     const activeNetwork = useGetter<INetwork>('activeNetwork');
 
     return {

--- a/src/popup/components/NodeConnectionStatus.vue
+++ b/src/popup/components/NodeConnectionStatus.vue
@@ -22,7 +22,7 @@ import {
 } from 'vue';
 import { TranslateResult, useI18n } from 'vue-i18n';
 import { useStore } from 'vuex';
-import { useAccounts, useConnection, useSdk } from '../../composables';
+import { useAccounts, useConnection, useAeSdk } from '../../composables';
 
 const CONNECTED_DISPLAY_TIME = 2000;
 
@@ -32,7 +32,7 @@ export default defineComponent({
     const { t } = useI18n();
 
     const { isOnline } = useConnection();
-    const { isNodeConnecting, isNodeReady, isNodeError } = useSdk({ store });
+    const { isNodeConnecting, isNodeReady, isNodeError } = useAeSdk({ store });
     const { isLoggedIn } = useAccounts({ store });
 
     const justBeenConnected = ref(false);

--- a/src/popup/components/SwapRoute.vue
+++ b/src/popup/components/SwapRoute.vue
@@ -35,7 +35,7 @@ import { mapState, mapGetters } from 'vuex';
 import { camelCase } from 'lodash-es';
 import { transactionTokenInfoResolvers } from '../utils/transactionTokenInfoResolvers';
 import { DEX_CONTRACTS, isTxFunctionDexSwap } from '../utils';
-import { useSdk } from '../../composables';
+import { useAeSdk } from '../../composables';
 
 import Tokens from './Tokens.vue';
 import ArrowHead from '../../icons/arrow-head.svg?vue-component';
@@ -68,7 +68,7 @@ export default {
           tokens[1],
         ];
       }
-      const { nodeNetworkId } = useSdk({ store: this.$store });
+      const { nodeNetworkId } = useAeSdk({ store: this.$store });
       const waeContract = DEX_CONTRACTS[nodeNetworkId.value]?.wae;
       if (tokens[0].isAe && waeContract && !waeContract?.includes(tokens[1].contractId)) {
         tokens.unshift({
@@ -90,7 +90,7 @@ export default {
       if (idx === this.tokens.length - 1) {
         return false;
       }
-      const { nodeNetworkId } = useSdk({ store: this.$store });
+      const { nodeNetworkId } = useAeSdk({ store: this.$store });
       const contracts = DEX_CONTRACTS[nodeNetworkId.value];
       return (
         contracts?.wae?.includes(this.tokens[idx].contractId)

--- a/src/popup/components/TransactionList.vue
+++ b/src/popup/components/TransactionList.vue
@@ -64,7 +64,7 @@ import {
   useAccounts,
   usePendingMultisigTransaction,
   useUi,
-  useSdk,
+  useAeSdk,
 } from '../../composables';
 
 import TransactionListItem from './TransactionListItem.vue';
@@ -113,7 +113,7 @@ export default defineComponent({
       FILTER_MODE,
     } = useTransactionAndTokenFilter();
 
-    const { dexContracts } = useSdk({ store });
+    const { dexContracts } = useAeSdk({ store });
 
     const { pendingMultisigTransaction } = usePendingMultisigTransaction({ store });
 

--- a/src/popup/components/TransactionOverview.vue
+++ b/src/popup/components/TransactionOverview.vue
@@ -26,7 +26,7 @@ import {
   TX_FUNCTIONS,
 } from '../utils';
 import { AeScan } from '../../lib/AeScan';
-import { useMiddleware, useSdk, useTransactionTx } from '../../composables';
+import { useMiddleware, useAeSdk, useTransactionTx } from '../../composables';
 import { useGetter } from '../../composables/vuex';
 import {
   IAccount,
@@ -60,7 +60,7 @@ export default defineComponent({
     const activeNetwork = useGetter<INetwork>('activeNetwork');
     const getPreferredName = useGetter('names/getPreferred');
 
-    const { getSdk } = useSdk({ store });
+    const { getAeSdk } = useAeSdk({ store });
     const { getMiddleware } = useMiddleware({ store });
 
     const {
@@ -213,9 +213,9 @@ export default defineComponent({
 
       if (!(innerTx.value.contractId && calldata)) return undefined;
 
-      const sdk = await getSdk();
-      const { bytecode } = await sdk.getContractByteCode(innerTx.value.contractId);
-      // TODO: use sdk method on sdk 13 update
+      const aeSdk = await getAeSdk();
+      const { bytecode } = await aeSdk.getContractByteCode(innerTx.value.contractId);
+      // TODO: use method from aeSdk once calldata-js library supports decoding bytecode feature
       const txParams: ITx = await postJson(
         `${activeNetwork.value.compilerUrl}/decode-calldata/bytecode`,
         { body: { bytecode, calldata } },

--- a/src/popup/components/TransferReview.vue
+++ b/src/popup/components/TransferReview.vue
@@ -136,7 +136,7 @@ import {
   useModals,
   useMultisigAccounts,
   useMultisigTransactions,
-  useSdk,
+  useAeSdk,
   useUi,
   useTippingContracts,
 } from '../../composables';
@@ -198,7 +198,7 @@ export default defineComponent({
     const { getTippingContracts } = useTippingContracts({ store });
 
     const loading = ref<boolean>(false);
-    const { getSdk } = useSdk({ store });
+    const { getAeSdk } = useAeSdk({ store });
     const isRecipientName = computed(
       () => props.recipientAddress && checkAensName(props.recipientAddress),
     );
@@ -219,7 +219,7 @@ export default defineComponent({
     }
 
     async function transfer({ amount, recipient, selectedAsset }: any) {
-      const sdk = await getSdk();
+      const aeSdk = await getAeSdk();
 
       loading.value = true;
       try {
@@ -241,7 +241,7 @@ export default defineComponent({
             { waitMined: false, modal: false },
           ]);
         } else {
-          actionResult = await sdk.spendWithCustomOptions(amount, recipient, {
+          actionResult = await aeSdk.spendWithCustomOptions(amount, recipient, {
             payload: encode(Buffer.from(props.transferData.payload), Encoding.Bytearray),
             modal: false,
           });
@@ -325,7 +325,7 @@ export default defineComponent({
             {
               amount,
               waitMined: false,
-              ...{ modal: false } as any, // TODO: `modal` is not a part of sdk types
+              ...{ modal: false } as any, // TODO: `modal` is not a part of aeSdk types
             },
           );
         }

--- a/src/popup/pages/AccountDetails.vue
+++ b/src/popup/pages/AccountDetails.vue
@@ -56,7 +56,7 @@ import {
   useAccounts,
   useBalances,
   useConnection,
-  useSdk,
+  useAeSdk,
 } from '../../composables';
 
 import AccountDetailsBase from '../components/AccountDetailsBase.vue';
@@ -86,7 +86,7 @@ export default defineComponent({
     const store = useStore();
     const { isOnline } = useConnection();
 
-    const { isNodeMainnet, isNodeTestnet } = useSdk({ store });
+    const { isNodeMainnet, isNodeTestnet } = useAeSdk({ store });
 
     const {
       activeAccount,

--- a/src/popup/pages/Address.vue
+++ b/src/popup/pages/Address.vue
@@ -12,7 +12,7 @@ import { IAppData } from '../../types';
 import {
   useAccounts,
   useDeepLinkApi,
-  useSdk,
+  useAeSdk,
   usePopupProps,
 } from '../../composables';
 import { POPUP_CONNECT_ADDRESS_PERMISSION } from '../utils/constants';
@@ -25,7 +25,7 @@ export default defineComponent({
     const store = useStore();
     const router = useRouter();
 
-    const { nodeNetworkId } = useSdk({ store });
+    const { nodeNetworkId } = useAeSdk({ store });
     const { openCallbackOrGoHome, callbackOrigin } = useDeepLinkApi({ router });
     const { activeAccount } = useAccounts({ store });
     const { setPopupProps } = usePopupProps();

--- a/src/popup/pages/CommentNew.vue
+++ b/src/popup/pages/CommentNew.vue
@@ -42,7 +42,7 @@ import {
   useAccounts,
   useDeepLinkApi,
   useModals,
-  useSdk,
+  useAeSdk,
 } from '../../composables';
 import { useGetter } from '../../composables/vuex';
 import { ROUTE_ACCOUNT } from '../router/routeNames';
@@ -66,7 +66,7 @@ export default defineComponent({
     const route = useRoute();
     const { t } = useI18n();
 
-    const { getSdk, fetchRespondChallenge, isTippingSupported } = useSdk({ store });
+    const { getAeSdk, fetchRespondChallenge, isTippingSupported } = useAeSdk({ store });
     const { openDefaultModal } = useModals();
     const { openCallbackOrGoHome } = useDeepLinkApi({ router });
     const {
@@ -99,14 +99,14 @@ export default defineComponent({
 
     async function sendComment() {
       loading.value = true;
-      const sdk = await getSdk();
+      const aeSdk = await getAeSdk();
       try {
         const postToCommentApi = async (body: any) => postJson(`${activeNetwork.value.backendUrl}/comment/api/`, { body });
 
         const responseChallenge = await postToCommentApi({
           tipId: id.value,
           text: text.value,
-          author: sdk.address,
+          author: aeSdk.address,
           parentId: parentId.value,
         });
         const respondChallenge = await fetchRespondChallenge(responseChallenge);
@@ -126,10 +126,10 @@ export default defineComponent({
       }
     }
 
-    // Wait until the `isTippingSupported` is established by the SDK
+    // Wait until the `isTippingSupported` is established by the aeSdk
     (async () => {
       loading.value = true;
-      await getSdk();
+      await getAeSdk();
       loading.value = false;
     })();
 

--- a/src/popup/pages/Dashboard.vue
+++ b/src/popup/pages/Dashboard.vue
@@ -45,7 +45,7 @@ import { useStore } from 'vuex';
 import { IS_IOS } from '../../lib/environment';
 import { DASHBOARD_CARD_ID } from '../utils';
 import { ROUTE_ACCOUNT_DETAILS_NAMES_CLAIM } from '../router/routeNames';
-import { useAccounts, useSdk } from '../../composables';
+import { useAccounts, useAeSdk } from '../../composables';
 
 import DashboardCard from '../components/DashboardCard.vue';
 import DashboardWrapper from '../components/DashboardWrapper.vue';
@@ -80,7 +80,7 @@ export default defineComponent({
       activeAccountFaucetUrl,
     } = useAccounts({ store });
 
-    const { isNodeMainnet, isNodeTestnet } = useSdk({ store });
+    const { isNodeMainnet, isNodeTestnet } = useAeSdk({ store });
 
     return {
       DASHBOARD_CARD_ID,

--- a/src/popup/pages/FungibleTokens/TokenContainer.vue
+++ b/src/popup/pages/FungibleTokens/TokenContainer.vue
@@ -110,7 +110,7 @@ import {
 import {
   useAccounts,
   useCurrencies,
-  useSdk,
+  useAeSdk,
   useTokensList,
 } from '../../../composables';
 import { useState, useGetter } from '../../../composables/vuex';
@@ -150,7 +150,7 @@ export default defineComponent({
 
     const isMultisig = computed((): boolean => !!route?.meta?.isMultisig);
 
-    const { isNodeMainnet, isNodeTestnet, getSdk } = useSdk({ store });
+    const { isNodeMainnet, isNodeTestnet, getAeSdk } = useAeSdk({ store });
     const {
       activeAccountSimplexLink,
       activeAccountFaucetUrl,
@@ -216,7 +216,7 @@ export default defineComponent({
 
     onMounted(async () => {
       if (isContract(contractId) && !isAe) {
-        await getSdk();
+        await getAeSdk();
         tokenPairs.value = await store.dispatch('fungibleTokens/getContractTokenPairs', contractId);
       }
       loading.value = false;

--- a/src/popup/pages/Invite.vue
+++ b/src/popup/pages/Invite.vue
@@ -63,7 +63,7 @@ import { useStore } from 'vuex';
 import { useState } from '../../composables/vuex';
 import {
   useBalances,
-  useSdk,
+  useAeSdk,
   useMaxAmount,
   IFormModel,
 } from '../../composables';
@@ -87,7 +87,7 @@ export default defineComponent({
     const store = useStore();
     const loading = ref(false);
 
-    const { getSdk } = useSdk({ store });
+    const { getAeSdk } = useAeSdk({ store });
     const { balance, aeternityCoin } = useBalances({ store });
 
     const formModel = ref<IFormModel>({
@@ -104,8 +104,8 @@ export default defineComponent({
       const { publicKey, secretKey } = generateKeyPair();
 
       try {
-        const sdk = await getSdk();
-        await sdk.spend(
+        const aeSdk = await getAeSdk();
+        await aeSdk.spend(
           formModel.value.amount || 0,
           publicKey,
           // @ts-ignore

--- a/src/popup/pages/InviteClaim.vue
+++ b/src/popup/pages/InviteClaim.vue
@@ -7,7 +7,7 @@ import { defineComponent, onMounted } from 'vue';
 import { decode } from '@aeternity/aepp-sdk';
 import { useStore } from 'vuex';
 import { useRouter } from 'vue-router';
-import { useModals, useSdk } from '../../composables';
+import { useModals, useAeSdk } from '../../composables';
 import { ROUTE_ACCOUNT } from '../router/routeNames';
 
 export default defineComponent({
@@ -17,11 +17,11 @@ export default defineComponent({
   setup(props) {
     const store = useStore();
     const router = useRouter();
-    const { getSdk } = useSdk({ store });
+    const { getAeSdk } = useAeSdk({ store });
     const { openDefaultModal } = useModals();
 
     onMounted(async () => {
-      await getSdk();
+      await getAeSdk();
 
       try {
         // sg_ prefix was chosen as a dummy to decode from base58Check

--- a/src/popup/pages/More.vue
+++ b/src/popup/pages/More.vue
@@ -89,7 +89,7 @@ import {
   DEX_URL,
   SIMPLEX_URL,
 } from '../utils/constants';
-import { useAccounts, useSdk } from '../../composables';
+import { useAccounts, useAeSdk } from '../../composables';
 
 import PanelItem from '../components/PanelItem.vue';
 import Invites from '../../icons/invites.svg?vue-component';
@@ -118,7 +118,7 @@ export default defineComponent({
     const store = useStore();
 
     const { activeAccountFaucetUrl } = useAccounts({ store });
-    const { isNodeMainnet, isNodeTestnet } = useSdk({ store });
+    const { isNodeMainnet, isNodeTestnet } = useAeSdk({ store });
 
     return {
       BUG_REPORT_URL,

--- a/src/popup/pages/MultisigProposalDetails.vue
+++ b/src/popup/pages/MultisigProposalDetails.vue
@@ -411,7 +411,7 @@ export default defineComponent({
         type: Tag[Tag.GaMetaTx],
         tag: Tag.GaMetaTx,
       } as any;
-      // TODO: remove `any` by adding returned type from `unpackTx` sdk function to `ITx` type
+      // TODO: remove `any` by adding returned type from `unpackTx` aeSdk function to `ITx` type
     }
 
     function handleInsufficientBalanceError(

--- a/src/popup/pages/Names/AuctionBid.vue
+++ b/src/popup/pages/Names/AuctionBid.vue
@@ -57,7 +57,7 @@ import {
   unpackTx,
   Tag,
 } from '@aeternity/aepp-sdk';
-import { useModals, useSdk } from '../../../composables';
+import { useModals, useAeSdk } from '../../../composables';
 import type { IAuctionBid } from '../../../types';
 import { useGetter } from '../../../composables/vuex';
 import {
@@ -91,7 +91,7 @@ export default defineComponent({
     const router = useRouter();
     const { t } = useI18n();
 
-    const { getSdk } = useSdk({ store });
+    const { getAeSdk } = useAeSdk({ store });
     const { openDefaultModal } = useModals();
 
     const loading = ref(false);
@@ -122,11 +122,11 @@ export default defineComponent({
     });
 
     async function bid() {
-      const sdk = await getSdk();
+      const aeSdk = await getAeSdk();
       if (amountError.value) return;
       try {
         loading.value = true;
-        await sdk.aensBid(props.name, aeToAettos(amount.value));
+        await aeSdk.aensBid(props.name, aeToAettos(amount.value));
         openDefaultModal({
           msg: t('pages.names.auctions.bid-added', { name: props.name }),
         });

--- a/src/popup/pages/Names/Claim.vue
+++ b/src/popup/pages/Names/Claim.vue
@@ -50,7 +50,7 @@
     <BtnMain
       class="btn-register"
       extend
-      :disabled="!isSdkReady || !name || errorName"
+      :disabled="!isAeSdkReady || !name || errorName"
       @click="claim"
     >
       {{
@@ -78,7 +78,7 @@ import {
   checkAensName,
 } from '../../utils';
 import { ROUTE_ACCOUNT_DETAILS_NAMES } from '../../router/routeNames';
-import { useAccounts, useModals, useSdk } from '../../../composables';
+import { useAccounts, useModals, useAeSdk } from '../../../composables';
 import InputField from '../../components/InputField.vue';
 import CheckBox from '../../components/CheckBox.vue';
 import BtnMain from '../../components/buttons/BtnMain.vue';
@@ -113,7 +113,7 @@ export default defineComponent({
       .shiftedBy(-AETERNITY_COIN_PRECISION)
       .toFixed(4));
 
-    const { getSdk, isSdkReady } = useSdk({ store });
+    const { getAeSdk, isAeSdkReady } = useAeSdk({ store });
 
     async function claim() {
       if (!await validate()) return;
@@ -121,10 +121,10 @@ export default defineComponent({
       const { openDefaultModal } = useModals();
       const { activeAccount } = useAccounts({ store });
 
-      const sdk = await getSdk();
+      const aeSdk = await getAeSdk();
 
       const fullName: AensName = `${name.value}${AENS_DOMAIN}`;
-      const nameEntry = await sdk.api.getNameEntryByName(fullName).catch(() => false);
+      const nameEntry = await aeSdk.api.getNameEntryByName(fullName).catch(() => false);
 
       if (nameEntry) {
         openDefaultModal({
@@ -135,8 +135,8 @@ export default defineComponent({
         let claimTxHash;
 
         try {
-          const { salt } = await sdk.aensPreclaim(fullName);
-          claimTxHash = (await sdk.aensClaim(fullName, salt, { waitMined: false })).hash;
+          const { salt } = await aeSdk.aensPreclaim(fullName);
+          claimTxHash = (await aeSdk.aensClaim(fullName, salt, { waitMined: false })).hash;
           if (autoExtend.value) {
             store.commit('names/setPendingAutoExtendName', fullName);
           }
@@ -157,7 +157,7 @@ export default defineComponent({
 
         try {
           store.dispatch('names/fetchOwned');
-          await sdk.poll(claimTxHash);
+          await aeSdk.poll(claimTxHash);
           if (AENS_NAME_AUCTION_MAX_LENGTH < fullName.length) {
             store.dispatch('names/updatePointer', {
               name: fullName,
@@ -176,7 +176,7 @@ export default defineComponent({
       AENS_DOMAIN,
       autoExtend,
       isNameValid,
-      isSdkReady,
+      isAeSdkReady,
       name,
       nameFee,
       errorName,

--- a/src/popup/pages/Retip.vue
+++ b/src/popup/pages/Retip.vue
@@ -87,7 +87,7 @@ import {
   useModals,
   useAccounts,
   useTippingContracts,
-  useSdk,
+  useAeSdk,
 } from '../../composables';
 import { useGetter } from '../../composables/vuex';
 import InputAmount from '../components/InputAmount.vue';
@@ -115,7 +115,7 @@ export default defineComponent({
       amount: '',
     });
 
-    const { isTippingSupported } = useSdk({ store });
+    const { isTippingSupported } = useAeSdk({ store });
     const { openDefaultModal } = useModals();
     const { activeAccount } = useAccounts({ store });
     const { openCallbackOrGoHome } = useDeepLinkApi({ router });

--- a/src/popup/pages/SignMessage.vue
+++ b/src/popup/pages/SignMessage.vue
@@ -3,7 +3,7 @@ import { defineComponent, onMounted } from 'vue';
 import { useRouter, useRoute } from 'vue-router';
 import { useStore } from 'vuex';
 import { RejectedByUserError } from '../../lib/errors';
-import { useDeepLinkApi, useModals, useSdk } from '../../composables';
+import { useDeepLinkApi, useModals, useAeSdk } from '../../composables';
 import { MODAL_MESSAGE_SIGN, handleUnknownError } from '../utils';
 
 export default defineComponent({
@@ -15,11 +15,11 @@ export default defineComponent({
 
     onMounted(async () => {
       const { callbackOrigin, openCallbackOrGoHome } = useDeepLinkApi({ router });
-      const { getSdk } = useSdk({ store });
+      const { getAeSdk } = useAeSdk({ store });
       const { openModal } = useModals();
 
       try {
-        const sdk = await getSdk();
+        const aeSdk = await getAeSdk();
         const { message } = route.query;
 
         await openModal(MODAL_MESSAGE_SIGN, {
@@ -31,7 +31,7 @@ export default defineComponent({
           },
         });
 
-        const signature = await sdk.signMessage(message as string);
+        const signature = await aeSdk.signMessage(message as string);
         const signatureHex = Buffer.from(signature).toString('hex');
         openCallbackOrGoHome(true, { signature: signatureHex });
       } catch (error: any) {

--- a/src/popup/pages/SignTransaction.vue
+++ b/src/popup/pages/SignTransaction.vue
@@ -12,7 +12,7 @@ import { handleUnknownError } from '../utils';
 import {
   useDeepLinkApi,
   useModals,
-  useSdk,
+  useAeSdk,
 } from '../../composables';
 
 export default defineComponent({
@@ -25,11 +25,11 @@ export default defineComponent({
 
     onMounted(async () => {
       const { callbackOrigin, openCallbackOrGoHome } = useDeepLinkApi({ router });
-      const { nodeNetworkId, getSdk } = useSdk({ store });
+      const { nodeNetworkId, getAeSdk } = useAeSdk({ store });
       const { openDefaultModal } = useModals();
 
       try {
-        const sdk = await getSdk();
+        const aeSdk = await getAeSdk();
         const { transaction, networkId, broadcast } = route.query;
 
         if (networkId !== nodeNetworkId.value) {
@@ -43,7 +43,7 @@ export default defineComponent({
           return;
         }
 
-        const signedTransaction = await sdk.signTransaction(
+        const signedTransaction = await aeSdk.signTransaction(
           transaction as Encoded.Transaction,
           {
             networkId,
@@ -52,7 +52,7 @@ export default defineComponent({
         );
 
         if (broadcast) {
-          const result = await sdk.sendTransaction(signedTransaction, { waitMined: true });
+          const result = await aeSdk.sendTransaction(signedTransaction, { waitMined: true });
           openCallbackOrGoHome(true, { 'transaction-hash': result.hash });
         } else {
           openCallbackOrGoHome(true, { transaction: signedTransaction });

--- a/src/popup/pages/TipsClaim.vue
+++ b/src/popup/pages/TipsClaim.vue
@@ -64,7 +64,7 @@ import { IS_EXTENSION } from '../../lib/environment';
 import {
   useAccounts,
   useModals,
-  useSdk,
+  useAeSdk,
   useTippingContracts,
 } from '../../composables';
 import { ROUTE_ACCOUNT } from '../router/routeNames';
@@ -86,7 +86,7 @@ export default defineComponent({
     const store = useStore();
     const router = useRouter();
 
-    const { isTippingSupported } = useSdk({ store });
+    const { isTippingSupported } = useAeSdk({ store });
     const { activeAccount } = useAccounts({ store });
     const { openModal, openDefaultModal } = useModals();
     const { getTippingContracts } = useTippingContracts({ store });

--- a/src/popup/router/index.ts
+++ b/src/popup/router/index.ts
@@ -29,7 +29,7 @@ import {
   IS_CORDOVA,
   IS_WEB,
 } from '../../lib/environment';
-import { useAccounts, usePopupProps, useSdk } from '../../composables';
+import { useAccounts, usePopupProps, useAeSdk } from '../../composables';
 import { RouteQueryActionsController } from '../../lib/RouteQueryActionsController';
 
 const router = createRouter({
@@ -69,9 +69,9 @@ router.beforeEach(async (to, from, next) => {
     return;
   }
 
-  const { isSdkReady } = useSdk({ store });
+  const { isAeSdkReady } = useAeSdk({ store });
 
-  if (!isSdkReady.value && !RUNNING_IN_POPUP) {
+  if (!isAeSdkReady.value && !RUNNING_IN_POPUP) {
     initSdk();
   }
 

--- a/src/popup/utils/utils.ts
+++ b/src/popup/utils/utils.ts
@@ -40,9 +40,6 @@ import dayjs from '../plugins/dayjsConfig';
 import type {
   BigNumberPublic,
   IAccount,
-  IRespondChallenge,
-  IResponseChallenge,
-  ISdk,
   ITransaction,
   ITx,
   IPageableResponse,
@@ -335,21 +332,6 @@ export async function fetchAllPages<T = any>(
   return result;
 }
 
-// TODO - move to sdk.ts composable after the removal of action.js file
-export async function fetchRespondChallenge(
-  sdk: ISdk,
-  responseChallenge: IResponseChallenge,
-): Promise<IRespondChallenge> {
-  const signedChallenge = Buffer.from(
-    await sdk.signMessage(responseChallenge.challenge),
-  ).toString('hex');
-
-  return {
-    challenge: responseChallenge.challenge,
-    signature: signedChallenge,
-  };
-}
-
 export function getPayload(transaction: ITransaction) {
   return (transaction.tx?.payload)
     ? decode(transaction.tx?.payload).toString()
@@ -478,10 +460,10 @@ export function getTxTag(tx: ITx): Tag | null {
   if (tx.tag) {
     return tx.tag;
   }
-  if (compareCaseInsensitive(tx.type, 'GAAttachTx')) { // Sdk: GaAttachTx, mdw: GAAttachTx
+  if (compareCaseInsensitive(tx.type, 'GAAttachTx')) { // aeSdk: GaAttachTx, mdw: GAAttachTx
     return Tag.GaAttachTx;
   }
-  if (compareCaseInsensitive(tx.type, 'GAMetaTx')) { // Sdk: GaMetaTx, mdw: GAMetaTx
+  if (compareCaseInsensitive(tx.type, 'GAMetaTx')) { // aeSdk: GaMetaTx, mdw: GAMetaTx
     return Tag.GaMetaTx;
   }
   if (tx.type in Tag) {
@@ -497,7 +479,7 @@ export function isTransactionAex9(transaction: ITransaction): boolean {
 
 export function isContainingNestedTx(tx: ITx): boolean {
   return [
-    'GAMetaTx', // Sdk: GaMetaTx, mdw: GAMetaTx
+    'GAMetaTx', // aeSdk: GaMetaTx, mdw: GAMetaTx
     Tag[Tag.GaMetaTx],
     Tag[Tag.PayingForTx],
   ].includes(tx.type);

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -10,7 +10,7 @@ import {
 import JsonBig from '../lib/json-big';
 import {
   useMiddleware,
-  useSdk,
+  useAeSdk,
 } from '../composables';
 
 export default {
@@ -19,7 +19,7 @@ export default {
     commit('initTransactions');
   },
   addPendingTransaction(context, transaction) {
-    const { nodeNetworkId } = useSdk({ store: context });
+    const { nodeNetworkId } = useAeSdk({ store: context });
     context.commit('addPendingTransaction', {
       network: nodeNetworkId.value,
       transaction: { ...transaction, microTime: Date.now(), pending: true },
@@ -27,10 +27,10 @@ export default {
   },
   async fetchPendingTransactions(context, address) {
     const { state: { transactions } } = context;
-    const { nodeNetworkId, getSdk } = useSdk({ store: context });
-    const sdk = await getSdk();
+    const { nodeNetworkId, getAeSdk } = useAeSdk({ store: context });
+    const aeSdk = await getAeSdk();
     return (
-      await sdk.api.getPendingAccountTransactionsByPubkey(address).then(
+      await aeSdk.api.getPendingAccountTransactionsByPubkey(address).then(
         (r) => JsonBig.parse(JsonBig.stringify(r.transactions)),
         (error) => {
           if (!isAccountNotFoundError(error)) {
@@ -87,7 +87,7 @@ export default {
       return null;
     }
 
-    const { nodeNetworkId } = useSdk({ store: context });
+    const { nodeNetworkId } = useAeSdk({ store: context });
     const { getMiddleware, fetchFromMiddlewareCamelCased } = useMiddleware({ store: context });
 
     let txs = await Promise.all([

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -14,7 +14,7 @@ import {
   categorizeContractCallTxObject,
   getHdWalletAccount,
 } from '../popup/utils';
-import { useSdk } from '../composables';
+import { useAeSdk } from '../composables';
 
 export default {
   wallet({ mnemonic }) {
@@ -52,7 +52,7 @@ export default {
     return nodeStatus === NODE_STATUS_CONNECTED;
   },
   getTx: (state, getters) => (hash) => {
-    const { nodeNetworkId } = useSdk({ store: { state, getters } });
+    const { nodeNetworkId } = useAeSdk({ store: { state, getters } });
     return state.transactions.loaded
       .concat(state.transactions.pending[nodeNetworkId.value])
       ?.find((tx) => tx?.hash === hash);
@@ -100,7 +100,7 @@ export default {
       : TX_DIRECTION.received;
   },
   getAccountPendingTransactions: (state, getters) => {
-    const { nodeNetworkId } = useSdk({ store: { state, getters } });
+    const { nodeNetworkId } = useAeSdk({ store: { state, getters } });
     const { address } = getters.account;
     const pendingTransactions = state.transactions.pending[nodeNetworkId.value];
 

--- a/src/store/modules/accounts/hdWallet.js
+++ b/src/store/modules/accounts/hdWallet.js
@@ -6,7 +6,7 @@ import {
   buildTx,
 } from '@aeternity/aepp-sdk';
 
-import { useModals, useSdk } from '../../../composables';
+import { useModals, useAeSdk } from '../../../composables';
 import {
   ACCOUNT_HD_WALLET,
   MODAL_CONFIRM_RAW_SIGN,
@@ -27,9 +27,9 @@ export default {
   },
   actions: {
     async isAccountUsed(context, address) {
-      const { getSdk } = useSdk({ store: context });
-      const sdk = await getSdk();
-      return sdk.api.getAccountByPubkey(address).then(() => true, () => false);
+      const { getAeSdk } = useAeSdk({ store: context });
+      const aeSdk = await getAeSdk();
+      return aeSdk.api.getAccountByPubkey(address).then(() => true, () => false);
     },
     async discover({ state, rootGetters, dispatch }) {
       let lastNotEmptyIdx = 0;

--- a/src/store/modules/invites.js
+++ b/src/store/modules/invites.js
@@ -21,11 +21,11 @@ export default {
   },
   actions: {
     async claim({ rootGetters: { account, activeNetwork } }, secretKey) {
-      const sdk = new AeSdk({
+      const aeSdk = new AeSdk({
         nodes: [{ name: activeNetwork.name, instance: new Node(activeNetwork.url) }],
         accounts: [new MemoryAccount(secretKey)],
       });
-      await sdk.transferFunds(1, account.address, { payload: encode(Buffer.from('referral'), Encoding.Bytearray), verify: false });
+      await aeSdk.transferFunds(1, account.address, { payload: encode(Buffer.from('referral'), Encoding.Bytearray), verify: false });
     },
     async handleNotEnoughFoundsError(_, { error: { message }, isInviteError = false }) {
       if (!isInviteError && !message.includes('is not enough to execute')) return false;

--- a/src/store/plugins/fungibleTokens.js
+++ b/src/store/plugins/fungibleTokens.js
@@ -10,10 +10,10 @@ import {
   calculateSupplyAmount,
   fetchAllPages,
 } from '../../popup/utils';
-import { useMiddleware, useSdk } from '../../composables';
+import { useMiddleware, useAeSdk } from '../../composables';
 
 export default (store) => {
-  const { getSdk } = useSdk({ store });
+  const { getAeSdk } = useAeSdk({ store });
 
   store.registerModule('fungibleTokens', {
     namespaced: true,
@@ -97,10 +97,10 @@ export default (store) => {
         { rootGetters: { activeNetwork, account } },
         [contractId, amount],
       ) {
-        const sdk = await getSdk();
+        const aeSdk = await getAeSdk();
         const selectedToken = store.state.fungibleTokens.tokens?.[account.address]?.tokenBalances
           ?.find((t) => t?.contractId === contractId);
-        const tokenContract = await sdk.initializeContract({
+        const tokenContract = await aeSdk.initializeContract({
           aci: FungibleTokenFullInterfaceACI,
           address: selectedToken.contractId,
         });
@@ -123,8 +123,8 @@ export default (store) => {
         address,
       ) {
         try {
-          const sdk = await getSdk();
-          const tokenContract = await sdk.initializeContract({
+          const aeSdk = await getAeSdk();
+          const tokenContract = await aeSdk.initializeContract({
             aci: AedexV2PairACI,
             address,
           });
@@ -169,16 +169,16 @@ export default (store) => {
         }
       },
       async transfer(_, [address, toAccount, amount, option]) {
-        const sdk = await getSdk();
-        const tokenContract = await sdk.initializeContract({
+        const aeSdk = await getAeSdk();
+        const tokenContract = await aeSdk.initializeContract({
           aci: FungibleTokenFullInterfaceACI,
           address,
         });
         return tokenContract.transfer(toAccount, amount.toFixed(), option);
       },
       async burnTriggerPoS(_, [address, amount, posAddress, invoiceId, option]) {
-        const sdk = await getSdk();
-        const tokenContract = await sdk.initializeContract({
+        const aeSdk = await getAeSdk();
+        const tokenContract = await aeSdk.initializeContract({
           aci: ZeitTokenACI,
           address,
         });

--- a/src/store/plugins/names.js
+++ b/src/store/plugins/names.js
@@ -10,14 +10,14 @@ import {
   handleUnknownError,
 } from '../../popup/utils';
 import { i18n } from './languages';
-import { useMiddleware, useModals, useSdk } from '../../composables';
+import { useMiddleware, useModals, useAeSdk } from '../../composables';
 
 export default (store) => {
   const {
     nodeNetworkId,
-    getSdk,
+    getAeSdk,
     fetchRespondChallenge,
-  } = useSdk({ store });
+  } = useAeSdk({ store });
 
   const {
     isMiddlewareReady,
@@ -154,13 +154,13 @@ export default (store) => {
         _,
         { name, address, type = 'update' },
       ) {
-        const sdk = await getSdk();
-        const nameEntry = await sdk.aensQuery(name);
+        const aeSdk = await getAeSdk();
+        const nameEntry = await aeSdk.aensQuery(name);
         try {
           if (type === 'extend') {
             await nameEntry.extendTtl();
           } else if (type === 'update') {
-            await sdk.aensUpdate(name, { account_pubkey: address }, { extendPointers: true });
+            await aeSdk.aensUpdate(name, { account_pubkey: address }, { extendPointers: true });
           }
           openDefaultModal({
             msg: i18n.global.t('pages.names.pointer-added', { type }),
@@ -229,13 +229,13 @@ export default (store) => {
 
   watch(getMiddlewareRef(), async () => {
     if (isMiddlewareReady.value) {
-      const [sdk] = await Promise.all([
-        getSdk(),
+      const [aeSdk] = await Promise.all([
+        getAeSdk(),
         store.dispatch('names/fetchOwned').catch(() => {}),
         store.dispatch('names/setDefaults'),
       ]);
 
-      const height = await sdk.getHeight();
+      const height = await aeSdk.getHeight();
       await Promise.all(
         store.state.names.owned
           .filter(({ autoExtend }) => autoExtend)

--- a/src/store/plugins/pendingTransactionHandler.js
+++ b/src/store/plugins/pendingTransactionHandler.js
@@ -1,22 +1,22 @@
-import { useSdk } from '../../composables';
+import { useAeSdk } from '../../composables';
 import { watchUntilTruthy } from '../../popup/utils';
 
 export default async (store) => {
-  const { isSdkReady, nodeNetworkId, getSdk } = useSdk({ store });
+  const { isAeSdkReady, nodeNetworkId, getAeSdk } = useAeSdk({ store });
 
   const waitTransactionMined = async ({
     hash,
   }) => {
     try {
-      const sdk = await getSdk();
-      await sdk.poll(hash);
+      const aeSdk = await getAeSdk();
+      await aeSdk.poll(hash);
       store.commit('setPendingTransactionSentByHash', { hash, network: nodeNetworkId.value });
     } catch (e) {
       store.commit('removePendingTransactionByHash', { hash, network: nodeNetworkId.value });
     }
   };
 
-  await watchUntilTruthy(() => isSdkReady);
+  await watchUntilTruthy(() => isAeSdkReady);
 
   // eslint-disable-next-line no-unused-expressions
   store.state.transactions.pending[nodeNetworkId.value]

--- a/src/store/plugins/veeValidate.js
+++ b/src/store/plugins/veeValidate.js
@@ -13,7 +13,7 @@ import {
   isValidURL,
 } from '../../popup/utils';
 import { AENS_DOMAIN } from '../../popup/utils/constants';
-import { useBalances, useCurrencies, useSdk } from '../../composables';
+import { useBalances, useCurrencies, useAeSdk } from '../../composables';
 
 defineRule('url', (url) => isValidURL(url));
 defineRule('required', required);
@@ -58,7 +58,7 @@ configure({
 export default (store) => {
   const { balance, updateBalances } = useBalances({ store });
   const { minTipAmount } = useCurrencies({ withoutPolling: true });
-  const { getSdk } = useSdk({ store });
+  const { getAeSdk } = useAeSdk({ store });
 
   const NAME_STATES = {
     REGISTERED: Symbol('name state: registered'),
@@ -70,8 +70,8 @@ export default (store) => {
   const checkNameDebounced = debounce(
     async (name, expectedNameState, comparedAddress, { resolve, reject }) => {
       try {
-        const sdk = await getSdk();
-        const nameEntry = await sdk.api.getNameEntryByName(name);
+        const aeSdk = await getAeSdk();
+        const nameEntry = await aeSdk.api.getNameEntryByName(name);
         const address = getAddressByNameEntry(nameEntry);
         resolve(({
           [NAME_STATES.REGISTERED]: true,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -154,7 +154,7 @@ export interface IAccount {
 }
 
 /**
- * Account fetched from the node with the use of `sdk.api.getAccountByPubkey`
+ * Account fetched from the node with the use of `aeSdk.api.getAccountByPubkey`
  */
 type AeternityAccountFetched = Awaited<ReturnType<InstanceType<typeof Node>['getAccountByPubkey']>>;
 
@@ -371,7 +371,7 @@ export interface ITx {
   selectedTokenContractId?: string
   tag?: Tag;
   /**
-   * Middleware represents the `type` with different case than the SDK.
+   * Middleware represents the `type` with different case than the aeSdk.
    * the `Tag.GaAttachTx` is `GAAttachTX`, `Tag.GaMetaTX` equal to `GAMetaTx`.
    * When comparing the `type` it is suggested to do case insensitive comparison.
    */
@@ -486,78 +486,13 @@ export interface IName {
 }
 
 /**
- * Data fetched with the use of `sdk.api.getNameEntryByName` method.
+ * Data fetched with the use of `aeSdk.api.getNameEntryByName` method.
  */
 export interface INameEntryFetched {
   id: string;
   owner: string;
   pointers: { id: string; key: string }[];
   ttl: number;
-}
-
-/**
- * Temporary typing for the SDK used in the app.
- * TODO remove after migrating to SDK v12
- */
-export interface ISdk {
-  addNode: (name: string, node: any, select: boolean) => void;
-  addRpcClient: (connection: any) => any;
-  Ae: Dictionary;
-  aensClaim: (name: string, salt: string, options?: any) => Promise<any>;
-  aensPreclaim: (name: string) => Promise<any>;
-  aensQuery: (name: string) => Promise<any>;
-  api: Record<string, GenericApiMethod>;
-  balance: (address: string, options?: any) => Promise<number>;
-  compilerApi: Record<string, (...args: any[]) => Promise<any>>;
-  getAccount: (publicKey: any) => Promise<any>
-  gaAttachTx: (options: {
-    ownerId: any
-    code: any
-    callData: any
-    authFun: any
-    gas: any
-    options: { innerTx: boolean }
-  }) => Promise<any>
-  getContractInstance: (o: any) => Promise<any>
-  getContractByteCode: (contractId: Encoded.ContractAddress) => Promise<{ bytecode: any }>
-  getNetworkId: () => string
-  payForTransaction: (
-    rawTx: string,
-    options: {
-      waitMined: boolean;
-      modal: boolean;
-      innerTx?: boolean;
-    }
-  ) => Promise<{ hash: string, rawTx: string }>;
-  payingForTx(arg0: any): any;
-  poll: (txHash: string, options?: any) => any;
-  pool: Map<string, any>;
-  rpcClients: any[];
-  shareWalletInfo: (c: any) => any;
-  signTransaction: (t: any, o: any) => Promise<any>;
-  signMessage: ISignMessage;
-  send: (
-    tx: any,
-    options?: {
-      innerTx?: boolean;
-      onAccount: string;
-      authData?: any;
-    }
-  ) => Promise<ITransaction>;
-  sendTransaction: (t: any, o: any) => Promise<any>;
-  selectedNode: {
-    consensusProtocolVersion: number;
-    instance: any; // Node instance
-    internalUrl?: any;
-    name: string; // Testnet / Mainnet
-    networkId: string; // ae_uat / ae_mainnet
-    url: string;
-    version: string;
-  };
-  spend: (a: any, r: any, o: any) => Promise<any>;
-  spendTx: (a: any) => Promise<any>;
-  address: () => Promise<string>;
-  aensBid: (name: string, aettos: any) => Promise<any>;
 }
 
 /**


### PR DESCRIPTION
as we import multiple SDKs for multichain architecture, Naming sdk as aeSdk( as per SDK repo), and other public examples is good.

Removed the `ISDK` type too.