### PR TITLE
fix: keep transaction lists mounted during details swipe-back

### DIFF
--- a/src/popup/components/AccountDetailsTransactionsBase.vue
+++ b/src/popup/components/AccountDetailsTransactionsBase.vue
@@ -16,16 +16,32 @@ import {
   onUnmounted,
   ref,
 } from 'vue';
+import { useRoute } from 'vue-router';
 import { IonPage, onIonViewDidEnter, onIonViewDidLeave } from '@ionic/vue';
 
 import {
   useAccounts,
   useTransactionList,
 } from '@/composables';
+import {
+  ROUTE_ACCOUNT_DETAILS,
+  ROUTE_ACCOUNT_DETAILS_ASSETS,
+  ROUTE_ACCOUNT_DETAILS_NAMES,
+  ROUTE_ACCOUNT_DETAILS_NAMES_AUCTIONS,
+  ROUTE_ACCOUNT_DETAILS_NAMES_CLAIM,
+} from '@/popup/router/routeNames';
 
 import TransactionList from '@/popup/components/TransactionList.vue';
 
-let initialized = false;
+const ROUTE_GROUPS = [
+  [
+    ROUTE_ACCOUNT_DETAILS,
+    ROUTE_ACCOUNT_DETAILS_ASSETS,
+    ROUTE_ACCOUNT_DETAILS_NAMES,
+    ROUTE_ACCOUNT_DETAILS_NAMES_AUCTIONS,
+    ROUTE_ACCOUNT_DETAILS_NAMES_CLAIM,
+  ],
+];
 
 export default defineComponent({
   components: {
@@ -33,7 +49,12 @@ export default defineComponent({
     TransactionList,
   },
   setup() {
+    const route = useRoute();
+    const currentRouteGroup = ROUTE_GROUPS.find((routeGroup) => (
+      routeGroup.includes(route.name as string)
+    )) || [];
     const { activeAccount } = useAccounts();
+    let initialized = false;
 
     const {
       transactionsLoadedAndPending,
@@ -61,11 +82,15 @@ export default defineComponent({
       }
     });
 
-    // Fired only when leaving to different tab within the AccountDetails.
+    // Fired when leaving to a different tab within AccountDetails.
+    // During iOS swipe-back the page is still visible while leaving, so keep the list mounted
+    // to avoid an empty redraw/flicker; onUnmounted handles cleanup when leaving AccountDetails.
     onIonViewDidLeave(() => {
-      isPageActive.value = false;
-      stopTransactionListPolling();
-      initialized = false;
+      if (currentRouteGroup.includes(route.name as string)) {
+        isPageActive.value = false;
+        stopTransactionListPolling();
+        initialized = false;
+      }
     });
 
     // Fired when leaving the AccountDetails page.

--- a/src/popup/pages/AccountDetailsMultisigTransactions.vue
+++ b/src/popup/pages/AccountDetailsMultisigTransactions.vue
@@ -18,15 +18,33 @@ import {
   onUnmounted,
   ref,
 } from 'vue';
+import { useRoute } from 'vue-router';
 import { IonPage, onIonViewDidEnter, onIonViewDidLeave } from '@ionic/vue';
 
 import type { ICommonTransaction } from '@/types';
 import { PROTOCOLS } from '@/constants';
 import { useMultisigAccounts, usePendingMultisigTransaction, useTransactionList } from '@/composables';
+import {
+  ROUTE_MULTISIG_DETAILS,
+  ROUTE_MULTISIG_DETAILS_ASSETS,
+  ROUTE_MULTISIG_COIN,
+  ROUTE_MULTISIG_COIN_DETAILS,
+  ROUTE_MULTISIG_DETAILS_INFO,
+} from '@/popup/router/routeNames';
 
 import TransactionList from '../components/TransactionList.vue';
 
-let initialized = false;
+const ROUTE_GROUPS = [
+  [
+    ROUTE_MULTISIG_DETAILS,
+    ROUTE_MULTISIG_DETAILS_ASSETS,
+    ROUTE_MULTISIG_DETAILS_INFO,
+  ],
+  [
+    ROUTE_MULTISIG_COIN,
+    ROUTE_MULTISIG_COIN_DETAILS,
+  ],
+];
 
 export default defineComponent({
   components: {
@@ -34,8 +52,13 @@ export default defineComponent({
     TransactionList,
   },
   setup() {
+    const route = useRoute();
+    const currentRouteGroup = ROUTE_GROUPS.find((routeGroup) => (
+      routeGroup.includes(route.name as string)
+    )) || [];
     const { activeMultisigAccount } = useMultisigAccounts();
     const { pendingMultisigTransaction } = usePendingMultisigTransaction();
+    let initialized = false;
 
     const {
       transactionsLoaded,
@@ -68,11 +91,15 @@ export default defineComponent({
       }
     });
 
-    // Fired only when leaving to different tab within the AccountDetails.
+    // Fired when leaving to a different tab within AccountDetails.
+    // During iOS swipe-back the page is still visible while leaving, so keep the list mounted
+    // to avoid an empty redraw/flicker; onUnmounted handles cleanup when leaving AccountDetails.
     onIonViewDidLeave(() => {
-      isPageActive.value = false;
-      stopTransactionListPolling();
-      initialized = false;
+      if (currentRouteGroup.includes(route.name as string)) {
+        isPageActive.value = false;
+        stopTransactionListPolling();
+        initialized = false;
+      }
     });
 
     // Fired when leaving the AccountDetails page.

--- a/src/popup/pages/Assets/AssetDetailsTransactions.vue
+++ b/src/popup/pages/Assets/AssetDetailsTransactions.vue
@@ -30,10 +30,25 @@ import {
   useMultisigAccounts,
   useTransactionList,
 } from '@/composables';
+import {
+  ROUTE_COIN,
+  ROUTE_COIN_DETAILS,
+  ROUTE_TOKEN,
+  ROUTE_TOKEN_DETAILS,
+} from '@/popup/router/routeNames';
 
 import TransactionList from '@/popup/components/TransactionList.vue';
 
-let initialized = false;
+const ROUTE_GROUPS = [
+  [
+    ROUTE_COIN,
+    ROUTE_COIN_DETAILS,
+  ],
+  [
+    ROUTE_TOKEN,
+    ROUTE_TOKEN_DETAILS,
+  ],
+];
 
 export default defineComponent({
   name: 'AssetDetailsTransactions',
@@ -43,7 +58,11 @@ export default defineComponent({
   },
   setup() {
     const route = useRoute();
+    const currentRouteGroup = ROUTE_GROUPS.find((routeGroup) => (
+      routeGroup.includes(route.name as string)
+    )) || [];
     const assetContractId = route.params.id as AssetContractId;
+    let initialized = false;
 
     const { sharedAssetDetails } = useAssetDetails();
     const { activeAccount } = useAccounts();
@@ -76,7 +95,7 @@ export default defineComponent({
       protocol: (isMultisig.value) ? PROTOCOLS.aeternity : activeAccount.value.protocol,
     });
 
-    // Fired when accessing the page both as tab and whole AccountDetails page.
+    // Fired when accessing the page both as tab and whole AssetDetails page.
     onIonViewDidEnter(() => {
       isPageActive.value = true;
       // IonRouterOutlet re-renders the page twice
@@ -87,14 +106,18 @@ export default defineComponent({
       }
     });
 
-    // Fired only when leaving to different tab within the AccountDetails.
+    // Fired when leaving to a different tab within AssetDetails.
+    // During iOS swipe-back the page is still visible while leaving, so keep the list mounted
+    // to avoid an empty redraw/flicker; onUnmounted handles cleanup when leaving AssetDetails.
     onIonViewDidLeave(() => {
-      isPageActive.value = false;
-      stopTransactionListPolling();
-      initialized = false;
+      if (currentRouteGroup.includes(route.name as string)) {
+        isPageActive.value = false;
+        stopTransactionListPolling();
+        initialized = false;
+      }
     });
 
-    // Fired when leaving the AccountDetails page.
+    // Fired when leaving the AssetDetails page.
     onUnmounted(() => {
       isPageActive.value = false;
       stopTransactionListPolling();

--- a/tests/unit/popup/pages/transactionDetailsLeave.spec.js
+++ b/tests/unit/popup/pages/transactionDetailsLeave.spec.js
@@ -1,0 +1,215 @@
+import { nextTick } from 'vue';
+import { shallowMount } from '@vue/test-utils';
+
+import AccountDetailsTransactionsBase from '../../../../src/popup/components/AccountDetailsTransactionsBase.vue';
+import AccountDetailsMultisigTransactions from '../../../../src/popup/pages/AccountDetailsMultisigTransactions.vue';
+import AssetDetailsTransactions from '../../../../src/popup/pages/Assets/AssetDetailsTransactions.vue';
+import {
+  ROUTE_ACCOUNT,
+  ROUTE_ACCOUNT_DETAILS,
+  ROUTE_ACCOUNT_DETAILS_ASSETS,
+  ROUTE_COIN,
+  ROUTE_COIN_DETAILS,
+  ROUTE_MULTISIG_ACCOUNT,
+  ROUTE_MULTISIG_COIN,
+  ROUTE_MULTISIG_COIN_DETAILS,
+  ROUTE_MULTISIG_DETAILS,
+  ROUTE_MULTISIG_DETAILS_ASSETS,
+  ROUTE_TOKEN,
+  ROUTE_TOKEN_DETAILS,
+} from '../../../../src/popup/router/routeNames';
+
+let mockDidEnterCallback;
+let mockDidLeaveCallback;
+
+const mockRoute = {
+  name: ROUTE_ACCOUNT_DETAILS,
+  params: { id: 'ae' },
+};
+
+const mockInitializeTransactionListPolling = jest.fn();
+const mockStopTransactionListPolling = jest.fn();
+
+jest.mock('@ionic/vue', () => ({
+  IonPage: { name: 'IonPage', template: '<div><slot /></div>' },
+  isPlatform: jest.fn(() => false),
+  onIonViewDidEnter: jest.fn((callback) => {
+    mockDidEnterCallback = callback;
+  }),
+  onIonViewDidLeave: jest.fn((callback) => {
+    mockDidLeaveCallback = callback;
+  }),
+}));
+
+jest.mock('vue-router', () => ({
+  useRoute: () => mockRoute,
+}));
+
+jest.mock('@/lib/ProtocolAdapterFactory', () => ({
+  ProtocolAdapterFactory: {
+    getAdapter: jest.fn(() => ({ coinContractId: 'ae' })),
+  },
+}));
+
+jest.mock('@/composables', () => ({
+  useAccounts: () => ({
+    activeAccount: {
+      value: {
+        address: 'ak_account',
+        protocol: 'aeternity',
+      },
+    },
+  }),
+  useAssetDetails: () => ({
+    sharedAssetDetails: {
+      isMultisig: false,
+    },
+  }),
+  useMultisigAccounts: () => ({
+    activeMultisigAccount: {
+      value: {
+        gaAccountId: 'ak_multisig',
+      },
+    },
+  }),
+  usePendingMultisigTransaction: () => ({
+    pendingMultisigTransaction: { value: null },
+  }),
+  useTransactionList: () => ({
+    transactionsLoaded: { value: [] },
+    transactionsLoadedAndPending: { value: [] },
+    isEndReached: { value: false },
+    isLoading: { value: false },
+    loadCurrentPageTransactions: jest.fn(),
+    initializeTransactionListPolling: mockInitializeTransactionListPolling,
+    stopTransactionListPolling: mockStopTransactionListPolling,
+  }),
+}));
+
+function mountPage(Component, sourceRouteName) {
+  mockRoute.name = sourceRouteName;
+  mockDidEnterCallback = undefined;
+  mockDidLeaveCallback = undefined;
+
+  const wrapper = shallowMount(Component);
+  mockDidEnterCallback();
+
+  return nextTick().then(() => wrapper);
+}
+
+async function expectTransactionListLeaveBehavior(Component, {
+  sourceRouteName,
+  tabRouteName,
+  outsideRouteName,
+}) {
+  let wrapper = await mountPage(Component, sourceRouteName);
+
+  expect(wrapper.vm.isPageActive).toBe(true);
+
+  mockRoute.name = tabRouteName;
+  mockDidLeaveCallback();
+  await nextTick();
+
+  expect(wrapper.vm.isPageActive).toBe(false);
+  expect(mockStopTransactionListPolling).toHaveBeenCalledTimes(1);
+  wrapper.unmount();
+
+  mockStopTransactionListPolling.mockClear();
+
+  wrapper = await mountPage(Component, sourceRouteName);
+  expect(wrapper.vm.isPageActive).toBe(true);
+
+  mockRoute.name = outsideRouteName;
+  mockDidLeaveCallback();
+  await nextTick();
+
+  expect(wrapper.vm.isPageActive).toBe(true);
+  expect(mockStopTransactionListPolling).not.toHaveBeenCalled();
+  wrapper.unmount();
+}
+
+async function expectCachedRouteGroupSwitchInitializes(Component, {
+  firstRouteName,
+  secondRouteName,
+}) {
+  const firstWrapper = await mountPage(Component, firstRouteName);
+
+  expect(mockInitializeTransactionListPolling).toHaveBeenCalledTimes(1);
+
+  mockRoute.name = secondRouteName;
+  mockDidLeaveCallback();
+  await nextTick();
+
+  expect(firstWrapper.vm.isPageActive).toBe(true);
+
+  mockInitializeTransactionListPolling.mockClear();
+
+  const secondWrapper = await mountPage(Component, secondRouteName);
+
+  expect(secondWrapper.vm.isPageActive).toBe(true);
+  expect(mockInitializeTransactionListPolling).toHaveBeenCalledTimes(1);
+
+  firstWrapper.unmount();
+  secondWrapper.unmount();
+}
+
+describe('transaction details leave behavior', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRoute.params = { id: 'ae' };
+  });
+
+  it('keeps regular account transactions mounted when leaving account details', async () => {
+    await expectTransactionListLeaveBehavior(AccountDetailsTransactionsBase, {
+      sourceRouteName: ROUTE_ACCOUNT_DETAILS,
+      tabRouteName: ROUTE_ACCOUNT_DETAILS_ASSETS,
+      outsideRouteName: ROUTE_ACCOUNT,
+    });
+  });
+
+  it('keeps multisig account transactions mounted when leaving multisig details', async () => {
+    await expectTransactionListLeaveBehavior(AccountDetailsMultisigTransactions, {
+      sourceRouteName: ROUTE_MULTISIG_DETAILS,
+      tabRouteName: ROUTE_MULTISIG_DETAILS_ASSETS,
+      outsideRouteName: ROUTE_MULTISIG_ACCOUNT,
+    });
+  });
+
+  it('keeps multisig coin transactions mounted when leaving multisig coin details', async () => {
+    await expectTransactionListLeaveBehavior(AccountDetailsMultisigTransactions, {
+      sourceRouteName: ROUTE_MULTISIG_COIN,
+      tabRouteName: ROUTE_MULTISIG_COIN_DETAILS,
+      outsideRouteName: ROUTE_MULTISIG_DETAILS_ASSETS,
+    });
+  });
+
+  it('keeps coin transactions mounted when leaving coin details', async () => {
+    await expectTransactionListLeaveBehavior(AssetDetailsTransactions, {
+      sourceRouteName: ROUTE_COIN,
+      tabRouteName: ROUTE_COIN_DETAILS,
+      outsideRouteName: ROUTE_ACCOUNT_DETAILS_ASSETS,
+    });
+  });
+
+  it('keeps token transactions mounted when leaving token details', async () => {
+    await expectTransactionListLeaveBehavior(AssetDetailsTransactions, {
+      sourceRouteName: ROUTE_TOKEN,
+      tabRouteName: ROUTE_TOKEN_DETAILS,
+      outsideRouteName: ROUTE_ACCOUNT_DETAILS_ASSETS,
+    });
+  });
+
+  it('initializes polling for cached multisig pages mounted across route groups', async () => {
+    await expectCachedRouteGroupSwitchInitializes(AccountDetailsMultisigTransactions, {
+      firstRouteName: ROUTE_MULTISIG_DETAILS,
+      secondRouteName: ROUTE_MULTISIG_COIN,
+    });
+  });
+
+  it('initializes polling for cached asset pages mounted across route groups', async () => {
+    await expectCachedRouteGroupSwitchInitializes(AssetDetailsTransactions, {
+      firstRouteName: ROUTE_COIN,
+      secondRouteName: ROUTE_TOKEN,
+    });
+  });
+});


### PR DESCRIPTION
fixes #3674

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Ionic view-leave lifecycle handling and polling cleanup for transaction lists; mistakes could leave polling running or cause lists not to refresh when navigating between cached routes.
> 
> **Overview**
> Prevents transaction lists from unmounting/flickering during iOS swipe-back by **only deactivating the list and stopping polling on tab switches within the same details route group**, while relying on `onUnmounted` to clean up when actually leaving details pages.
> 
> This introduces per-page `ROUTE_GROUPS` checks in regular account, multisig, and asset transaction pages, and adds a unit test (`transactionDetailsLeave.spec.js`) covering tab-vs-outside navigation behavior and ensuring polling re-initializes when switching between cached route groups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bfa60193f576d4c2c6ddca970343fc1e66959dce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->