### PR TITLE
Be able to connect to dapp

### DIFF
--- a/src/offscreen/wallet.ts
+++ b/src/offscreen/wallet.ts
@@ -24,20 +24,74 @@ window.browser = require('webextension-polyfill');
 let isAeSdkBlocked = false;
 let connectionsQueue: Runtime.Port[] = [];
 
+/**
+ * Errors that surface when an aepp port is gone but our state still references it:
+ * - `UnknownRpcClientError` / "RpcClient with id ... do not exist": the SDK's own
+ *   port.onDisconnect listener already deleted the client from `_clients` before
+ *   our cleanup ran.
+ * - `NoWalletConnectedError`: SDK connection was already torn down.
+ * - "Attempting to use a disconnected port object" / "message channel is closed":
+ *   the dapp page entered bfcache or was discarded; `port.postMessage` throws.
+ * These are all recoverable and must not crash the offscreen document.
+ */
+function isExpectedDisconnectedClientError(error: unknown): boolean {
+  return error instanceof Error && (
+    error.name === 'UnknownRpcClientError'
+    || error.name === 'NoWalletConnectedError'
+    || /RpcClient with id .* do not exist/.test(error.message)
+    || /Attempting to use a disconnected port object/.test(error.message)
+    || /message channel is closed/.test(error.message)
+  );
+}
+
 const addAeppConnection = async (port: Runtime.Port) => {
   const { getAeSdk } = useAeSdk();
   const aeSdk = await getAeSdk();
   const connection = new BrowserRuntimeConnection({ port, debug: false });
   const clientId = aeSdk.addRpcClient(connection);
-  await aeSdk.shareWalletInfo(clientId);
-  const shareWalletInfo = setInterval(
-    () => !isAeSdkBlocked && aeSdk.shareWalletInfo(clientId),
-    3000,
-  );
-  port.onDisconnect.addListener(() => {
-    clearInterval(shareWalletInfo);
-    aeSdk.removeRpcClient(clientId);
-  });
+  let shareWalletInfoInterval: NodeJS.Timeout | undefined;
+  let isDisconnected = false;
+
+  const cleanup = () => {
+    if (isDisconnected) return;
+    isDisconnected = true;
+    clearInterval(shareWalletInfoInterval);
+
+    // The SDK auto-deletes the client when its own port.onDisconnect listener
+    // fires (registered inside `addRpcClient`). The `has()` check covers the
+    // common race; the try/catch is the safety net for the narrow window
+    // between `has()` and the call.
+    try {
+      if (aeSdk._clients.has(clientId)) {
+        aeSdk.removeRpcClient(clientId);
+      }
+    } catch (error) {
+      if (!isExpectedDisconnectedClientError(error)) {
+        throw error;
+      }
+    }
+  };
+
+  const shareWalletInfo = async () => {
+    if (isAeSdkBlocked || isDisconnected) return;
+
+    try {
+      await aeSdk.shareWalletInfo(clientId);
+    } catch (error) {
+      if (!isExpectedDisconnectedClientError(error)) {
+        throw error;
+      }
+      cleanup();
+    }
+  };
+
+  port.onDisconnect.addListener(cleanup);
+  await shareWalletInfo();
+  if (!isDisconnected) {
+    shareWalletInfoInterval = setInterval(() => {
+      shareWalletInfo();
+    }, 3000);
+  }
 };
 
 export async function init() {
@@ -135,12 +189,33 @@ export async function disconnect() {
 
   aeSdk._clients.forEach((aepp, aeppId) => {
     if (aepp.status && aepp.status !== 'DISCONNECTED') {
-      aepp.rpc.connection.sendMessage(
-        { method: 'connection.close', params: { reason: 'bye' }, jsonrpc: '2.0' },
-      );
-      aepp.rpc.connection.disconnect();
-      browser.tabs.reload((aepp.rpc.connection as BrowserRuntimeConnection).port.sender!.tab!.id);
+      // If any of these three statements throws an expected disconnect error
+      // the remaining ones are intentionally skipped: the port is already gone,
+      // there's nothing left to send, disconnect, or reload.
+      try {
+        aepp.rpc.connection.sendMessage(
+          { method: 'connection.close', params: { reason: 'bye' }, jsonrpc: '2.0' },
+        );
+        aepp.rpc.connection.disconnect();
+        browser.tabs.reload((aepp.rpc.connection as BrowserRuntimeConnection).port.sender!.tab!.id);
+      } catch (error) {
+        if (!isExpectedDisconnectedClientError(error)) {
+          throw error;
+        }
+      }
     }
-    aeSdk.removeRpcClient(aeppId);
+    // Needed even when `aepp.status === 'DISCONNECTED'`: the SDK's `closeConnection`
+    // RPC handler marks the client DISCONNECTED but leaves it in `_clients`.
+    // The has() guard + catch defend against the SDK auto-removing it first
+    // (see comment in `addAeppConnection.cleanup`).
+    try {
+      if (aeSdk._clients.has(aeppId)) {
+        aeSdk.removeRpcClient(aeppId);
+      }
+    } catch (error) {
+      if (!isExpectedDisconnectedClientError(error)) {
+        throw error;
+      }
+    }
   });
 }

--- a/src/popup/animations/fade.ts
+++ b/src/popup/animations/fade.ts
@@ -5,20 +5,26 @@ const ANIMATION_DURATION = 100;
 
 export const fadeAnimation: IonAnimationBuilder = (
   baseEl: Element,
-  opts: { enteringEl: Element; leavingEl: Element },
+  opts: { enteringEl?: Element; leavingEl?: Element },
 ) => {
-  const enteringAnimation = createAnimation()
-    .addElement(opts.enteringEl)
-    .fromTo('opacity', 0, 1)
-    .duration(ANIMATION_DURATION);
+  const animation = createAnimation();
 
-  const leavingAnimation = createAnimation()
-    .addElement(opts.leavingEl)
-    .fromTo('opacity', 1, 0);
+  if (opts.enteringEl) {
+    const enteringAnimation = createAnimation()
+      .addElement(opts.enteringEl)
+      .fromTo('opacity', 0, 1)
+      .duration(ANIMATION_DURATION);
 
-  const animation = createAnimation()
-    .addAnimation(enteringAnimation)
-    .addAnimation(leavingAnimation);
+    animation.addAnimation(enteringAnimation);
+  }
+
+  if (opts.leavingEl) {
+    const leavingAnimation = createAnimation()
+      .addElement(opts.leavingEl)
+      .fromTo('opacity', 1, 0);
+
+    animation.addAnimation(leavingAnimation);
+  }
 
   return animation;
 };

--- a/src/popup/components/ProtocolSpecificView.vue
+++ b/src/popup/components/ProtocolSpecificView.vue
@@ -2,6 +2,7 @@
   <Component
     :is="componentToDisplay"
     v-if="viewComponentName"
+    v-bind="$attrs"
     :page-did-enter="pageDidEnter"
     :page-will-enter="pageWillEnter"
     :protocol="protocol"

--- a/src/popup/locales/en-US.json
+++ b/src/popup/locales/en-US.json
@@ -783,7 +783,7 @@
       "externalCallbackTitle": "Return to external site",
       "externalCallbackMsg": "Send the result of this action back to \"{url}\"? Any data you just signed will be shared with this destination.",
       "invalidCallbackTitle": "Invalid deeplink callback",
-      "invalidCallbackMsg": "Refusing to redirect to \"{url}\". Callback URLs must use https://, or http:// for local development hosts."
+      "invalidCallbackMsg": "Refusing to redirect to \"{url}\". Callback URLs must use http://, https://, or a supported app scheme."
     },
     "secureLogin": {
       "descriptionBiometric": "Enabling secure login will let you access Superhero Wallet app using your mobile device authentication preferences.",

--- a/src/popup/locales/zh-CN.json
+++ b/src/popup/locales/zh-CN.json
@@ -773,7 +773,7 @@
       "externalCallbackTitle": "返回到外部网站",
       "externalCallbackMsg": "是否将本次操作的结果发送回「{url}」？你刚刚签名的所有数据都将与该目标共享。",
       "invalidCallbackTitle": "无效的深度链接回调",
-      "invalidCallbackMsg": "拒绝重定向到“{url}”。回调 URL 必须使用 https://，或在本地开发主机上使用 http://。"
+      "invalidCallbackMsg": "拒绝重定向到“{url}”。回调 URL 必须使用 http://、https:// 或受支持的应用协议。"
     },
     "secureLogin": {
       "descriptionBiometric": "启用安全登录后，你可以使用移动设备的身份验证方式访问 Superhero 钱包应用。",

--- a/src/protocols/aeternity/views/TransactionDetails.vue
+++ b/src/protocols/aeternity/views/TransactionDetails.vue
@@ -1,190 +1,187 @@
 <template>
-  <div class="transaction-details">
-    <template v-if="transaction && !transaction.incomplete">
-      <TransactionDetailsBase
-        :transaction="transaction"
-        :amount="amount"
-        :amount-total="amountTotal"
-        :fee="transactionFee"
-        :is-error-transaction="isErrorTransaction"
-        :payload="getTransactionPayload(transaction)"
-        :hide-amount-total="(
-          isDex
-          || isAllowance
-          || isAex9
-          || isTokenSale
-          || isTokenSaleFactory
-        )"
-        :hide-fiat="hideFiat"
-        :hash="hash"
+  <TransactionDetailsBase
+    class="transaction-details"
+    :transaction="transaction"
+    :amount="amount"
+    :amount-total="amountTotal"
+    :fee="transactionFee"
+    :is-error-transaction="isErrorTransaction"
+    :payload="transaction ? getTransactionPayload(transaction) : ''"
+    :hide-amount-total="(
+      isDex
+      || isAllowance
+      || isAex9
+      || isTokenSale
+      || isTokenSaleFactory
+    )"
+    :hide-fiat="hideFiat"
+    :hash="hash"
+    :protocol="PROTOCOLS.aeternity"
+    :price="price"
+  >
+    <template #tokens>
+      <TransactionAssetRows
+        :assets="transactionAssets"
+        :error="isErrorTransaction"
+        :is-reversed="isDexPool"
         :protocol="PROTOCOLS.aeternity"
