### PR TITLE
Harden iframe connection

### DIFF
--- a/src/lib/FramesConnection.ts
+++ b/src/lib/FramesConnection.ts
@@ -1,4 +1,3 @@
-import { times } from 'lodash-es';
 import { BrowserWindowMessageConnection } from '@aeternity/aepp-sdk';
 import { executeAndSetInterval, handleUnknownError } from '@/utils';
 import { AeSdkSuperhero } from '@/protocols/aeternity/libs/AeSdkSuperhero';
@@ -10,56 +9,97 @@ const POLLING_INTERVAL = 3000;
  * and the parent dapps.
  */
 export const FramesConnection = (() => {
-  const connectedFrames = new Set();
   let initialized = false;
   let baseIntervalId: NodeJS.Timeout;
+  let clientIntervalId: NodeJS.Timeout;
+  let clientId: string | null = null;
+  let connectedParent: Window | null = null;
 
-  function getArrayOfAvailableFrames(): Window[] {
-    return [
-      window.parent,
-      ...times(window.parent.frames.length, (i) => window.parent.frames[i]),
-    ];
+  function getParentFrame(): Window | null {
+    return window.parent === window ? null : window.parent;
+  }
+
+  function getParentOrigin(): string | undefined {
+    const ancestorOrigins = (window.location as Location & { ancestorOrigins?: DOMStringList })
+      .ancestorOrigins;
+    if (ancestorOrigins?.length) {
+      return ancestorOrigins[0];
+    }
+
+    if (!document.referrer) {
+      return undefined;
+    }
+    try {
+      return new URL(document.referrer).origin;
+    } catch {
+      return undefined;
+    }
+  }
+
+  function removeClient(aeSdk: AeSdkSuperhero) {
+    clearInterval(clientIntervalId);
+    if (clientId) {
+      aeSdk.removeRpcClient(clientId);
+      clientId = null;
+    }
+    connectedParent = null;
   }
 
   function init(aeSdk: AeSdkSuperhero) {
     initialized = true;
     clearInterval(baseIntervalId);
+    removeClient(aeSdk);
 
     try {
       baseIntervalId = executeAndSetInterval(
-        () => getArrayOfAvailableFrames()
-          .filter((frame) => frame !== window)
-          .forEach((target) => {
-            if (connectedFrames.has(target)) {
-              return;
-            }
+        () => {
+          const parentFrame = getParentFrame();
 
-            connectedFrames.add(target);
-            const connection = new BrowserWindowMessageConnection({ target });
-            const originalConnect = connection.connect;
-            let intervalId: NodeJS.Timeout;
+          if (!parentFrame) {
+            removeClient(aeSdk);
+            return;
+          }
+          if (connectedParent === parentFrame) {
+            return;
+          }
 
-            connection.connect = function connect(onMessage: any) {
-              originalConnect.call(this, (data: any, origin: any, source: any) => {
-                if (source !== target) {
-                  return;
-                }
-                clearInterval(intervalId);
-                onMessage(data, origin, source);
-              }, () => {});
-            };
+          removeClient(aeSdk);
+          connectedParent = parentFrame;
 
-            const clientId = aeSdk.addRpcClient(connection);
+          const connection = new BrowserWindowMessageConnection({
+            target: parentFrame,
+            origin: getParentOrigin(),
+          });
+          const originalConnect = connection.connect;
 
-            intervalId = executeAndSetInterval(() => {
-              if (!getArrayOfAvailableFrames().includes(target)) {
-                clearInterval(intervalId);
-                aeSdk.removeRpcClient(clientId);
+          connection.connect = function connect(onMessage: any) {
+            originalConnect.call(this, (data: any, origin: any, source: any) => {
+              if (source !== parentFrame) {
                 return;
               }
-              aeSdk.shareWalletInfo(clientId);
-            }, 3000);
-          }),
+
+              /**
+               * If the parent origin wasn't available before the first wallet
+               * announcement, pin the connection to the origin that answered it.
+               */
+              if (!this.origin) {
+                this.origin = origin;
+              }
+              clearInterval(clientIntervalId);
+              onMessage(data, origin, source);
+            }, () => {});
+          };
+
+          clientId = aeSdk.addRpcClient(connection);
+
+          clientIntervalId = executeAndSetInterval(() => {
+            if (getParentFrame() !== parentFrame || !clientId) {
+              removeClient(aeSdk);
+              return;
+            }
+            aeSdk.shareWalletInfo(clientId);
+          }, POLLING_INTERVAL);
+        },
         POLLING_INTERVAL,
       );
     } catch (error: any) {
@@ -68,7 +108,9 @@ export const FramesConnection = (() => {
   }
 
   return {
-    initialized,
+    get initialized() {
+      return initialized;
+    },
     init,
   };
 })();

--- a/src/lib/FramesConnection.ts
+++ b/src/lib/FramesConnection.ts
@@ -3,6 +3,7 @@ import { executeAndSetInterval, handleUnknownError } from '@/utils';
 import { AeSdkSuperhero } from '@/protocols/aeternity/libs/AeSdkSuperhero';
 
 const POLLING_INTERVAL = 3000;
+const PARENT_ORIGIN_QUERY_PARAM = 'parentOrigin';
 
 /**
  * Abstraction layer that allows to communicate between the wallet app running in an IFrame
@@ -20,17 +21,27 @@ export const FramesConnection = (() => {
   }
 
   function getParentOrigin(): string | undefined {
-    const ancestorOrigins = (window.location as Location & { ancestorOrigins?: DOMStringList })
-      .ancestorOrigins;
+    const { ancestorOrigins } = (window.location as Location & { ancestorOrigins?: DOMStringList });
     if (ancestorOrigins?.length) {
       return ancestorOrigins[0];
     }
 
-    if (!document.referrer) {
+    if (document.referrer) {
+      try {
+        return new URL(document.referrer).origin;
+      } catch {
+        // Continue to the explicit parent-origin hint fallback below.
+      }
+    }
+
+    const parentOrigin = new URLSearchParams(window.location.search)
+      .get(PARENT_ORIGIN_QUERY_PARAM);
+    if (!parentOrigin) {
       return undefined;
     }
     try {
-      return new URL(document.referrer).origin;
+      const { origin, protocol } = new URL(parentOrigin);
+      return ['http:', 'https:'].includes(protocol) ? origin : undefined;
     } catch {
       return undefined;
     }

--- a/src/protocols/aeternity/libs/AeSdkSuperhero.ts
+++ b/src/protocols/aeternity/libs/AeSdkSuperhero.ts
@@ -3,6 +3,7 @@
 import {
   AensName,
   AeSdkWallet,
+  METHODS,
   sendTransaction,
   spend,
   Encoded,
@@ -17,6 +18,8 @@ type ISpendOptions = Omit<Parameters<typeof spend>[2], 'onAccount' | 'onNode'>
   & {
     payload?: Encoded.Any; // support payload along with the transaction
   }
+
+type IWalletPresenceInfo = Pick<IWalletInfo, 'id' | 'name' | 'origin' | 'type'>;
 
 /**
  * Class extends `AeSdkWallet` from aepp-sdk-js
@@ -69,8 +72,25 @@ export class AeSdkSuperhero extends AeSdkWallet {
       id: this.id,
       name: this.name,
       networkId: await this.api.getNetworkId(),
-      origin: undefined as any,
+      origin: window.location.origin === 'file://' ? '*' : window.location.origin,
       type: this._type as any,
     };
+  }
+
+  getWalletPresenceInfo(): IWalletPresenceInfo {
+    return {
+      id: this.id,
+      name: this.name,
+      origin: window.location.origin === 'file://' ? '*' : window.location.origin,
+      type: this._type as any,
+    };
+  }
+
+  shareWalletInfo(clientId: string): Promise<void> {
+    (this as any)._getClient(clientId).rpc.notify(
+      METHODS.readyToConnect,
+      this.getWalletPresenceInfo(),
+    );
+    return Promise.resolve();
   }
 }

--- a/tests/unit/lib/FramesConnection.spec.ts
+++ b/tests/unit/lib/FramesConnection.spec.ts
@@ -1,0 +1,89 @@
+import {
+  describe, expect, it, jest,
+} from '@jest/globals';
+
+const mockConnectionInstances: any[] = [];
+const mockExecuteAndSetInterval = jest.fn((handler: () => void) => {
+  handler();
+  return 1;
+});
+
+jest.mock('@aeternity/aepp-sdk', () => ({
+  BrowserWindowMessageConnection: jest.fn().mockImplementation(function MockConnection(
+    this: any,
+    options: any,
+  ) {
+    this.origin = options.origin;
+    this.options = options;
+    this.connect = jest.fn();
+    mockConnectionInstances.push(this);
+  }),
+}));
+
+jest.mock('@/utils', () => ({
+  executeAndSetInterval: mockExecuteAndSetInterval,
+  handleUnknownError: jest.fn(),
+}));
+
+describe('FramesConnection', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    mockConnectionInstances.length = 0;
+    mockExecuteAndSetInterval.mockClear();
+    window.history.replaceState({}, '', '/');
+    Object.defineProperty(document, 'referrer', {
+      value: '',
+      configurable: true,
+    });
+  });
+
+  it('connects only to the embedding parent frame', async () => {
+    const parentFrame = { frames: [{}, {}] };
+    Object.defineProperty(window, 'parent', {
+      value: parentFrame,
+      configurable: true,
+    });
+    Object.defineProperty(document, 'referrer', {
+      value: 'https://dapp.example/page',
+      configurable: true,
+    });
+
+    const { FramesConnection } = await import('@/lib/FramesConnection');
+    const aeSdk = {
+      addRpcClient: jest.fn(() => 'client-id'),
+      removeRpcClient: jest.fn(),
+      shareWalletInfo: jest.fn(),
+    };
+
+    FramesConnection.init(aeSdk as any);
+
+    expect(mockConnectionInstances).toHaveLength(1);
+    expect(mockConnectionInstances[0].options).toMatchObject({
+      target: parentFrame,
+      origin: 'https://dapp.example',
+    });
+    expect(aeSdk.shareWalletInfo).toHaveBeenCalledWith('client-id');
+  });
+
+  it('uses parentOrigin query hint when referrer is absent', async () => {
+    const parentFrame = {};
+    Object.defineProperty(window, 'parent', {
+      value: parentFrame,
+      configurable: true,
+    });
+    window.history.replaceState({}, '', '/?parentOrigin=https%3A%2F%2Fhint.example%2Fpath');
+
+    const { FramesConnection } = await import('@/lib/FramesConnection');
+
+    FramesConnection.init({
+      addRpcClient: jest.fn(() => 'client-id'),
+      removeRpcClient: jest.fn(),
+      shareWalletInfo: jest.fn(),
+    } as any);
+
+    expect(mockConnectionInstances[0].options).toMatchObject({
+      target: parentFrame,
+      origin: 'https://hint.example',
+    });
+  });
+});

--- a/tests/unit/protocols/aeternity/libs/AeSdkSuperhero.walletInfo.spec.ts
+++ b/tests/unit/protocols/aeternity/libs/AeSdkSuperhero.walletInfo.spec.ts
@@ -1,0 +1,43 @@
+import {
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+
+const notify = jest.fn();
+
+jest.mock('@aeternity/aepp-sdk', () => ({
+  AeSdkWallet: class {},
+  METHODS: {
+    readyToConnect: 'connection.announcePresence',
+  },
+  sendTransaction: jest.fn(),
+  spend: jest.fn(),
+}));
+
+describe('AeSdkSuperhero wallet info sharing', () => {
+  beforeEach(() => {
+    notify.mockClear();
+  });
+
+  it('announces minimal wallet presence without network details', async () => {
+    const { AeSdkSuperhero } = await import('@/protocols/aeternity/libs/AeSdkSuperhero');
+    const sdk = Object.create(AeSdkSuperhero.prototype);
+
+    sdk.id = 'Superhero Wallet';
+    sdk.name = 'Superhero';
+    sdk._type = 'window';
+    sdk._getClient = jest.fn(() => ({ rpc: { notify } }));
+
+    await sdk.shareWalletInfo('client-id');
+
+    expect(notify).toHaveBeenCalledWith('connection.announcePresence', {
+      id: 'Superhero Wallet',
+      name: 'Superhero',
+      origin: window.location.origin,
+      type: 'window',
+    });
+    expect(notify.mock.calls[0][1]).not.toHaveProperty('networkId');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes iframe-to-parent RPC client setup and origin pinning, which can affect connectivity and cross-origin message acceptance for embedded wallet flows.
> 
> **Overview**
> Hardens the iframe wallet RPC handshake to **only connect to the immediate embedding parent window** (instead of iterating all available frames), and adds parent-origin detection via `ancestorOrigins`, `document.referrer`, or an explicit `?parentOrigin=` hint.
> 
> The connection now **pins the allowed origin on first valid response**, tracks a single active RPC client, and cleans it up when the parent frame changes/disappears; wallet presence announcements are sent via a new `AeSdkSuperhero.shareWalletInfo()` that notifies `METHODS.readyToConnect` with a *minimal* presence payload. Adds unit tests covering parent-only connection/origin selection and presence announcement payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39875bde928adb20d51f51269cc96b4057e3c4bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->