### PR TITLE
perf: optimize account discovery

### DIFF
--- a/src/protocols/avalanche/libs/AvalancheAdapter.ts
+++ b/src/protocols/avalanche/libs/AvalancheAdapter.ts
@@ -152,7 +152,7 @@ export class AvalancheAdapter extends BaseProtocolAdapter {
 
   override async isAccountUsed(address: AccountAddress): Promise<boolean> {
     const [balance, txCount] = await Promise.all([
-      await this.fetchBalance(address),
+      this.fetchBalance(address),
       this.getTransactionCount(address),
     ]);
     return parseFloat(balance) > 0 || txCount > 0;

--- a/src/protocols/bnb/libs/BnbAdapter.ts
+++ b/src/protocols/bnb/libs/BnbAdapter.ts
@@ -185,7 +185,7 @@ export class BnbAdapter extends BaseProtocolAdapter {
 
   override async isAccountUsed(address: AccountAddress): Promise<boolean> {
     const [balance, txCount] = await Promise.all([
-      await this.fetchBalance(address),
+      this.fetchBalance(address),
       this.getTransactionCount(address),
     ]);
     return parseFloat(balance) > 0 || txCount > 0;

--- a/src/protocols/ethereum/libs/EthereumAdapter.ts
+++ b/src/protocols/ethereum/libs/EthereumAdapter.ts
@@ -190,7 +190,7 @@ export class EthereumAdapter extends BaseProtocolAdapter {
 
   override async isAccountUsed(address: AccountAddress): Promise<boolean> {
     const [balance, txCount] = await Promise.all([
-      await this.fetchBalance(address),
+      this.fetchBalance(address),
       this.getTransactionCount(address),
     ]);
 

--- a/src/protocols/polygonPos/libs/PolygonPosAdapter.ts
+++ b/src/protocols/polygonPos/libs/PolygonPosAdapter.ts
@@ -183,7 +183,7 @@ export class PolygonAdapter extends BaseProtocolAdapter {
 
   override async isAccountUsed(address: AccountAddress): Promise<boolean> {
     const [balance, txCount] = await Promise.all([
-      await this.fetchBalance(address),
+      this.fetchBalance(address),
       this.getTransactionCount(address),
     ]);
     return parseFloat(balance) > 0 || txCount > 0;


### PR DESCRIPTION
fixes #3657

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes redundant `await` inside `Promise.all` so balance and transaction-count fetches actually run in parallel; behavior should be unchanged aside from timing and error surfacing order.
> 
> **Overview**
> Improves EVM account discovery performance by fixing `isAccountUsed` to *truly* run its balance lookup and pending transaction-count lookup concurrently.
> 
> This removes an unnecessary `await` inside `Promise.all` in the `AvalancheAdapter`, `BnbAdapter`, `EthereumAdapter`, and `PolygonPosAdapter`, reducing sequential RPC latency while keeping the same “used account” criteria (non-zero balance or tx count).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d35a2d691569d6f201b0825da25d5a08b554186. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->