### PR TITLE
[SW-1019] Implement multichain protocol interface

### DIFF
--- a/src/composables/accounts.ts
+++ b/src/composables/accounts.ts
@@ -8,9 +8,7 @@ import type {
   INetwork,
 } from '@/types';
 import { tg } from '@/store/plugins/languages';
-import { PROTOCOL_AETERNITY, PROTOCOL_BITCOIN } from '@/constants';
 import { getAccountNameToDisplay } from '@/utils';
-import { STUB_ACCOUNT } from '@/constants/stubs';
 import { AE_FAUCET_URL } from '@/protocols/aeternity/config';
 import { buildSimplexLink } from '@/protocols/aeternity/helpers';
 import { AeScan } from '@/protocols/aeternity/libs/AeScan';
@@ -18,30 +16,7 @@ import { AeScan } from '@/protocols/aeternity/libs/AeScan';
 export function useAccounts({ store }: IDefaultComposableOptions) {
   // TODO in the future the state of the accounts should be stored in this composable
   const activeIdx = computed((): number => store.state.accounts?.activeIdx || 0);
-  const accounts = computed((): IAccount[] => {
-    const baseAccounts: IAccount[] = (store.getters.accounts || []).map((acc: IAccount) => ({
-      ...acc,
-      protocol: PROTOCOL_AETERNITY,
-    }));
-
-    /**
-     * For the purpose of multichain Vue components architecture testing
-     * we add this dummy BTC account.
-     * TODO remove when PoC is approved
-     */
-    if (baseAccounts.length) {
-      baseAccounts.push({
-        idx: baseAccounts.length,
-        address: STUB_ACCOUNT.address,
-        protocol: PROTOCOL_BITCOIN,
-        publicKey: new Uint8Array(),
-        secretKey: new Uint8Array(),
-        showed: true,
-        type: '',
-      });
-    }
-    return baseAccounts;
-  });
+  const accounts = computed((): IAccount[] => store.getters.accounts || []);
   const accountsAddressList = computed(() => accounts.value.map((acc) => acc.address));
   const activeAccount = computed((): IAccount => accounts.value[activeIdx.value] || {});
   const isLoggedIn = computed(

--- a/src/composables/balances.ts
+++ b/src/composables/balances.ts
@@ -1,5 +1,4 @@
 import { computed } from 'vue';
-import { Encoded } from '@aeternity/aepp-sdk';
 import { isEmpty, mapValues } from 'lodash-es';
 import BigNumber from 'bignumber.js';
 import type {
@@ -14,6 +13,7 @@ import {
   AE_CONTRACT_ID,
 } from '@/protocols/aeternity/config';
 import { aettosToAe } from '@/protocols/aeternity/helpers';
+import { ProtocolAdapterFactory } from '@/lib/ProtocolAdapterFactory';
 import {
   createNetworkWatcher,
   createPollingBasedOnMountedComponents,
@@ -21,7 +21,6 @@ import {
 } from './composablesHelpers';
 import { useCurrencies } from './currencies';
 import { useAccounts } from './accounts';
-import { useAeSdk } from './aeSdk';
 
 type Balances = Record<string, Balance>;
 
@@ -43,7 +42,6 @@ const { useStorageRef } = createStorageRef<Balances>({}, LOCAL_STORAGE_BALANCES_
  * to live update the values. If no components are using it the polling stops.
  */
 export function useBalances({ store }: IDefaultComposableOptions) {
-  const { getAeSdk } = useAeSdk({ store });
   const { aeternityData } = useCurrencies();
   const { activeAccount, accounts } = useAccounts({ store });
 
@@ -68,10 +66,11 @@ export function useBalances({ store }: IDefaultComposableOptions) {
   }
 
   async function updateBalances() {
-    const aeSdk = await getAeSdk();
     const balancesPromises = accounts.value.map(
-      // TODO - type address in IAccount interface
-      ({ address }) => aeSdk.getBalance(address as Encoded.AccountAddress).catch((error) => {
+      async ({
+        address,
+        protocol,
+      }) => (ProtocolAdapterFactory.getAdapter(protocol)).getBalance(address).catch((error) => {
         if (!isNotFoundError(error)) {
           handleUnknownError(error);
         }

--- a/src/lib/ProtocolAdapterFactory.ts
+++ b/src/lib/ProtocolAdapterFactory.ts
@@ -1,0 +1,34 @@
+import type {
+  Class,
+  Protocol,
+} from '@/types';
+import { BaseProtocolAdapter } from '@/protocols/BaseProtocolAdapter';
+import { AeternityAdapter } from '@/protocols/aeternity/libs/AeternityAdapter';
+import { BitcoinAdapter } from '@/protocols/bitcoin/libs/BitcoinAdapter';
+import {
+  PROTOCOL_AETERNITY,
+  PROTOCOL_BITCOIN,
+} from '@/constants';
+
+/**
+ * Encapsulates helper methods related to multiple protocol instances
+ */
+export const ProtocolAdapterFactory = (() => {
+  const protocolAdapterClassRegistry: Record<Protocol, Class<BaseProtocolAdapter> > = {
+    [PROTOCOL_AETERNITY]: AeternityAdapter,
+    [PROTOCOL_BITCOIN]: BitcoinAdapter,
+  };
+
+  const protocolAdapterRegistry: Partial<Record<Protocol, BaseProtocolAdapter>> = {};
+
+  function getAdapter(protocol: Protocol): BaseProtocolAdapter {
+    if (!protocolAdapterRegistry[protocol]) {
+      protocolAdapterRegistry[protocol] = new protocolAdapterClassRegistry[protocol]();
+    }
+    return protocolAdapterRegistry[protocol]!;
+  }
+
+  return {
+    getAdapter,
+  };
+})();

--- a/src/protocols/BaseProtocolAdapter.ts
+++ b/src/protocols/BaseProtocolAdapter.ts
@@ -1,0 +1,6 @@
+/**
+ *  Represents common attributes and behavior of a protocol
+ */
+export abstract class BaseProtocolAdapter {
+  abstract getBalance(address: string): Promise<string>;
+}

--- a/src/protocols/aeternity/libs/AeternityAdapter.ts
+++ b/src/protocols/aeternity/libs/AeternityAdapter.ts
@@ -1,0 +1,15 @@
+/* eslint-disable class-methods-use-this */
+
+import { Encoded } from '@aeternity/aepp-sdk';
+import { useStore } from 'vuex';
+import { useAeSdk } from '@/composables/aeSdk';
+import { BaseProtocolAdapter } from '@/protocols/BaseProtocolAdapter';
+
+export class AeternityAdapter extends BaseProtocolAdapter {
+  async getBalance(address: Encoded.AccountAddress): Promise<string> {
+    const store = useStore();
+    const { getAeSdk } = useAeSdk({ store });
+    const sdk = await getAeSdk();
+    return sdk.getBalance(address);
+  }
+}

--- a/src/protocols/bitcoin/libs/BitcoinAdapter.ts
+++ b/src/protocols/bitcoin/libs/BitcoinAdapter.ts
@@ -1,0 +1,11 @@
+/* eslint-disable class-methods-use-this */
+
+import { BaseProtocolAdapter } from '@/protocols/BaseProtocolAdapter';
+
+export class BitcoinAdapter extends BaseProtocolAdapter {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async getBalance(address: string): Promise<string> {
+    // TODO: Implement this with bitcoin adapter
+    throw new Error('Method not implemented.');
+  }
+}

--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -4,10 +4,11 @@ import { mnemonicToSeed } from '@aeternity/bip39';
 import { Tag } from '@aeternity/aepp-sdk';
 import { toShiftedBigNumber } from '@/utils';
 import {
+  ACCOUNT_HD_WALLET,
   NETWORK_MAINNET,
   NETWORK_TESTNET,
   NODE_STATUS_CONNECTED,
-  ACCOUNT_HD_WALLET,
+  PROTOCOL_AETERNITY,
   TX_DIRECTION,
 } from '@/constants';
 import { useAeSdk } from '@/composables';
@@ -26,9 +27,12 @@ export default {
   accounts({ accounts: { list } }, getters) {
     if (!getters.wallet) return [];
     return list
-      .map(({ idx, type, ...acc }) => ({
+      .map(({
+        idx, type, protocol, ...acc
+      }) => ({
         idx,
         type,
+        protocol: protocol || PROTOCOL_AETERNITY,
         ...acc,
         ...(type === ACCOUNT_HD_WALLET ? getHdWalletAccount(getters.wallet, idx) : {}),
       }))

--- a/src/store/modules/accounts/hdWallet.js
+++ b/src/store/modules/accounts/hdWallet.js
@@ -11,6 +11,7 @@ import {
   ACCOUNT_HD_WALLET,
   MODAL_CONFIRM_RAW_SIGN,
   MODAL_CONFIRM_TRANSACTION_SIGN,
+  PROTOCOL_AETERNITY,
 } from '@/constants';
 import { getHdWalletAccount, isTxOfASupportedType } from '@/protocols/aeternity/helpers';
 
@@ -47,7 +48,12 @@ export default {
     create({ state, commit }, isRestored = false) {
       commit(
         'accounts/add',
-        { idx: state.nextAccountIdx, type: ACCOUNT_HD_WALLET, isRestored },
+        {
+          idx: state.nextAccountIdx,
+          type: ACCOUNT_HD_WALLET,
+          isRestored,
+          protocol: PROTOCOL_AETERNITY,
+        },
         { root: true },
       );
       state.nextAccountIdx += 1;

--- a/src/store/modules/accounts/index.js
+++ b/src/store/modules/accounts/index.js
@@ -1,6 +1,9 @@
 /* eslint no-param-reassign: ['error', { 'ignorePropertyModificationsFor': ['state'] }] */
 
-import { ACCOUNT_HD_WALLET } from '@/constants';
+import {
+  ACCOUNT_HD_WALLET,
+  PROTOCOL_AETERNITY,
+} from '@/constants';
 import hdWallet from './hdWallet';
 
 // TODO: modules file is an object, because previously it contained more than one module,
@@ -13,7 +16,7 @@ export default {
 
   state: {
     list: [{
-      idx: 0, showed: true, type: ACCOUNT_HD_WALLET,
+      idx: 0, showed: true, type: ACCOUNT_HD_WALLET, protocol: PROTOCOL_AETERNITY,
     }],
     activeIdx: 0,
   },

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -36,6 +36,8 @@ export * from './filter';
 export * from './forms';
 export * from './protocols';
 
+export type Class<T> = new (...args: unknown[]) => T
+
 export type Dictionary<T = any> = Record<string, T>;
 
 export type Truthy<T> = T extends false | '' | 0 | null | undefined ? never : T;


### PR DESCRIPTION
Approach
1. add new property `protocol` for `IAccount` which holds the account chain. Added default `aeternity` to existing accounts
2. Define interface `IProtocol` with common chain operations
3. Implement `AeternityProtocol, BitcoinProtocol, DogecoinProtocol implements IProtocol`  
4. Define a new composable `sdk.ts` which is crucial and exposes the Protocol instances to the project
5. Use `getSdk` method to send coins and to get the account address balance.