-        :price="price"
-      >
-        <template #tokens>
-          <TransactionAssetRows
-            :assets="transactionAssets"
-            :error="isErrorTransaction"
-            :is-reversed="isDexPool"
-            :protocol="PROTOCOLS.aeternity"
-            icon-size="rg"
-            multiple-rows
-          />
-        </template>
-
-        <template
-          v-if="isDexSwap || isTokenSale"
-          #swap-data
-        >
-          <SwapRates :transaction="transaction" />
-          <SwapRoute :transaction="transaction" />
-        </template>
-
-        <template #additional-content>
-          <TransactionDetailsPoolTokens
-            v-if="(isDexPool || isAllowance)"
-            :transaction="transaction"
-            :tokens="transactionAssets"
-            :reversed="isDexPool"
-          />
-
-          <DetailsItem
-            v-if="aensName"
-            :label="$t('pages.transactionDetails.name')"
-            :value="aensName"
-            class="aens-name"
-            data-cy="aens-name"
-          />
-
-          <DetailsItem
-            v-if="preclaimCommitment"
-            :label="$t('modals.confirmTransactionSign.commitmentId')"
-            class="aens-commitment"
-            data-cy="aens-commitment"
-            small
-          >
-            <template #value>
-              <CopyText
-                hide-icon
-                :value="preclaimCommitment"
-                :copied-text="$t('common.hashCopied')"
-              >
-                <span class="text-address">{{ splitAddress(preclaimCommitment) }}</span>
-              </CopyText>
-            </template>
-          </DetailsItem>
-
-          <DetailsItem
-            v-if="tipUrl"
-            :label="$t('pages.transactionDetails.tipUrl')"
-            class="tip-url"
-            data-cy="tip-url"
-          >
-            <template #value>
-              <CopyText :value="tipUrl">
-                <LinkButton :href="tipLink">
-                  <Truncate
-                    :str="tipUrl"
-                    fixed
-                  />
-                </LinkButton>
-              </CopyText>
-            </template>
-          </DetailsItem>
-        </template>
-
-        <template #multisig-content>
-          <DetailsItem
-            v-if="multisigTransactionFeePaidBy"
-            :label="$t('pages.transactionDetails.feePaidBy')"
-            small
-          >
-            <div class="row payer-id">
-              <Avatar
-                :address="multisigTransactionFeePaidBy"
-                size="sm"
-              />
-              <div>
-                <DialogBox
-                  v-if="isLocalAccountAddress(multisigTransactionFeePaidBy)"
-                  class="dialog-box"
-                  dense
-                  position="bottom"
-                >
-                  {{ $t('common.you') }}
-                </DialogBox>
-                <CopyText
-                  hide-icon
-                  :value="multisigTransactionFeePaidBy"
-                  :copied-text="$t('common.addressCopied')"
-                >
-                  <span class="text-address">
-                    {{ splitAddress(multisigTransactionFeePaidBy) }}
-                  </span>
-                </CopyText>
-              </div>
-            </div>
-          </DetailsItem>
-
-          <DetailsItem
-            v-if="multisigContractId"
-            :label="$t('pages.transactionDetails.vaultContractId')"
-            small
-          >
-            <div class="row">
-              <Avatar
-                :address="multisigContractId"
-                size="sm"
-              />
-              <CopyText
-                hide-icon
-                :value="multisigContractId"
-                :copied-text="$t('common.addressCopied')"
-              >
-                <span class="text-address">
-                  {{ splitAddress(multisigContractId) }}
-                </span>
-              </CopyText>
-            </div>
-          </DetailsItem>
-        </template>
-
-        <template #gas>
-          <DetailsItem
-            v-if="gasUsed"
-            :value="gasUsed"
-            :label="$t('pages.transactionDetails.gasUsed')"
-            data-cy="gas"
-          />
-          <DetailsItem
-            v-if="gasPrice"
-            :label="$t('pages.transactionDetails.gasPrice')"
-            data-cy="gas-price"
-          >
-            <template #value>
-              <TokenAmount
-                :amount="+aettosToAe(gasPrice)"
-                :symbol="AE_SYMBOL"
-                :protocol="PROTOCOLS.aeternity"
-              />
-            </template>
-          </DetailsItem>
-          <DetailsItem
-            v-if="gasCost"
-            :label="$t('transaction.gasCost')"
-            data-cy="gas-price"
-          >
-            <template #value>
-              <TokenAmount
-                :amount="+aettosToAe(gasCost)"
-                :symbol="AE_SYMBOL"
-                :protocol="PROTOCOLS.aeternity"
-              />
-            </template>
-          </DetailsItem>
-        </template>
-      </TransactionDetailsBase>
+        icon-size="rg"
+        multiple-rows
+      />
     </template>
