### PR TITLE
fix: show splash screen correctly

### DIFF
--- a/android/app/src/main/res/drawable/launch_screen.xml
+++ b/android/app/src/main/res/drawable/launch_screen.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@android:color/black" />
+    <item
+        android:drawable="@drawable/splash_logo"
+        android:gravity="center"
+        android:width="240dp"
+        android:height="240dp" />
+</layer-list>

--- a/android/app/src/main/res/drawable/splash_logo.xml
+++ b/android/app/src/main/res/drawable/splash_logo.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="240dp"
+    android:height="240dp"
+    android:viewportWidth="160"
+    android:viewportHeight="160">
+    <path
+        android:fillColor="#1161FE"
+        android:fillType="evenOdd"
+        android:pathData="M42.9,70.761l21.183,-19.13h37.634l21.183,19.13l-39.887,37.608L42.9,70.761zM66.449,57.5h11.493l24.563,24.239L82.9,100.217L51.689,70.87L66.449,57.5z" />
+</vector>

--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -18,6 +18,9 @@
 
     <style name="AppTheme.NoActionBarLaunch" parent="Theme.SplashScreen">
       <item name="android:windowSplashScreenBackground" tools:targetApi="s">#000000</item>
-      <item name="android:background">@drawable/splash</item>
+      <item name="android:windowSplashScreenAnimatedIcon" tools:targetApi="s">@drawable/splash_logo</item>
+      <item name="android:navigationBarColor">#000000</item>
+      <item name="android:windowLightNavigationBar">false</item>
+      <item name="android:background">@drawable/launch_screen</item>
     </style>
 </resources>

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -12,7 +12,8 @@ const config: CapacitorConfig = {
   plugins: {
     SplashScreen: {
       launchAutoHide: false,
-      backgroundColor: '#141414',
+      backgroundColor: '#000000',
+      androidSplashResourceName: 'launch_screen',
       androidScaleType: 'CENTER_INSIDE',
       splashFullScreen: true,
       useDialog: true,
@@ -21,8 +22,8 @@ const config: CapacitorConfig = {
       insetsHandling: 'disable',
     },
     EdgeToEdge: {
-      navigationBarColor: '#141414',
-      statusBarColor: '#141414',
+      navigationBarColor: '#000000',
+      statusBarColor: '#000000',
     },
   },
 };

--- a/src/popup/App.vue
+++ b/src/popup/App.vue
@@ -273,7 +273,7 @@ export default defineComponent({
           StatusBar.setOverlaysWebView({ overlay: false });
         }
         StatusBar.setStyle({ style: Style.Dark });
-        setMobileStatusBarColor('#141414');
+        setMobileStatusBarColor(IS_ANDROID ? '#000000' : '#141414');
         window.screen.orientation?.lock?.('portrait');
       }
     });
@@ -299,6 +299,8 @@ export default defineComponent({
         setTimeout(() => {
           SplashScreen.hide({
             fadeOutDuration: 300,
+          }).finally(() => {
+            setMobileStatusBarColor('#141414');
           });
         }, 2000);
       }

--- a/src/utils/systemBars.ts
+++ b/src/utils/systemBars.ts
@@ -14,7 +14,10 @@ export async function setMobileStatusBarColor(color: string) {
   if (!IS_MOBILE_APP) return;
 
   if (IS_ANDROID) {
-    await EdgeToEdge.setStatusBarColor({ color });
+    await Promise.all([
+      EdgeToEdge.setStatusBarColor({ color }),
+      EdgeToEdge.setNavigationBarColor({ color }),
+    ]);
     return;
   }
 


### PR DESCRIPTION
fixes #3672

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/configuration changes affecting Android splash resources and system bar coloring; main risk is visual regressions on different Android versions/devices.
> 
> **Overview**
> Fixes Android app startup visuals by introducing a dedicated `launch_screen` drawable (black background + centered vector `splash_logo`) and wiring it into the Android launch theme and Capacitor SplashScreen config.
> 
> Updates mobile runtime behavior to better match the splash transition: Android starts with black system bars, then after `SplashScreen.hide()` resets system bar colors, and `setMobileStatusBarColor` now applies the color to both status and navigation bars on Android via `EdgeToEdge`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7800164075e6c6c7dd1299467230f377d7b8d9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->