### PR TITLE
fix: allow to load only static stylesheets/fonts

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -3,7 +3,7 @@
   "description": "Superhero Wallet is a multi-blockchain wallet to manage crypto assets and navigate the web3 and DeFi space.",
   "manifest_version": 3,
   "content_security_policy": {
-    "extension_pages": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; connect-src * data:; font-src * data:; frame-src *; img-src * data:; style-src-elem * 'unsafe-inline'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; "
+    "extension_pages": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; connect-src * data:; font-src 'self' data:; frame-src *; img-src * data:; style-src-elem 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; frame-ancestors 'none'; "
   },
   "permissions": [
     "storage",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Tightens the extension Content Security Policy, which improves security but may cause UI regressions if any extension pages still rely on externally hosted fonts or stylesheets.
> 
> **Overview**
> Updates `src/manifest.json` Content Security Policy for extension pages to **disallow remote fonts and stylesheet elements**, limiting `font-src` and `style-src-elem` to `'self'` (plus `data:` for fonts) while keeping other directives unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 057e93acb67eac999642e8739d7db811afc0fac0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->