-  </div>
+
+    <template
+      v-if="isDexSwap || isTokenSale"
+      #swap-data
+    >
+      <SwapRates :transaction="transaction" />
+      <SwapRoute :transaction="transaction" />
+    </template>
+
+    <template #additional-content>
+      <TransactionDetailsPoolTokens
+        v-if="(isDexPool || isAllowance)"
+        :transaction="transaction"
+        :tokens="transactionAssets"
+        :reversed="isDexPool"
+      />
+
+      <DetailsItem
+        v-if="aensName"
+        :label="$t('pages.transactionDetails.name')"
+        :value="aensName"
+        class="aens-name"
+        data-cy="aens-name"
+      />
+
+      <DetailsItem
+        v-if="preclaimCommitment"
+        :label="$t('modals.confirmTransactionSign.commitmentId')"
+        class="aens-commitment"
+        data-cy="aens-commitment"
+        small
+      >
+        <template #value>
+          <CopyText
+            hide-icon
+            :value="preclaimCommitment"
+            :copied-text="$t('common.hashCopied')"
+          >
+            <span class="text-address">{{ splitAddress(preclaimCommitment) }}</span>
+          </CopyText>
+        </template>
+      </DetailsItem>
+
+      <DetailsItem
+        v-if="tipUrl"
+        :label="$t('pages.transactionDetails.tipUrl')"
+        class="tip-url"
+        data-cy="tip-url"
+      >
+        <template #value>
+          <CopyText :value="tipUrl">
+            <LinkButton :href="tipLink">
+              <Truncate
+                :str="tipUrl"
+                fixed
+              />
+            </LinkButton>
+          </CopyText>
+        </template>
+      </DetailsItem>
+    </template>
+
+    <template #multisig-content>
+      <DetailsItem
+        v-if="multisigTransactionFeePaidBy"
+        :label="$t('pages.transactionDetails.feePaidBy')"
+        small
+      >
+        <div class="row payer-id">
+          <Avatar
+            :address="multisigTransactionFeePaidBy"
+            size="sm"
+          />
+          <div>
+            <DialogBox
+              v-if="isLocalAccountAddress(multisigTransactionFeePaidBy)"
+              class="dialog-box"
+              dense
+              position="bottom"
+            >
+              {{ $t('common.you') }}
+            </DialogBox>
+            <CopyText
+              hide-icon
+              :value="multisigTransactionFeePaidBy"
+              :copied-text="$t('common.addressCopied')"
+            >
+              <span class="text-address">
+                {{ splitAddress(multisigTransactionFeePaidBy) }}
+              </span>
+            </CopyText>
+          </div>
+        </div>
+      </DetailsItem>
+
+      <DetailsItem
+        v-if="multisigContractId"
+        :label="$t('pages.transactionDetails.vaultContractId')"
+        small
+      >
+        <div class="row">
+          <Avatar
+            :address="multisigContractId"
+            size="sm"
+          />
+          <CopyText
+            hide-icon
+            :value="multisigContractId"
+            :copied-text="$t('common.addressCopied')"
+          >
+            <span class="text-address">
+              {{ splitAddress(multisigContractId) }}
+            </span>
+          </CopyText>
+        </div>
+      </DetailsItem>
+    </template>
+
+    <template #gas>
+      <DetailsItem
+        v-if="gasUsed"
+        :value="gasUsed"
+        :label="$t('pages.transactionDetails.gasUsed')"
+        data-cy="gas"
+      />
+      <DetailsItem
+        v-if="gasPrice"
+        :label="$t('pages.transactionDetails.gasPrice')"
+        data-cy="gas-price"
+      >
+        <template #value>
+          <TokenAmount
+            :amount="+aettosToAe(gasPrice)"
+            :symbol="AE_SYMBOL"
+            :protocol="PROTOCOLS.aeternity"
+          />
+        </template>
+      </DetailsItem>
+      <DetailsItem
+        v-if="gasCost"
+        :label="$t('transaction.gasCost')"
+        data-cy="gas-price"
+      >
+        <template #value>
+          <TokenAmount
+            :amount="+aettosToAe(gasCost)"
+            :symbol="AE_SYMBOL"
+            :protocol="PROTOCOLS.aeternity"
+          />
+        </template>
+      </DetailsItem>
+    </template>
+  </TransactionDetailsBase>
 </template>
 
 <script lang="ts">

