### PR TITLE
Refactor:  Move last popup utils to global utils dir

### DIFF
--- a/src/composables/transactionTx.ts
+++ b/src/composables/transactionTx.ts
@@ -12,13 +12,11 @@ import type {
 } from '@/types';
 import {
   includes,
+  getTxFunctionLabel,
+  getTxTypeLabel,
+  getTxTypeListLabel,
 } from '@/utils';
 import { TX_DIRECTION } from '@/constants';
-import {
-  TX_FUNCTION_TRANSLATIONS,
-  TX_TYPE_TRANSLATIONS,
-  TX_TYPE_LIST_TRANSLATIONS,
-} from '@/popup/utils';
 import {
   AE_TRANSACTION_OWNERSHIP_STATUS,
   TX_RETURN_TYPE_OK,
@@ -76,31 +74,25 @@ export function useTransactionTx({
    * Transaction TX type value converted into human readable label
    * displayed on the transaction details page.
    */
-  const txTypeLabel = computed((): string => {
-    const translateFunc = (txType.value) ? TX_TYPE_TRANSLATIONS[txType.value] : null;
-    return translateFunc ? translateFunc() : '';
-  });
+  const txTypeLabel = computed((): string => txType.value ? getTxTypeLabel(txType.value) : '');
 
   /**
    * Transaction TX type value converted into human readable label
    * displayed on the transaction lists.
    */
   const txTypeListLabel = computed((): string => {
-    const translateFunc = (txType.value)
-      ? TX_TYPE_LIST_TRANSLATIONS[txType.value]
-      : null;
-    return translateFunc ? translateFunc() : txTypeLabel.value;
+    const listTranslation = (txType.value) ? getTxTypeListLabel(txType.value) : '';
+    return listTranslation ?? txTypeLabel.value;
   });
 
   /**
    * Transaction TX function value converted into human readable label
    */
-  const txFunctionLabel = computed((): string => {
-    const translateFunc = (outerTx.value?.function)
-      ? TX_FUNCTION_TRANSLATIONS[outerTx.value.function as TxFunctionRaw]
-      : null;
-    return translateFunc ? translateFunc() : '';
-  });
+  const txFunctionLabel = computed(
+    (): string => (outerTx.value?.function)
+      ? getTxFunctionLabel(outerTx.value.function as TxFunctionRaw)
+      : '',
+  );
 
   const isDex = computed((): boolean => isTxDex(innerTx.value, dexContracts.value));
 

--- a/src/popup/router/index.ts
+++ b/src/popup/router/index.ts
@@ -18,21 +18,18 @@ import {
   POPUP_TYPE_ACCOUNT_LIST,
   RUNNING_IN_POPUP,
 } from '@/constants';
-import {
-  watchUntilTruthy,
-} from '@/utils';
+import { watchUntilTruthy } from '@/utils';
+import { getPopupProps } from '@/utils/getPopupProps';
+import store from '@/store';
+import initSdk from '@/lib/wallet';
+import { RouteQueryActionsController } from '@/lib/RouteQueryActionsController';
+import { useAccounts, usePopupProps, useAeSdk } from '@/composables';
+import { routes } from './routes';
 import {
   ROUTE_ACCOUNT,
   ROUTE_INDEX,
   ROUTE_NOT_FOUND,
 } from './routeNames';
-import { routes } from './routes';
-import getPopupProps from '../utils/getPopupProps';
-import store from '../../store';
-import initSdk from '../../lib/wallet';
-
-import { useAccounts, usePopupProps, useAeSdk } from '../../composables';
-import { RouteQueryActionsController } from '../../lib/RouteQueryActionsController';
 
 const router = createRouter({
   routes: routes as RouteRecordRaw[],

--- a/src/popup/utils/index.ts
+++ b/src/popup/utils/index.ts
@@ -1,1 +1,0 @@
-export * from './i18nTranslations';

--- a/src/utils/getPopupProps.ts
+++ b/src/utils/getPopupProps.ts
@@ -83,7 +83,7 @@ const postMessageTest = async ({ type }: PopupMessageData): PostMessageReturn =>
  * Handle the communication between browser popup windows opened by the extension
  * and the extension itself.
  */
-export default async () => {
+export async function getPopupProps() {
   const internalPostMessage = (RUNNING_IN_TESTS)
     ? postMessageTest
     : postMessage;
@@ -111,4 +111,4 @@ export default async () => {
   props.resolve = closingWrapper(resolve);
   props.reject = closingWrapper(reject);
   return props;
-};
+}

--- a/src/utils/i18nTranslations.ts
+++ b/src/utils/i18nTranslations.ts
@@ -3,8 +3,8 @@
  * `t(`foo.bar.${someKey}`);`
  */
 
-import type { TxFunctionMultisig, TxFunctionRaw, TxType } from '../../types';
-import { tg } from '../../store/plugins/languages';
+import type { TxFunctionMultisig, TxFunctionRaw, TxType } from '@/types';
+import { tg } from '@/store/plugins/languages';
 
 type TranslationMap<T extends string | number | symbol = string> = Partial<
   Record<T, () => string>
@@ -13,7 +13,7 @@ type TranslationMap<T extends string | number | symbol = string> = Partial<
 /**
  * ITx.type translated into human readable label
  */
-export const TX_TYPE_TRANSLATIONS: TranslationMap<TxType> = {
+const TX_TYPE_TRANSLATIONS: TranslationMap<TxType> = {
   ChannelCloseSoloTx: () => tg('transaction.type.channelCloseSoloTx'),
   ChannelSlashTx: () => tg('transaction.type.channelSlashTx'),
   ChannelSettleTx: () => tg('transaction.type.channelSettleTx'),
@@ -34,12 +34,16 @@ export const TX_TYPE_TRANSLATIONS: TranslationMap<TxType> = {
   PayingForTx: () => tg('transaction.type.payingForTx'),
   SpendTx: () => tg('transaction.type.sentTx'),
 };
+export function getTxTypeLabel(txType: TxType): string {
+  const translateFunc = TX_TYPE_TRANSLATIONS[txType];
+  return translateFunc ? translateFunc() : '';
+}
 
 /**
  * Replacements for the `txTypeTranslations` displayed on the transaction lists
  * ITx.type
  */
-export const TX_TYPE_LIST_TRANSLATIONS: TranslationMap<TxType> = {
+const TX_TYPE_LIST_TRANSLATIONS: TranslationMap<TxType> = {
   NamePreclaimTx: () => tg('transaction.listType.namePreclaimTx'),
   NameClaimTx: () => tg('transaction.listType.nameClaimTx'),
   NameUpdateTx: () => tg('transaction.listType.nameUpdateTx'),
@@ -47,11 +51,15 @@ export const TX_TYPE_LIST_TRANSLATIONS: TranslationMap<TxType> = {
   NameRevokeTx: () => tg('transaction.listType.nameRevokeTx'),
   SpendTx: () => tg('transaction.listType.sentTx'),
 };
+export function getTxTypeListLabel(txType: TxType): string {
+  const translateFunc = TX_TYPE_LIST_TRANSLATIONS[txType];
+  return translateFunc ? translateFunc() : '';
+}
 
 /**
  * ITx.function translated into human readable label
  */
-export const TX_FUNCTION_TRANSLATIONS: TranslationMap<TxFunctionRaw | TxFunctionMultisig> = {
+const TX_FUNCTION_TRANSLATIONS: TranslationMap<TxFunctionRaw | TxFunctionMultisig> = {
   propose: () => tg('transaction.function.propose'),
   revoke: () => tg('transaction.function.revoke'),
   refuse: () => tg('transaction.function.refuse'),
@@ -59,3 +67,7 @@ export const TX_FUNCTION_TRANSLATIONS: TranslationMap<TxFunctionRaw | TxFunction
   tip_token: () => tg('transaction.function.tip_token'),
   retip_token: () => tg('transaction.function.retip_token'),
 };
+export function getTxFunctionLabel(txFunction: TxFunctionRaw | TxFunctionMultisig): string {
+  const translateFunc = TX_FUNCTION_TRANSLATIONS[txFunction];
+  return translateFunc ? translateFunc() : '';
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './avatar';
 export * from './common';
 export * from './formatters';
+export * from './i18nTranslations';
 export * from './validators';


### PR DESCRIPTION
This is 2nd approach for merging the same change as it turns out the previous one are not present in the feature branch. The previous PR is here: https://github.com/aeternity/superhero-wallet/pull/2225