### PR TITLE
Fix asset details send amount error

### DIFF
--- a/src/composables/coinMaxAmount.ts
+++ b/src/composables/coinMaxAmount.ts
@@ -27,14 +27,18 @@ export function useCoinMaxAmount({ formModel, fee }: CoinMaxAmountOptions) {
     const adapter = ProtocolAdapterFactory.getAdapter(formModel.value.selectedAsset?.protocol!);
     return formModel.value?.selectedAsset?.contractId === adapter.coinContractId;
   });
-  const selectedTokenBalance = computed(
-    () => new BigNumber(
-      toShiftedBigNumber(
-        formModel.value.selectedAsset?.amount!,
-        -(formModel.value.selectedAsset?.decimals || -0),
-      ) || 0,
-    ),
-  );
+
+  const selectedTokenBalance = computed(() => {
+    const asset = formModel.value.selectedAsset;
+    const rawAmount = asset?.amount;
+
+    if (rawAmount == null || rawAmount === '') {
+      return new BigNumber(0);
+    }
+
+    const shifted = toShiftedBigNumber(rawAmount, -(asset?.decimals ?? 0));
+    return shifted.isNaN() ? new BigNumber(0) : shifted;
+  });
 
   const max = computed(() => {
     if (balance.value && isCoin.value) {

--- a/src/protocols/ethereum/views/TransferSendModal.vue
+++ b/src/protocols/ethereum/views/TransferSendModal.vue
@@ -42,7 +42,7 @@ import {
   PROTOCOL_VIEW_TRANSFER_SEND,
   TRANSFER_SEND_STEPS,
 } from '@/constants';
-import { useFungibleTokens } from '@/composables';
+import { useAccountAssetsList, useFungibleTokens } from '@/composables';
 
 import TransferSendBase, { transferSendModalRequiredProps } from '@/popup/components/Modals/TransferSendBase.vue';
 import TransferReview from '../components/TransferReview.vue';
@@ -60,6 +60,7 @@ export default defineComponent({
   },
   setup(props) {
     const { getProtocolAvailableTokens } = useFungibleTokens();
+    const { accountAssets } = useAccountAssetsList();
 
     const ethTokensAvailable = computed(() => getProtocolAvailableTokens(props.protocol));
 
@@ -71,7 +72,8 @@ export default defineComponent({
       amount: props.amount,
       payload: props.payload,
       selectedAsset: (props.tokenContractId)
-        ? ethTokensAvailable.value[props.tokenContractId as keyof AssetList]
+        ? accountAssets.value.find(({ contractId }) => contractId === props.tokenContractId)
+          ?? ethTokensAvailable.value[props.tokenContractId as keyof AssetList]
         : undefined,
     });
 

--- a/src/protocols/solana/libs/SolanaAdapter.ts
+++ b/src/protocols/solana/libs/SolanaAdapter.ts
@@ -534,15 +534,14 @@ export class SolanaAdapter extends BaseProtocolAdapter {
       try {
         const ix = tx?.transaction?.message?.instructions?.[0];
         const accIndex = ix?.accounts?.[1];
-        const key = tx?.transaction?.message?.accountKeys?.[accIndex];
-        return key?.toBase58?.();
+        return tx?.transaction?.message?.accountKeys?.[accIndex];
       } catch (e) {
         return undefined;
       }
     })();
 
     const firstIx = tx?.transaction?.message?.instructions?.[0];
-    const programIdBase58 = tx?.transaction?.message?.indexToProgramIds.get(
+    const programIdBase58 = tx?.transaction?.message?.indexToProgramIds?.get(
       firstIx?.programIdIndex,
     )?.toBase58?.();
     const isSystemTransfer = programIdBase58 === SystemProgram.programId.toBase58();
@@ -675,8 +674,8 @@ export class SolanaAdapter extends BaseProtocolAdapter {
       microTime: tx?.blockTime ? tx.blockTime * 1000 : undefined,
       tx: {
         amount: finalAmountSol,
-        senderId: sysSender.toBase58(),
-        recipientId: sysRecipient.toBase58(),
+        senderId: sysSender?.toBase58?.() || '',
+        recipientId: sysRecipient?.toBase58?.() || '',
         ...(!isSystemTransfer ? { contractId: (programIdBase58 || SOL_CONTRACT_ID) } : {}),
         type: (isContractCall ? (Tag[Tag.ContractCallTx] as any) : (Tag[Tag.SpendTx] as any)),
         tag: (isContractCall ? Tag.ContractCallTx : Tag.SpendTx),

--- a/src/protocols/solana/views/TransferSendModal.vue
+++ b/src/protocols/solana/views/TransferSendModal.vue
@@ -40,7 +40,7 @@ import {
   PROTOCOL_VIEW_TRANSFER_SEND,
   TRANSFER_SEND_STEPS,
 } from '@/constants';
-import { useFungibleTokens } from '@/composables';
+import { useAccountAssetsList, useFungibleTokens } from '@/composables';
 
 import TransferSendBase, { transferSendModalRequiredProps } from '@/popup/components/Modals/TransferSendBase.vue';
 import TransferReview from '../components/TransferReview.vue';
@@ -57,6 +57,7 @@ export default defineComponent({
   },
   setup(props) {
     const { getProtocolAvailableTokens } = useFungibleTokens();
+    const { accountAssets } = useAccountAssetsList();
 
     const solanaTokensAvailable = computed(() => getProtocolAvailableTokens(PROTOCOLS.solana));
 
@@ -68,7 +69,8 @@ export default defineComponent({
       amount: props.amount,
       payload: props.payload,
       selectedAsset: (props.tokenContractId)
-        ? solanaTokensAvailable.value[props.tokenContractId as keyof AssetList]
+        ? accountAssets.value.find(({ contractId }) => contractId === props.tokenContractId)
+          ?? solanaTokensAvailable.value[props.tokenContractId as keyof AssetList]
         : undefined,
     });
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches transfer send initialization and max-amount calculation; mistakes could lead to incorrect default asset selection or max amount display, but changes are small and mostly defensive null-handling.
> 
> **Overview**
> Fixes send amount/max calculation by making `useCoinMaxAmount` treat missing/empty `selectedAsset.amount` (and invalid shifted values) as `0` instead of producing NaNs.
> 
> Updates Ethereum and Solana `TransferSendModal` to prefer the matching entry from `useAccountAssetsList().accountAssets` when `tokenContractId` is provided, falling back to protocol token lists only if not found.
> 
> Hardens Solana transaction normalization against missing message fields by making `indexToProgramIds` optional and avoiding crashes/undefined sender/recipient by defaulting `senderId`/`recipientId` to empty strings when public keys are absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4176b0788706001909dd848ef1b98e0a4629c6be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->