--- a/src/protocols/bitcoin/views/TransactionDetails.vue
+++ b/src/protocols/bitcoin/views/TransactionDetails.vue
@@ -1,26 +1,23 @@
 <template>
-  <div class="transaction-details">
-    <template v-if="transaction">
-      <TransactionDetailsBase
-        :transaction="transaction"
-        :amount="amount"
-        :amount-total="amountTotal"
-        :fee="fee"
-        :hash="hash"
+  <TransactionDetailsBase
+    class="transaction-details"
+    :transaction="transaction"
+    :amount="amount"
+    :amount-total="amountTotal"
+    :fee="fee"
+    :hash="hash"
+    :protocol="protocol"
+  >
+    <template #tokens>
+      <TransactionAssetRows
+        :assets="assets"
+        :is-rounded="!!assets"
         :protocol="protocol"
-      >
-        <template #tokens>
-          <TransactionAssetRows
-            :assets="assets"
-            :is-rounded="!!assets"
-            :protocol="protocol"
-            icon-size="rg"
-            multiple-rows
-          />
-        </template>
-      </TransactionDetailsBase>
+        icon-size="rg"
+        multiple-rows
+      />
     </template>
-  </div>
+  </TransactionDetailsBase>
 </template>
 
 <script lang="ts">

--- a/src/protocols/ethereum/views/TransactionDetails.vue
+++ b/src/protocols/ethereum/views/TransactionDetails.vue
@@ -1,6 +1,5 @@
 <template>
   <TransactionDetailsBase
-    v-if="transaction"
     class="transaction-details"
     :transaction="transaction"
     :amount="amount"

--- a/src/protocols/solana/views/TransactionDetails.vue
+++ b/src/protocols/solana/views/TransactionDetails.vue
@@ -1,27 +1,24 @@
 <template>
