### PR TITLE
fix: show only asset transaction list on asset details page

### DIFF
--- a/src/composables/transactionList.ts
+++ b/src/composables/transactionList.ts
@@ -80,7 +80,8 @@ export function useTransactionList({
 
   const transactionsLoadedAndPending = computed(() => uniqBy([
     ...transactionsPending.value,
-    ...(accountsTransactionsLatest.value[accountAddress] || []),
+    // Latest cache is account-wide; skip it on asset-specific lists.
+    ...(assetContractId ? [] : (accountsTransactionsLatest.value[accountAddress] || [])),
     ...transactionsLoaded.value,
   ].filter(({ protocol: transactionProtocol }) => transactionProtocol === protocol), 'hash'));
 

--- a/src/popup/components/AddressBook/AddressBookList.vue
+++ b/src/popup/components/AddressBook/AddressBookList.vue
@@ -20,8 +20,7 @@
 
     <IonContent
       ref="scrollWrapperEl"
-      class="ion-padding"
-      :class="{ 'ion-content-bg': !isSelector }"
+      class="ion-padding address-book-content"
     >
       <div
         v-if="Object.keys(accountsFiltered).length"
@@ -224,6 +223,11 @@ export default defineComponent({
 
 .address-book-list {
   --border-width: 2px;
+
+  .address-book-content {
+    --background: var(--screen-bg-color, #{$color-bg-app});
+    background-color: var(--screen-bg-color, #{$color-bg-app});
+  }
 
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk, CSS-only change that adjusts `IonContent` background styling for the address book list without touching data flow or business logic.
> 
> **Overview**
> Updates `AddressBookList.vue` to apply a dedicated `address-book-content` class on `IonContent` and removes the previous conditional `ion-content-bg` class.
> 
> Adds scoped styles to set the content background via `--screen-bg-color` (with fallback to `$color-bg-app`), ensuring a consistent address book content background across modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f08817982793baedeff62c736b45a436a22c8e31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->