### PR TITLE
feat: make in-app browser feature mobile-only

### DIFF
--- a/src/popup/components/Header.vue
+++ b/src/popup/components/Header.vue
@@ -47,7 +47,7 @@
         <NetworkButton />
 
         <template v-if="isLoggedIn">
-          <AppsBrowserBtn />
+          <AppsBrowserBtn v-if="IS_CORDOVA" />
 
           <NotificationsIcon />
 
@@ -67,6 +67,7 @@ import { computed, defineComponent } from 'vue';
 import { useStore } from 'vuex';
 import { useRoute, useRouter, RouteLocationRaw } from 'vue-router';
 import { useI18n } from 'vue-i18n';
+import { IS_CORDOVA } from '@/constants';
 import { WalletRouteMeta } from '../../types';
 import {
   ROUTE_ACCOUNT,
@@ -182,6 +183,7 @@ export default defineComponent({
       ThreeDotsIcon,
       ROUTE_ACCOUNT,
       ROUTE_MORE,
+      IS_CORDOVA,
       isLoggedIn,
       showHeaderNavigation,
       isLogoDisabled,

--- a/src/popup/router/index.ts
+++ b/src/popup/router/index.ts
@@ -70,10 +70,19 @@ router.beforeEach(async (to, from, next) => {
     return;
   }
 
-  if (to.name === ROUTE_APPS_BROWSER && activeAccount.value.protocol !== PROTOCOL_AETERNITY) {
-    setActiveAccountByIdx(0);
-    next({ name: ROUTE_APPS_BROWSER });
-    return;
+  if (to.name === ROUTE_APPS_BROWSER) {
+    // In-app browser is mobile-only
+    if (!IS_CORDOVA) {
+      next({ name: ROUTE_INDEX });
+      return;
+    }
+
+    // In-app browser only works with AE accounts
+    if (activeAccount.value.protocol !== PROTOCOL_AETERNITY) {
+      setActiveAccountByIdx(0);
+      next({ name: ROUTE_APPS_BROWSER });
+      return;
+    }
   }
 
   const { isAeSdkReady } = useAeSdk({ store });


### PR DESCRIPTION
In-app browser feature is mobile only so we want to hide it from other platforms.
**Note:** should only be merged when #2242 is tested and is ready to be merged.