-  <div class="transaction-details">
-    <template v-if="transaction">
-      <TransactionDetailsBase
-        :transaction="transaction"
-        :amount="amount"
-        :amount-total="amountTotal"
-        :fee="fee"
-        :hash="hash"
+  <TransactionDetailsBase
+    class="transaction-details"
+    :transaction="transaction"
+    :amount="amount"
+    :amount-total="amountTotal"
+    :fee="fee"
+    :hash="hash"
+    :protocol="PROTOCOLS.solana"
+    :hide-amount-total="!isTransactionCoin"
+    :hide-fiat="!isTransactionCoin"
+  >
+    <template #tokens>
+      <TransactionAssetRows
+        :assets="transactionAssets"
         :protocol="PROTOCOLS.solana"
-        :hide-amount-total="!isTransactionCoin"
-        :hide-fiat="!isTransactionCoin"
-      >
-        <template #tokens>
-          <TransactionAssetRows
-            :assets="transactionAssets"
-            :protocol="PROTOCOLS.solana"
-            icon-size="rg"
-            multiple-rows
-          />
-        </template>
-      </TransactionDetailsBase>
+        icon-size="rg"
+        multiple-rows
+      />
     </template>
-  </div>
+  </TransactionDetailsBase>
 </template>
 
 <script lang="ts">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -916,7 +916,7 @@ export interface IHistoryItem {
  */
 export type IonAnimationBuilder = (
   baseEl: Element,
-  opts: { enteringEl: Element; leavingEl: Element }
+  opts: { enteringEl?: Element; leavingEl?: Element }
 ) => Animation;
 
 export interface ITransferResponse {

--- a/src/utils/callbackUrl.ts
+++ b/src/utils/callbackUrl.ts
@@ -22,17 +22,6 @@ function getCallbackUrlString(value: LocationQuery[string]): string | null {
   return (typeof value === 'string' && value.length > 0) ? value : null;
 }
 
-function isLoopbackCallbackHost(hostname: string): boolean {
-  return (
-    hostname === 'localhost'
-    || hostname.endsWith('.localhost')
-    || hostname === '0.0.0.0'
-    || hostname === '::1'
-    || hostname === '[::1]'
-    || /^127(?:\.\d{1,3}){3}$/.test(hostname)
-  );
-}
-
 export function isTrustedCallbackUrl(url: URL): boolean {
   if (ALLOWED_NATIVE_CALLBACK_PROTOCOLS.has(url.protocol)) {
     return true;
@@ -62,10 +51,7 @@ export function validateCallbackUrl(rawUrl: LocationQuery[string]): URL | null {
     }
   }
 
-  if (url.protocol === 'https:') {
-    return url;
-  }
-  if (url.protocol === 'http:' && isLoopbackCallbackHost(url.hostname)) {
+  if (['https:', 'http:'].includes(url.protocol)) {
     return url;
   }
   if (ALLOWED_NATIVE_CALLBACK_PROTOCOLS.has(url.protocol)) {

--- a/tests/unit/composables/deepLinkApi.callback.spec.ts
+++ b/tests/unit/composables/deepLinkApi.callback.spec.ts
@@ -21,25 +21,23 @@ describe('useDeepLinkApi.openCallbackOrGoHome — security gating (HIGH-09)', ()
   const validateCallbackUrl = (rawUrl: string) => {
     try {
       const url = new URL(rawUrl);
-      if (url.protocol === 'https:') return url;
-      if (
-        url.protocol === 'http:'
-        && ['localhost', '0.0.0.0'].includes(url.hostname)
-      ) return url;
-      if (url.protocol === 'http:' && /^127(?:\.\d{1,3}){3}$/.test(url.hostname)) return url;
+      if (['https:', 'http:'].includes(url.protocol)) return url;
       return null;
     } catch {
       return null;
     }
   };
 
-  const isTrustedCallbackUrl = (url: URL) => (
-    url.protocol === 'https:'
-    && (
-      url.hostname === 'superhero.com'
-      || url.hostname.endsWith('.superhero.com')
-    )
-  );
+  const isTrustedCallbackUrl = (url: URL) => {
+    const parsed = validateCallbackUrl(url.toString());
+    return !!parsed && (
+      url.protocol === 'https:'
+      && (
+        url.hostname === 'superhero.com'
+        || url.hostname.endsWith('.superhero.com')
+      )
+    );
+  };
 
   const setup = () => {
     jest.resetModules();
@@ -306,7 +304,9 @@ describe('useDeepLinkApi.openCallbackOrGoHome — security gating (HIGH-09)', ()
     jest.useRealTimers();
   });
 
-  it('rejects non-loopback http callbacks without redirecting', async () => {
+  it('warns before redirecting to http callbacks', async () => {
+    jest.useFakeTimers();
+    confirmModalImpl = () => Promise.resolve();
     route = {
       query: { 'x-success': encodeURIComponent('http://superhero.com/?s={signature}') },
     };
@@ -315,17 +315,19 @@ describe('useDeepLinkApi.openCallbackOrGoHome — security gating (HIGH-09)', ()
     // eslint-disable-next-line global-require
     const { useDeepLinkApi } = require('@/composables/deepLinkApi');
     await useDeepLinkApi().openCallbackOrGoHome(true, { signature: 'SIG123' });
+    jest.runAllTimers();
 
-    expect(loggerWrite).toHaveBeenCalledTimes(1);
-    expect(openConfirmModalMock).not.toHaveBeenCalled();
-    expect(windowOpen).not.toHaveBeenCalled();
+    expect(loggerWrite).not.toHaveBeenCalled();
+    expect(openConfirmModalMock).toHaveBeenCalledTimes(1);
+    expect(windowOpen).toHaveBeenCalledWith('http://superhero.com/?s=SIG123', '_self');
+    jest.useRealTimers();
   });
 
-  it('allows loopback http callbacks but still requires confirmation', async () => {
+  it('warns before redirecting to localhost-style http callbacks', async () => {
     jest.useFakeTimers();
     confirmModalImpl = () => Promise.resolve();
     route = {
-      query: { 'x-success': encodeURIComponent('http://localhost:3000/callback?s={signature}') },
+      query: { 'x-success': encodeURIComponent('http://192.168.100.42:5173/callback?s={signature}') },
     };
     setup();
 
@@ -335,7 +337,7 @@ describe('useDeepLinkApi.openCallbackOrGoHome — security gating (HIGH-09)', ()
     jest.runAllTimers();
 
     expect(openConfirmModalMock).toHaveBeenCalledTimes(1);
-    expect(windowOpen).toHaveBeenCalledWith('http://localhost:3000/callback?s=SIG123', '_self');
+    expect(windowOpen).toHaveBeenCalledWith('http://192.168.100.42:5173/callback?s=SIG123', '_self');
     jest.useRealTimers();
   });
 

--- a/tests/unit/offscreen/wallet.spec.ts
+++ b/tests/unit/offscreen/wallet.spec.ts
@@ -1,0 +1,227 @@
+// @ts-nocheck
+describe('offscreen wallet connections', () => {
+  let onConnectListener: jest.Mock;
+  let disconnectListener: jest.Mock;
+  let aeSdk: any;
+
+  function createPort() {
+    return {
+      name: '',
+      sender: {
+        id: 'test-extension-id',
+        url: 'https://dapp.example',
+      },
+      onDisconnect: {
+        addListener: jest.fn((listener) => {
+          disconnectListener = listener;
+        }),
+      },
+      onMessage: { addListener: jest.fn() },
+    };
+  }
+
+  function mockDependencies() {
+    onConnectListener = jest.fn();
+    disconnectListener = jest.fn();
+    aeSdk = {
+      _clients: new Map([['client-id', {}]]),
+      addRpcClient: jest.fn(() => 'client-id'),
+      removeRpcClient: jest.fn((clientId) => {
+        if (!aeSdk._clients.has(clientId)) {
+          throw new Error(`RpcClient with id ${clientId} do not exist`);
+        }
+        aeSdk._clients.delete(clientId);
+      }),
+      shareWalletInfo: jest.fn().mockResolvedValue(undefined),
+      _pushAccountsToApps: jest.fn(),
+    };
+
+    (global as any).browser = {
+      runtime: {
+        id: 'test-extension-id',
+        onConnect: {
+          addListener: jest.fn((listener) => {
+            onConnectListener = listener;
+          }),
+        },
+        sendMessage: jest.fn(),
+      },
+      tabs: { reload: jest.fn() },
+    };
+
+    jest.doMock('webextension-polyfill', () => (global as any).browser, { virtual: true });
+    jest.doMock('vue', () => ({ watch: jest.fn() }));
+    jest.doMock('@/utils', () => ({ getCleanModalOptions: jest.fn((params) => params) }));
+    jest.doMock('@aeternity/aepp-sdk', () => ({
+      BrowserRuntimeConnection: jest.fn().mockImplementation(({ port }) => ({ port })),
+    }));
+    jest.doMock('@/background/bgPopupHandler', () => ({ setSessionTimeout: jest.fn() }));
+    jest.doMock('@/composables', () => ({
+      useAccounts: () => ({ activeAccount: { value: {} } }),
+      useAeSdk: () => ({
+        isAeSdkReady: { value: true },
+        getAeSdk: jest.fn().mockResolvedValue(aeSdk),
+        resetNode: jest.fn(),
+      }),
+      useAuth: () => ({ secureLoginTimeoutDecrypted: { value: '0' } }),
+      useNetworks: () => ({ activeNetwork: { value: {} } }),
+    }));
+    jest.doMock('@/constants', () => ({
+      CONNECTION_TYPES: {
+        OTHER: 'OTHER',
+        POPUP: 'POPUP',
+        SESSION: 'SESSION',
+      },
+      IS_FIREFOX: false,
+      POPUP_ACTIONS: { getProps: 'getProps' },
+      SESSION_METHODS: { setSessionTimeout: 'setSessionTimeout' },
+    }));
+    jest.doMock('@/offscreen/popupHandler', () => ({
+      getPopup: jest.fn(),
+      removePopup: jest.fn(),
+    }));
+  }
+
+  beforeEach(() => {
+    jest.resetModules();
+    mockDependencies();
+  });
+
+  it('ignores sdk-owned client removal on port disconnect', async () => {
+    let wallet: any;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line global-require
+      wallet = require('@/offscreen/wallet');
+    });
+    await wallet.init();
+    await onConnectListener(createPort());
+
+    aeSdk._clients.delete('client-id');
+
+    expect(() => disconnectListener()).not.toThrow();
+    expect(aeSdk.removeRpcClient).not.toHaveBeenCalled();
+  });
+
+  it('cleans up when sharing wallet info hits a disconnected port', async () => {
+    const error = new Error('Attempting to use a disconnected port object');
+    aeSdk.shareWalletInfo.mockRejectedValueOnce(error);
+
+    let wallet: any;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line global-require
+      wallet = require('@/offscreen/wallet');
+    });
+    await wallet.init();
+    await expect(onConnectListener(createPort())).resolves.toBeUndefined();
+
+    expect(aeSdk.removeRpcClient).toHaveBeenCalledWith('client-id');
+  });
+
+  it('swallows expected errors thrown by removeRpcClient (catch-path safety net)', async () => {
+    const error: any = new Error('RpcClient with id client-id do not exist');
+    error.name = 'UnknownRpcClientError';
+    // Force the has() guard to pass so we actually reach the throwing call.
+    aeSdk._clients.has = jest.fn(() => true);
+    aeSdk.removeRpcClient.mockImplementation(() => { throw error; });
+
+    let wallet: any;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line global-require
+      wallet = require('@/offscreen/wallet');
+    });
+    await wallet.init();
+    await onConnectListener(createPort());
+
+    expect(() => disconnectListener()).not.toThrow();
+    expect(aeSdk.removeRpcClient).toHaveBeenCalledWith('client-id');
+  });
+
+  it('re-throws unexpected errors thrown by removeRpcClient on disconnect', async () => {
+    const error = new Error('something completely unexpected');
+    aeSdk._clients.has = jest.fn(() => true);
+    aeSdk.removeRpcClient.mockImplementation(() => { throw error; });
+
+    let wallet: any;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line global-require
+      wallet = require('@/offscreen/wallet');
+    });
+    await wallet.init();
+    await onConnectListener(createPort());
+
+    expect(() => disconnectListener()).toThrow('something completely unexpected');
+  });
+
+  describe('disconnect()', () => {
+    function setupConnectedClient(overrides: Partial<{
+      sendMessage: jest.Mock;
+      disconnect: jest.Mock;
+      status: string;
+    }> = {}) {
+      const sendMessage = overrides.sendMessage ?? jest.fn();
+      const disconnect = overrides.disconnect ?? jest.fn();
+      const client = {
+        status: overrides.status ?? 'CONNECTED',
+        rpc: {
+          connection: {
+            sendMessage,
+            disconnect,
+            port: { sender: { tab: { id: 42 } } },
+          },
+        },
+      };
+      aeSdk._clients = new Map([['client-id', client]]);
+      return { client, sendMessage, disconnect };
+    }
+
+    it('ignores expected errors thrown by connection.sendMessage / disconnect', async () => {
+      const sendMessage = jest.fn(() => {
+        throw new Error('Attempting to use a disconnected port object');
+      });
+      setupConnectedClient({ sendMessage });
+
+      let wallet: any;
+      jest.isolateModules(() => {
+        // eslint-disable-next-line global-require
+        wallet = require('@/offscreen/wallet');
+      });
+      await wallet.init();
+
+      await expect(wallet.disconnect()).resolves.toBeUndefined();
+      expect(sendMessage).toHaveBeenCalled();
+      expect(aeSdk.removeRpcClient).toHaveBeenCalledWith('client-id');
+    });
+
+    it('ignores expected errors thrown by removeRpcClient', async () => {
+      setupConnectedClient({ status: 'DISCONNECTED' });
+      const error: any = new Error('RpcClient with id client-id do not exist');
+      error.name = 'UnknownRpcClientError';
+      aeSdk._clients.has = jest.fn(() => true);
+      aeSdk.removeRpcClient.mockImplementation(() => { throw error; });
+
+      let wallet: any;
+      jest.isolateModules(() => {
+        // eslint-disable-next-line global-require
+        wallet = require('@/offscreen/wallet');
+      });
+      await wallet.init();
+
+      await expect(wallet.disconnect()).resolves.toBeUndefined();
+      expect(aeSdk.removeRpcClient).toHaveBeenCalledWith('client-id');
+    });
+
+    it('re-throws unexpected errors from connection.sendMessage', async () => {
+      const sendMessage = jest.fn(() => { throw new Error('boom'); });
+      setupConnectedClient({ sendMessage });
+
+      let wallet: any;
+      jest.isolateModules(() => {
+        // eslint-disable-next-line global-require
+        wallet = require('@/offscreen/wallet');
+      });
+      await wallet.init();
+
+      await expect(wallet.disconnect()).rejects.toThrow('boom');
+    });
+  });
+});

--- a/tests/unit/popup/animations/fade.spec.js
+++ b/tests/unit/popup/animations/fade.spec.js
@@ -1,0 +1,48 @@
+import { fadeAnimation } from '@/popup/animations';
+
+const mockAnimations = [];
+
+function mockCreateAnimation() {
+  const animation = {
+    addElement: jest.fn(() => animation),
+    fromTo: jest.fn(() => animation),
+    duration: jest.fn(() => animation),
+    addAnimation: jest.fn(() => animation),
+  };
+
+  mockAnimations.push(animation);
+  return animation;
+}
+
+jest.mock('@ionic/vue', () => ({
+  createAnimation: jest.fn(mockCreateAnimation),
+}));
+
+describe('fadeAnimation', () => {
+  beforeEach(() => {
+    mockAnimations.length = 0;
+  });
+
+  it('animates both route elements when Ionic provides them', () => {
+    const enteringEl = document.createElement('div');
+    const leavingEl = document.createElement('div');
+
+    const animation = fadeAnimation(document.createElement('div'), { enteringEl, leavingEl });
+
+    expect(mockAnimations[1].addElement).toHaveBeenCalledWith(enteringEl);
+    expect(mockAnimations[2].addElement).toHaveBeenCalledWith(leavingEl);
+    expect(animation.addAnimation).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not pass undefined elements to Ionic animations', () => {
+    const enteringEl = document.createElement('div');
+
+    const animation = fadeAnimation(document.createElement('div'), { enteringEl });
+
+    expect(mockAnimations[1].addElement).toHaveBeenCalledWith(enteringEl);
+    expect(mockAnimations.some(({ addElement }) => addElement.mock.calls.some(
+      ([element]) => element === undefined,
+    ))).toBe(false);
+    expect(animation.addAnimation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/popup/components/ProtocolSpecificView.evm.spec.js
+++ b/tests/unit/popup/components/ProtocolSpecificView.evm.spec.js
@@ -1,6 +1,9 @@
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount } from '@vue/test-utils';
 import ProtocolSpecificView from '../../../../src/popup/components/ProtocolSpecificView.vue';
-import { PROTOCOL_VIEW_ACCOUNT_DETAILS } from '../../../../src/constants';
+import {
+  PROTOCOL_VIEW_ACCOUNT_DETAILS,
+  PROTOCOL_VIEW_TRANSFER_SEND,
+} from '../../../../src/constants';
 
 let mockActiveProtocol = 'ethereum';
 
@@ -25,6 +28,19 @@ jest.mock('@/protocols/ethereum/views', () => ({
   default: {
     AccountDetails: () => Promise.resolve({
       template: '<div data-cy="evm-account-details" />',
+    }),
+    TransferSendModal: () => Promise.resolve({
+      props: {
+        isMultisig: Boolean,
+        tokenContractId: String,
+      },
+      template: `
+        <div
+          data-cy="evm-transfer-send"
+          :data-is-multisig="String(isMultisig)"
+          :data-token-contract-id="tokenContractId"
+        />
+      `,
     }),
   },
 }));
@@ -56,5 +72,23 @@ describe('ProtocolSpecificView - EVM protocol mapping', () => {
       global: { stubs: ['InfoBox'] },
     });
     expect(wrapper.exists()).toBe(true);
+  });
+
+  it('forwards modal attributes to the protocol-specific view', async () => {
+    const wrapper = mount(ProtocolSpecificView, {
+      props: {
+        viewComponentName: PROTOCOL_VIEW_TRANSFER_SEND,
+      },
+      attrs: {
+        isMultisig: true,
+        tokenContractId: 'ct_test',
+      },
+      global: { stubs: ['InfoBox'] },
+    });
+    await flushPromises();
+
+    const modal = wrapper.find('[data-cy="evm-transfer-send"]');
+    expect(modal.attributes('data-is-multisig')).toBe('true');
+    expect(modal.attributes('data-token-contract-id')).toBe('ct_test');
   });
 });

--- a/tests/unit/utils/callbackUrl.spec.ts
+++ b/tests/unit/utils/callbackUrl.spec.ts
@@ -41,7 +41,9 @@ describe('callback URL security helpers', () => {
     'http://localhost:3000/callback',
     'http://127.0.0.1:8080/callback',
     'http://0.0.0.0:8080/callback',
-  ])('allows loopback http callbacks for local development %s', (url) => {
+    'http://192.168.100.42:5173/callback',
+    'http://example.com/callback',
+  ])('allows http callbacks but does not trust them %s', (url) => {
     const { validateCallbackUrl, isTrustedCallbackUrl } = loadHelpers();
     const parsed = validateCallbackUrl(url);
 
@@ -61,7 +63,6 @@ describe('callback URL security helpers', () => {
   });
 
   it.each([
-    'http://example.com/callback',
     // eslint-disable-next-line no-script-url
     'javascript:alert(1)',
     'myapp://callback',


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes dapp connection lifecycle/cleanup in the offscreen wallet and relaxes callback URL validation to allow all `http:` redirects (still gated by confirmation), which affects security-sensitive redirect and connectivity paths.
> 
> **Overview**
> **Offscreen dapp connectivity is made more resilient.** `offscreen/wallet.ts` now treats several “port already gone”/SDK race errors as expected, adds guarded cleanup around `shareWalletInfo` and `removeRpcClient`, and makes `disconnect()` best-effort (skip reload/send when the port is already closed) while still removing stale clients.
> 
> **Deeplink callback handling is broadened.** Callback URL validation now accepts any `http:`/`https:` URL (and still supports specific native schemes like `superhero:`/`wc:`), updates locale copy, and adjusts unit tests to ensure `http:` redirects prompt for confirmation rather than being rejected.
> 
> **UI robustness/refactors.** The Ionic `fadeAnimation` builder and `IonAnimationBuilder` typing now allow missing `enteringEl`/`leavingEl`; `ProtocolSpecificView` forwards `$attrs` to protocol-specific components; and protocol `TransactionDetails` views are refactored to consistently render `TransactionDetailsBase` with slot content. New unit tests cover the new behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d2085530af450adeba34af13032654d655ab372. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->