### PR TITLE
ci: add csp headers

### DIFF
--- a/src/web/nginx.conf
+++ b/src/web/nginx.conf
@@ -1,4 +1,11 @@
 server {
+  add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+  add_header X-Content-Type-Options "nosniff" always;
+  add_header X-Frame-Options "DENY" always;
+  add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+  add_header Permissions-Policy "accelerometer=(), autoplay=(), encrypted-media=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), picture-in-picture=(), xr-spatial-tracking=()" always;
+  add_header Content-Security-Policy "default-src 'self'; base-uri 'self'; object-src 'none'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; style-src-elem 'self' 'unsafe-inline'; img-src * data: blob:; font-src 'self' data:; connect-src * data: blob:; frame-src *; worker-src 'self' blob:; manifest-src 'self'; form-action 'self'; frame-ancestors 'none'" always;
+
   location / {
     root /usr/share/nginx/html;
     try_files $uri $uri/ /index.html;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds strict security headers (notably a restrictive `Content-Security-Policy`) at the Nginx layer, which can unintentionally block scripts/styles/frames or third-party integrations if the policy is too tight. No application logic changes, but misconfiguration could cause runtime UI regressions in production.
> 
> **Overview**
> Adds a set of security response headers to `src/web/nginx.conf`, including **HSTS**, **CSP**, and hardening headers like `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, and `Permissions-Policy`.
> 
> The new `Content-Security-Policy` defaults most resources to `self`, disables `object-src`, forbids framing via `frame-ancestors 'none'`, and explicitly scopes allowed sources for scripts/styles/images/fonts/connect/workers/forms.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 068ba8400469497090c8e0be859527460b87b4b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->