### PR TITLE
fix: seed-phrase verification button not fixed to bottom

### DIFF
--- a/src/popup/pages/SeedPhraseVerifySettings.vue
+++ b/src/popup/pages/SeedPhraseVerifySettings.vue
@@ -173,6 +173,9 @@ export default defineComponent({
 
 .seed-phrase-verify-settings {
   position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
 
   &-body {
     padding: var(--screen-padding-x);


### PR DESCRIPTION
closes #2939 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only layout adjustment; main impact is potential minor visual regressions on the seed phrase verification screen across different viewport sizes.
> 
> **Overview**
> Adjusts the `SeedPhraseVerifySettings` page layout to use a full-height flex column container (`display: flex`, `flex-direction: column`, `min-height: 100%`). This ensures the `FixedScreenFooter`/verify button stays anchored to the bottom of the screen instead of floating with content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44b1f255dab98942633acf8f7628d1ba2853fe40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->