### PR TITLE
Performance improvements

### DIFF
--- a/src/composables/balances.ts
+++ b/src/composables/balances.ts
@@ -20,9 +20,10 @@ type Balances = Record<Protocol, Record<AccountAddress, Balance>>;
 type BalancesSerialized = Record<Protocol, Record<AccountAddress, string>>;
 
 let composableInitialized = false;
+let balancesUpdatePromise: Promise<void> | null = null;
 
 // TODO: Set it to 3000 once the own middleware is ready
-const POLLING_INTERVAL = 5000;
+const POLLING_INTERVAL = 8000;
 
 const initPollingWatcher = createPollingBasedOnMountedComponents(POLLING_INTERVAL);
 
@@ -47,7 +48,7 @@ const balances = useStorageRef<Balances, BalancesSerialized>(
  */
 export function useBalances() {
   const { activeAccount, accounts } = useAccounts();
-  const { onNetworkChange } = useNetworks();
+  const { activeNetwork, onNetworkChange } = useNetworks();
   const { getCurrentCurrencyRate } = useCurrencies();
 
   const balance = computed(() => (
@@ -71,8 +72,14 @@ export function useBalances() {
     return balances.value[protocol]?.[address] || new BigNumber(0);
   }
 
-  async function updateBalances() {
+  async function processBalancesUpdate() {
     const accountsCached = accounts.value; // Store the accounts for the time of update process
+    // Capture the network at the start so we can discard the result if the
+    // user switches networks mid-fetch. Individual `fetchBalance` calls go
+    // through SDKs that read the active network dynamically, so a fetch
+    // that started on the previous network may resolve with values that
+    // partially or fully belong to the new one.
+    const networkAtStart = activeNetwork.value.name;
     const balancesPromises = accountsCached.map(
       async ({
         address,
@@ -85,6 +92,11 @@ export function useBalances() {
       }),
     );
     const rawBalances = await Promise.all(balancesPromises);
+
+    if (activeNetwork.value.name !== networkAtStart) {
+      return;
+    }
+
     const newBalances: Balances = {} as Balances;
 
     rawBalances.forEach((val, index) => {
@@ -96,12 +108,33 @@ export function useBalances() {
     balances.value = newBalances;
   }
 
+  async function updateBalances() {
+    if (!balancesUpdatePromise) {
+      const updatePromise = processBalancesUpdate()
+        .finally(() => {
+          if (balancesUpdatePromise === updatePromise) {
+            balancesUpdatePromise = null;
+          }
+        });
+      balancesUpdatePromise = updatePromise;
+    }
+    return balancesUpdatePromise;
+  }
+
   initPollingWatcher(() => updateBalances());
 
   if (!composableInitialized) {
     composableInitialized = true;
 
     onNetworkChange(() => {
+      // Clear stale balances so the UI doesn't display the previous
+      // network's values until the next poll completes.
+      balances.value = {} as Balances;
+      // Drop the in-flight dedup reference so the next `updateBalances()`
+      // call starts a fresh fetch for the new network instead of awaiting
+      // the previous network's promise (which is now self-cancelling via
+      // the `networkAtStart` guard inside `processBalancesUpdate`).
+      balancesUpdatePromise = null;
       updateBalances();
     });
   }

--- a/src/composables/fungibleTokens.ts
+++ b/src/composables/fungibleTokens.ts
@@ -155,7 +155,7 @@ interface LoadAvailableTokensOptions {
   reset?: boolean;
 }
 
-const tokenBalancesPooling = createPollingBasedOnMountedComponents(10000);
+const tokenBalancesPooling = createPollingBasedOnMountedComponents(30000);
 
 let areTokenBalancesUpdating = false;
 

--- a/src/composables/latestTransactionList.ts
+++ b/src/composables/latestTransactionList.ts
@@ -4,6 +4,7 @@ import type {
   AccountAddress,
   IAccount,
   ICommonTransaction,
+  ITokenBalance,
   ITransaction,
 } from '@/types';
 import { STORAGE_KEYS } from '@/constants';
@@ -41,6 +42,16 @@ const accountsTransactionsPending = useStorageRef<AccountsTransactionList>(
 );
 
 const areLatestTransactionsUpdating = ref(false);
+
+function getTokenBalancesByAccountKey(tokenBalanceList: ITokenBalance[]) {
+  const result: Record<string, ITokenBalance[]> = {};
+  tokenBalanceList.forEach((tokenBalance) => {
+    const key = `${tokenBalance.protocol}:${tokenBalance.address}`;
+    result[key] ??= [];
+    result[key].push(tokenBalance);
+  });
+  return result;
+}
 
 /**
  * All pending and latest fetched transactions as a flat list sorted by date.
@@ -192,10 +203,16 @@ export function useLatestTransactionList() {
 
     watch(
       tokenBalances,
-      (oldTokens, newTokens) => {
-        if (!isEqual(oldTokens, newTokens)) {
-          loadAllLatestTransactions();
-        }
+      (newTokens, oldTokens) => {
+        const newTokensByAccount = getTokenBalancesByAccountKey(newTokens);
+        const oldTokensByAccount = getTokenBalancesByAccountKey(oldTokens);
+
+        accounts.value.forEach((account) => {
+          const key = `${account.protocol}:${account.address}`;
+          if (!isEqual(newTokensByAccount[key] || [], oldTokensByAccount[key] || [])) {
+            loadAccountLatestTransactions(account);
+          }
+        });
       },
       { deep: true },
     );

--- a/src/composables/multisigAccounts.ts
+++ b/src/composables/multisigAccounts.ts
@@ -44,9 +44,18 @@ export interface MultisigAccountsOptions {
 
 let multisigContractInstances: Dictionary<Contract<SimpleGAMultiSigContractApi>> = {};
 let composableInitialized = false;
+let multisigAccountsUpdatePromise: Promise<void> | null = null;
+let lastAllMultisigBalancesRefreshTime = 0;
+let lastAllMultisigConsensusRefreshTime = 0;
+let lastMultisigBackendListRefreshTime = 0;
+let cachedMultisigBackendList: IMultisigAccountResponse[] = [];
+let cachedMultisigBackendListAccountCount = 0;
 const isMultisigBackendUnavailable = ref(false);
 
 const POLLING_INTERVAL = 12000;
+const ALL_MULTISIG_BALANCES_REFRESH_INTERVAL = 60000;
+const ALL_MULTISIG_CONSENSUS_REFRESH_INTERVAL = 60000;
+const MULTISIG_BACKEND_LIST_REFRESH_INTERVAL = 60000;
 
 const multisigAccounts = useStorageRef<IMultisigAccount[]>(
   [],
@@ -114,6 +123,9 @@ export function useMultisigAccounts({
 
   function addPendingMultisigAccount(multisigAccount: IMultisigAccount) {
     pendingMultisigAccounts.value.push(multisigAccount);
+    // The newly created vault won't be in the cached backend list yet,
+    // so invalidate the cache to force the next poll to discover it.
+    lastMultisigBackendListRefreshTime = 0;
   }
 
   // TODO the account details should not store the transaction data
@@ -148,11 +160,17 @@ export function useMultisigAccounts({
   /**
    * Get extended data for a multisig account
    */
-  async function getMultisigAccountInfo({
-    contractId,
-    gaAccountId,
-    ...otherMultisigData
-  }: IMultisigAccountResponse): Promise<IMultisigAccount> {
+  async function getMultisigAccountInfo(
+    {
+      contractId,
+      gaAccountId,
+      ...otherMultisigData
+    }: IMultisigAccountResponse,
+    {
+      refreshBalance = false,
+      refreshConsensus = false,
+    }: { refreshBalance?: boolean; refreshConsensus?: boolean } = {},
+  ): Promise<IMultisigAccount> {
     const dryAeSdk = await getDryAeSdk();
     try {
       if (!multisigContractInstances[contractId]) {
@@ -168,6 +186,22 @@ export function useMultisigAccounts({
 
       const currentAccount = multisigAccounts.value
         .find((account) => account.contractId === contractId);
+      // The active vault and any vault that we already know has a pending tx
+      // need fresh data on every poll so the UI feels responsive.
+      const isActiveOrPending = (
+        gaAccountId === activeMultisigAccountId.value
+        || !!currentAccount?.hasPendingTransaction
+      );
+      const shouldRefreshBalance = (
+        refreshBalance
+        || !currentAccount
+        || isActiveOrPending
+      );
+      const shouldRefreshConsensus = (
+        refreshConsensus
+        || !currentAccount
+        || isActiveOrPending
+      );
 
       const [
         nonce,
@@ -184,11 +218,32 @@ export function useMultisigAccounts({
         currentAccount?.signers
           ? { decodedResult: currentAccount.signers }
           : contractInstance.get_signers(),
-        contractInstance.get_consensus_info(),
-        gaAccountId ? dryAeSdk.getBalance(gaAccountId as Encoded.AccountAddress) : 0,
+        shouldRefreshConsensus
+          ? contractInstance.get_consensus_info()
+          : null,
+        (shouldRefreshBalance && gaAccountId)
+          ? dryAeSdk
+            .getBalance(gaAccountId as Encoded.AccountAddress)
+            .then((value) => toShiftedBigNumber(value, -AE_COIN_PRECISION))
+          : currentAccount?.balance || new BigNumber(0),
       ]));
 
-      const decodedConsensus = consensusResult.decodedResult;
+      // When consensus is not refreshed we keep the previously stored consensus
+      // fields from `currentAccount` and only update the cheap, account-specific
+      // values (nonce, signers, balance).
+      if (!consensusResult && currentAccount) {
+        return {
+          ...currentAccount,
+          ...otherMultisigData,
+          contractId,
+          gaAccountId,
+          nonce: Number(nonce.decodedResult),
+          signers: signers.decodedResult,
+          balance,
+        };
+      }
+
+      const decodedConsensus = consensusResult!.decodedResult;
       const txHash = decodedConsensus.tx_hash;
       const consensus: IMultisigConsensus = camelCaseKeysDeep(decodedConsensus);
 
@@ -204,7 +259,7 @@ export function useMultisigAccounts({
         gaAccountId,
         nonce: Number(nonce.decodedResult),
         signers: signers.decodedResult,
-        balance: toShiftedBigNumber(balance, -AE_COIN_PRECISION),
+        balance,
         hasPendingTransaction,
         txHash: txHash ? Buffer.from(txHash).toString('hex') : undefined,
       };
@@ -222,7 +277,13 @@ export function useMultisigAccounts({
     }
   }
 
-  async function getAllMultisigAccountsInfo(rawMultisigData: IMultisigAccountResponse[]) {
+  async function getAllMultisigAccountsInfo(
+    rawMultisigData: IMultisigAccountResponse[],
+    {
+      refreshBalances = false,
+      refreshConsensus = false,
+    }: { refreshBalances?: boolean; refreshConsensus?: boolean } = {},
+  ) {
     const currentNetworkName = activeNetwork.value.name;
     /**
      * Splitting the rawMultisigData is required to not overload the node
@@ -238,7 +299,10 @@ export function useMultisigAccounts({
       }
       // Process each nested array sequentially
       const promises = nestedArray.map(
-        (rawData: IMultisigAccountResponse) => getMultisigAccountInfo(rawData),
+        (rawData: IMultisigAccountResponse) => getMultisigAccountInfo(
+          rawData,
+          { refreshBalance: refreshBalances, refreshConsensus },
+        ),
       );
       /* eslint-disable no-await-in-loop */
       const arrayResults = await Promise.all(promises) as IMultisigAccount[];
@@ -275,21 +339,42 @@ export function useMultisigAccounts({
   /**
    * Refresh the list of the multisig accounts.
    */
-  async function updateMultisigAccounts() {
+  async function processMultisigAccountsUpdate() {
+    const networkAtStart = activeNetwork.value.name;
     /**
-     * Establish the list of multisig accounts used by the regular accounts
+     * Establish the list of multisig accounts used by the regular accounts.
+     * The backend list rarely changes (a new vault appears only when one is
+     * created/added) so it's cached and only refreshed at most every
+     * MULTISIG_BACKEND_LIST_REFRESH_INTERVAL. The cache is also invalidated
+     * when the number of AE accounts changes (e.g. user adds an account).
      */
     let rawMultisigData: IMultisigAccountResponse[] = [];
-    try {
-      await Promise.all(aeAccounts.value.map(async ({ address }) => rawMultisigData.push(
-        ...(await fetchJson(`${aeActiveNetworkPredefinedSettings.value.multisigBackendUrl}/${address}`)),
-      )));
-      isMultisigBackendUnavailable.value = false;
-    } catch {
-      isMultisigBackendUnavailable.value = true;
-    }
+    const aeAccountCount = aeAccounts.value.length;
+    const shouldRefreshBackendList = (
+      Date.now() - lastMultisigBackendListRefreshTime > MULTISIG_BACKEND_LIST_REFRESH_INTERVAL
+      || cachedMultisigBackendListAccountCount !== aeAccountCount
+    );
 
-    rawMultisigData = uniqBy(rawMultisigData, 'contractId');
+    if (shouldRefreshBackendList) {
+      try {
+        await Promise.all(aeAccounts.value.map(async ({ address }) => rawMultisigData.push(
+          ...(await fetchJson(`${aeActiveNetworkPredefinedSettings.value.multisigBackendUrl}/${address}`)),
+        )));
+        if (activeNetwork.value.name !== networkAtStart) {
+          return;
+        }
+        isMultisigBackendUnavailable.value = false;
+        rawMultisigData = uniqBy(rawMultisigData, 'contractId');
+        cachedMultisigBackendList = rawMultisigData;
+        cachedMultisigBackendListAccountCount = aeAccountCount;
+        lastMultisigBackendListRefreshTime = Date.now();
+      } catch {
+        isMultisigBackendUnavailable.value = true;
+        rawMultisigData = cachedMultisigBackendList;
+      }
+    } else {
+      rawMultisigData = cachedMultisigBackendList;
+    }
 
     function isSignatureRequested(account: IMultisigAccount) {
       return (
@@ -301,7 +386,23 @@ export function useMultisigAccounts({
       );
     }
 
-    const allMultisigAccountsInfo = await getAllMultisigAccountsInfo(rawMultisigData);
+    const shouldRefreshAllBalances = (
+      Date.now() - lastAllMultisigBalancesRefreshTime > ALL_MULTISIG_BALANCES_REFRESH_INTERVAL
+    );
+    const shouldRefreshAllConsensus = (
+      Date.now() - lastAllMultisigConsensusRefreshTime > ALL_MULTISIG_CONSENSUS_REFRESH_INTERVAL
+    );
+    const allMultisigAccountsInfo = await getAllMultisigAccountsInfo(
+      rawMultisigData,
+      {
+        refreshBalances: shouldRefreshAllBalances,
+        refreshConsensus: shouldRefreshAllConsensus,
+      },
+    );
+
+    if (activeNetwork.value.name !== networkAtStart) {
+      return;
+    }
 
     const result: IMultisigAccount[] = allMultisigAccountsInfo
       .filter(Boolean)
@@ -336,6 +437,26 @@ export function useMultisigAccounts({
     }
 
     removeDuplicatesFromPendingAccounts();
+
+    if (shouldRefreshAllBalances) {
+      lastAllMultisigBalancesRefreshTime = Date.now();
+    }
+    if (shouldRefreshAllConsensus) {
+      lastAllMultisigConsensusRefreshTime = Date.now();
+    }
+  }
+
+  async function updateMultisigAccounts() {
+    if (!multisigAccountsUpdatePromise) {
+      const updatePromise = processMultisigAccountsUpdate()
+        .finally(() => {
+          if (multisigAccountsUpdatePromise === updatePromise) {
+            multisigAccountsUpdatePromise = null;
+          }
+        });
+      multisigAccountsUpdatePromise = updatePromise;
+    }
+    return multisigAccountsUpdatePromise;
   }
 
   function fetchAdditionalInfo() {
@@ -361,8 +482,17 @@ export function useMultisigAccounts({
     onNetworkChange(() => {
       multisigAccounts.value = [];
       activeMultisigAccountId.value = '';
-      updateMultisigAccounts();
       multisigContractInstances = {};
+      cachedMultisigBackendList = [];
+      cachedMultisigBackendListAccountCount = 0;
+      lastMultisigBackendListRefreshTime = 0;
+      lastAllMultisigBalancesRefreshTime = 0;
+      lastAllMultisigConsensusRefreshTime = 0;
+      // Drop the in-flight dedup reference so the next `updateMultisigAccounts()`
+      // call starts a fresh fetch for the new network instead of awaiting a stale
+      // run that may still complete and overwrite the reset timestamps or state.
+      multisigAccountsUpdatePromise = null;
+      updateMultisigAccounts();
     });
   }
 

--- a/src/popup/components/DetailsItem.vue
+++ b/src/popup/components/DetailsItem.vue
@@ -147,11 +147,22 @@ export default defineComponent({
     }
 
     > .value {
+      flex-direction: column;
+      align-items: stretch;
+      flex-wrap: nowrap;
       margin-top: 10px;
       padding: 8px 12px;
       background: $color-border;
       border: 1px solid $color-border-hover;
       border-radius: 6px;
+
+      .details-item {
+        width: 100%;
+
+        .value {
+          word-break: break-all;
+        }
+      }
     }
 
     &.expanded {

--- a/src/popup/components/Modals/ConfirmTransactionSign.vue
+++ b/src/popup/components/Modals/ConfirmTransactionSign.vue
@@ -822,7 +822,7 @@ export default defineComponent({
   }
 
   .advanced-transaction-details {
-    width:100%;
+    width: 100%;
   }
 }
 </style>

--- a/src/popup/components/PayloadDetails.vue
+++ b/src/popup/components/PayloadDetails.vue
@@ -1,51 +1,42 @@
 <template>
-  <div
+  <DetailsItem
     v-if="payload && payload.length"
-    class="payload"
+    class="payload-details"
+    :class="{ 'has-actions': Boolean($slots.default) }"
+    :label="$t('modals.send.payload')"
+    :value="payload"
   >
-    <div class="payload-header">
-      <span
-        class="text-text"
-        v-text="$t('modals.send.payload')"
-      />
+    <template
+      v-if="$slots.default"
+      #label
+    >
       <slot />
-    </div>
-
-    <div
-      class="payload-text"
-      v-text="payload"
-    />
-  </div>
+    </template>
+  </DetailsItem>
 </template>
 
-<script>
-export default {
+<script lang="ts">
+import { defineComponent } from 'vue';
+import DetailsItem from './DetailsItem.vue';
+
+export default defineComponent({
   name: 'PayloadDetails',
+  components: { DetailsItem },
   props: {
     payload: { type: String, default: '' },
   },
-};
+});
 </script>
 
 <style lang="scss" scoped>
-@use '@/styles/variables' as *;
-@use '@/styles/typography';
-
-.payload {
-  text-align: left;
-  width: 100%;
-
-  .payload-header {
-    display: flex;
-    justify-content: space-between;
-    margin-bottom: 4px;
+.payload-details {
+  &:deep(.value) {
+    word-break: break-all;
   }
 
-  .payload-text {
-    @extend %face-sans-15-regular;
-
-    color: $color-white;
-    opacity: 0.85;
+  &.has-actions:deep(.label) {
+    width: 100%;
+    justify-content: space-between;
   }
 }
 </style>

--- a/src/protocols/aeternity/composables/aeNames.ts
+++ b/src/protocols/aeternity/composables/aeNames.ts
@@ -59,10 +59,11 @@ import { useAeNetworkSettings } from './aeNetworkSettings';
 import { useAeTippingBackend } from './aeTippingBackend';
 import { useAeMiddleware } from './aeMiddleware';
 
-const POLLING_INTERVAL = 10000;
+const DEFAULT_NAMES_POLLING_INTERVAL = 20000;
 const FEE_ESTIMATION_ADDRESS = 'ak_enAPooFqpTQKkhJmU47J16QZu9HbPQQPwWBVeGnzDbDnv9dxp';
 const FEE_ESTIMATION_NONCE = 10000;
 const PENDING_NAME_TRANSFER_TX_MAX_AGE = 5 * 60 * 1000;
+const EXTERNAL_NAME_CACHE_TTL = 10 * 60 * 1000;
 
 interface IUpdateNamePointerParams {
   name: ChainName;
@@ -132,7 +133,19 @@ type NamesRegistry = Record<NetworkId, Record<AccountAddress, ChainName>>;
 let composableInitialized = false;
 let claimPreclaimedNamesPromise: Promise<void> | null = null;
 let extendExpiringOwnedNamesPromise: Promise<void> | null = null;
+let updateDefaultNamesPromise: Promise<void> | null = null;
 let preclaimedNamesEncryptionInitialized = false;
+
+/**
+ * In-memory cache + in-flight dedup for `updateExternalName` lookups.
+ * Many components call `getName(externalAddress)` on render (notification rows,
+ * tx details, address pickers) - without this, each render fires a request
+ * even though the data is already in `externalNamesRegistry`.
+ * Keys are scoped by `${networkId}:${address}` so values don't leak across
+ * network switches.
+ */
+const externalNameLastFetchTime = new Map<string, number>();
+const externalNameInFlight = new Map<string, Promise<void>>();
 
 const ownedNames = useStorageRef<IName[]>([], STORAGE_KEYS.namesOwned);
 const preclaimedNamesEncrypted = useStorageRef<string | null>(
@@ -175,7 +188,7 @@ const auctions = ref<Record<string, IAuction>>({});
 
 const resolvedChainNames = ref<Record<Encoded.Name, AensName>>({});
 
-const initPollingWatcher = createPollingBasedOnMountedComponents(POLLING_INTERVAL);
+const initPollingWatcher = createPollingBasedOnMountedComponents(DEFAULT_NAMES_POLLING_INTERVAL);
 
 /**
  * Aeternity Blockchain allows to match a .chain name to the addresses (AENS service).
@@ -235,14 +248,45 @@ export function useAeNames({ pollingDisabled = false }: aeNamesOptions = {}) {
   async function updateExternalName(address: AccountAddress) {
     ensureExternalNameRegistryExists();
 
-    const { preferredChainName } = await fetchJson(`${aeActiveNetworkSettings.value.backendUrl}/profile/${address}`)
-      .catch(() => ({}));
+    const networkId = nodeNetworkId.value!;
+    const cacheKey = `${networkId}:${address}`;
 
-    if (preferredChainName) {
-      externalNamesRegistry.value[nodeNetworkId.value!][address] = preferredChainName;
-    } else {
-      delete externalNamesRegistry.value[nodeNetworkId.value!][address];
+    const inFlight = externalNameInFlight.get(cacheKey);
+    if (inFlight) {
+      return inFlight;
     }
+
+    const lastFetch = externalNameLastFetchTime.get(cacheKey) || 0;
+    if (Date.now() - lastFetch < EXTERNAL_NAME_CACHE_TTL) {
+      return undefined;
+    }
+
+    const promise = (async () => {
+      let response: { preferredChainName?: ChainName } | null;
+      try {
+        response = await fetchJson(`${aeActiveNetworkSettings.value.backendUrl}/profile/${address}`);
+      } catch {
+        return;
+      }
+
+      // Bail if the network changed mid-flight to avoid writing into the
+      // wrong network's registry.
+      if (nodeNetworkId.value !== networkId) {
+        return;
+      }
+
+      if (response?.preferredChainName) {
+        externalNamesRegistry.value[networkId][address] = response.preferredChainName;
+      } else {
+        delete externalNamesRegistry.value[networkId][address];
+      }
+      externalNameLastFetchTime.set(cacheKey, Date.now());
+    })().finally(() => {
+      externalNameInFlight.delete(cacheKey);
+    });
+
+    externalNameInFlight.set(cacheKey, promise);
+    return promise;
   }
 
   // This function returns computed value to have reactive state and show proper data after fetching
@@ -540,22 +584,50 @@ export function useAeNames({ pollingDisabled = false }: aeNamesOptions = {}) {
     try {
       areNamesFetching.value = true;
 
+      const aeternityAdapter = ProtocolAdapterFactory.getAdapter(PROTOCOLS.aeternity);
       const currentNetworkId = nodeNetworkId.value!;
       const accountResults = await Promise.all(
         aeAccounts.value.map(async ({ address }) => {
-          const [
-            pendingClaimTransactions,
-            accountNames,
-            pendingTransferLookup,
-          ] = await Promise.all([
-            fetchPendingNameClaimTransactions(address),
+          // A single pending-transactions fetch per address; both the
+          // claim-pending and transfer-pending derived lists below are
+          // computed from it. Previously two separate requests were issued
+          // for the same data per account.
+          const [pendingResult, accountNames] = await Promise.all([
+            aeternityAdapter.fetchPendingTransactions?.(address)
+              .then((transactions: ITransaction[]) => ({
+                failed: false,
+                transactions: transactions || [],
+              }))
+              .catch((error: any) => {
+                logSilentError(error);
+                return { failed: true, transactions: [] as ITransaction[] };
+              }) ?? Promise.resolve({ failed: false, transactions: [] as ITransaction[] }),
             fetchAllNames(address),
-            getPendingNameLookupResult(address as AccountAddress, 'NameTransferTx'),
           ]);
+
+          const pendingClaimTransactions = pendingResult.transactions
+            .filter(({ tx: { type } }) => type === 'NameClaimTx')
+            .map(({ tx, ...otherTx }) => ({
+              ...otherTx,
+              ...tx,
+              owner: tx.accountId,
+            })) as unknown as IName[];
+
+          const pendingTransferLookup: PendingNameLookupResult = {
+            failed: pendingResult.failed,
+            transactions: pendingResult.transactions
+              .filter(({ tx: { type } }) => type === 'NameTransferTx')
+              .map(({ tx, hash }) => ({
+                hash,
+                name: tx.name as AensName,
+                owner: tx.accountId as AccountAddress,
+              }) as IPendingNameTransaction),
+          };
+
           return {
             address,
             names: [
-              ...(pendingClaimTransactions || []),
+              ...pendingClaimTransactions,
               ...(accountNames || []),
             ] as IName[],
             pendingTransferLookup,
@@ -621,8 +693,8 @@ export function useAeNames({ pollingDisabled = false }: aeNamesOptions = {}) {
     }
   }
 
-  function updateDefaultNames() {
-    aeAccounts.value.map(async ({ address }) => {
+  async function processDefaultNamesUpdate() {
+    await Promise.all(aeAccounts.value.map(async ({ address }) => {
       const currentNodeId = nodeNetworkId.value;
       const response = await fetchJson(
         `${aeActiveNetworkSettings.value.backendUrl}/profile/${address}`,
@@ -633,7 +705,20 @@ export function useAeNames({ pollingDisabled = false }: aeNamesOptions = {}) {
       }
 
       setDefaultName({ address, name: response?.preferredChainName });
-    });
+    }));
+  }
+
+  async function updateDefaultNames() {
+    if (!updateDefaultNamesPromise) {
+      const updatePromise = processDefaultNamesUpdate()
+        .finally(() => {
+          if (updateDefaultNamesPromise === updatePromise) {
+            updateDefaultNamesPromise = null;
+          }
+        });
+      updateDefaultNamesPromise = updatePromise;
+    }
+    return updateDefaultNamesPromise;
   }
 
   async function updateNamePointer(
@@ -943,6 +1028,8 @@ export function useAeNames({ pollingDisabled = false }: aeNamesOptions = {}) {
     retrieveCachedChainNames();
 
     onNetworkChange(async () => {
+      externalNameLastFetchTime.clear();
+      updateDefaultNamesPromise = null;
       await Promise.all([
         updateOwnedNames(),
         updateDefaultNames(),

--- a/src/protocols/aeternity/composables/aeTokenSales.ts
+++ b/src/protocols/aeternity/composables/aeTokenSales.ts
@@ -21,6 +21,15 @@ const POLLING_INTERVAL = 60000;
 
 const TIMEOUT_LIMIT = 5000;
 
+/**
+ * The per-account token-sales discovery is shared between every poll of
+ * `fetchAccountTokenBalances`. Re-fetching it on every cycle for every account
+ * (which is the same data) is wasteful. We throttle per (networkName, address).
+ */
+const PER_ACCOUNT_TOKEN_SALES_REFRESH_INTERVAL = 60_000;
+const lastTokenSalesByAccountRefreshTime = new Map<string, number>();
+const inFlightTokenSalesByAccount = new Map<string, Promise<void>>();
+
 let composableInitialized = false;
 
 interface TokenFactory {
@@ -169,22 +178,48 @@ export const useAeTokenSales = createCustomScopedComposable(() => {
   }
 
   async function loadAllTokenSalesInfoByAccount(address: Encoded.AccountAddress) {
+    const currentNetworkName = activeNetwork.value.name;
+    const cacheKey = `${currentNetworkName}:${address}`;
+
+    // De-dupe in-flight fetches for the same (network, address) so that
+    // parallel calls share a single network round-trip.
+    const inFlight = inFlightTokenSalesByAccount.get(cacheKey);
+    if (inFlight) {
+      return inFlight;
+    }
+
+    // Skip if we refreshed this (network, address) pair recently. Token sales
+    // discovery for an account is essentially network-wide pricing data;
+    // refreshing it every 30s is wasteful; once per minute is plenty.
+    const lastRefresh = lastTokenSalesByAccountRefreshTime.get(cacheKey) || 0;
+    if (Date.now() - lastRefresh < PER_ACCOUNT_TOKEN_SALES_REFRESH_INTERVAL) {
+      return undefined;
+    }
+
     const tokenSalesUrls = [
       ...(activeNetwork.value.type !== NETWORK_TYPE_CUSTOM
         ? [AE_TOKEN_SALES_URLS[activeNetwork.value.type]]
         : []),
       ...(customTokenSalesUrls.value[activeNetwork.value.name] || []),
     ];
-    const currentNetworkName = activeNetwork.value.name;
-    const allTokenSalesInfo = await Promise.all(
-      tokenSalesUrls.map((url) => loadTokenSalesInfoByAccount(url, address)),
-    );
-    if (currentNetworkName !== activeNetwork.value.name) {
-      return;
-    }
-    allTokenSalesInfo.forEach((response) => {
-      tokenSales.value = uniqBy([...tokenSales.value, ...response], 'address');
+
+    const promise = (async () => {
+      const allTokenSalesInfo = await Promise.all(
+        tokenSalesUrls.map((url) => loadTokenSalesInfoByAccount(url, address)),
+      );
+      if (currentNetworkName !== activeNetwork.value.name) {
+        return;
+      }
+      allTokenSalesInfo.forEach((response) => {
+        tokenSales.value = uniqBy([...tokenSales.value, ...response], 'address');
+      });
+      lastTokenSalesByAccountRefreshTime.set(cacheKey, Date.now());
+    })().finally(() => {
+      inFlightTokenSalesByAccount.delete(cacheKey);
     });
+
+    inFlightTokenSalesByAccount.set(cacheKey, promise);
+    return promise;
   }
 
   async function validateTokenSalesUrl(url: string): Promise<{
@@ -242,6 +277,8 @@ export const useAeTokenSales = createCustomScopedComposable(() => {
       if (network.name !== oldNetwork.name) {
         tokenSales.value = [];
         tokenFactories.value = [];
+        lastTokenSalesByAccountRefreshTime.clear();
+        inFlightTokenSalesByAccount.clear();
         await loadAllTokenFactoriesInfo();
       }
     });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches multiple polling/caching paths for balances, multisig vaults, token sales, and AENS name lookups; incorrect invalidation or network-switch guards could lead to stale/missing UI data across networks.
> 
> **Overview**
> Improves performance and correctness of several high-traffic composables by **deduping in-flight requests**, **throttling expensive refreshes**, and **guarding against network-switch race conditions**.
> 
> `useBalances` now prevents overlapping fetches, clears balances on network change, and discards results if the active network changes mid-request; polling is slowed (5s→8s). Token balance polling is also slowed (10s→30s).
> 
> Multisig polling is optimized by caching the backend vault list (with timed/account-count invalidation), refreshing full balances/consensus less frequently while keeping active/pending vaults fresh, and deduping concurrent updates with safe resets on network change.
> 
> Aeternity names and token-sales lookups add TTL caching + in-flight de-dupe for external address/profile fetches (cleared on network switch), reduce duplicate pending-tx requests when updating owned names, and dedupe default-name updates.
> 
> Transaction refresh triggers are tightened so token-balance changes reload transactions per-account rather than reloading everything. Minor popup UI adjustments improve expandable detail layout and refactor `PayloadDetails` to reuse `DetailsItem`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca549b6a5322cdb4325f5c9ba823d7211abb0d8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->