### PR TITLE
ci: do not use deprecated commands in actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,14 +43,13 @@ jobs:
           publish_dir: dist/web/root
           cname: wallet.superhero.com
 
-      - uses: actions/create-release@v1
+      - uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-      - uses: alexellis/upload-assets@0.2.3
+          name: Release ${{ github.ref }}
+      - uses: alexellis/upload-assets@0.4.0
         if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- https://github.com/actions/create-release is no longer maintained.
- Wallet were using deprecated commands via outdated actions https://github.com/aeternity/superhero-wallet/actions/runs/6224561419/job/16893035132#step:13:11