### PR TITLE
refactor: deprecate backend avatars

### DIFF
--- a/src/popup/components/Avatar.vue
+++ b/src/popup/components/Avatar.vue
@@ -14,10 +14,10 @@
   >
     <slot>
       <img
-        v-if="!isPlaceholder && srcUrl"
+        v-if="!isPlaceholder && avatarUrl"
         v-show="!isLoading"
         class="avatar-img"
-        :src="srcUrl"
+        :src="avatarUrl"
         alt="Avatar"
         @load="isLoading = false"
       >
@@ -31,15 +31,12 @@ import { IonSkeletonText } from '@ionic/vue';
 import {
   computed,
   defineComponent,
-  onMounted,
   PropType,
   ref,
 } from 'vue';
 
-import { checkImageAvailability, getAddressColor } from '@/utils';
+import { getAddressColor } from '@/utils';
 import { AE_AVATAR_URL } from '@/protocols/aeternity/config';
-import { isContract } from '@/protocols/aeternity/helpers';
-import { useAeNetworkSettings } from '@/protocols/aeternity/composables';
 
 const SIZES = ['xs', 'sm', 'rg', 'md', 'lg', 'xl'] as const;
 export type AvatarSize = typeof SIZES[number];
@@ -68,9 +65,6 @@ export default defineComponent({
     isPlaceholder: Boolean,
   },
   setup(props) {
-    const { aeActiveNetworkSettings } = useAeNetworkSettings();
-
-    const profileImageAvailable = ref(false);
     const isLoading = ref(true);
 
     const avatarUrl = computed(() => `${AE_AVATAR_URL}${props.address}`);
@@ -79,25 +73,9 @@ export default defineComponent({
       ? getAddressColor(props.address)
       : undefined);
 
-    const profileImageUrl = computed(() => (props.address === '' || isContract(props.address))
-      ? null
-      : `${aeActiveNetworkSettings.value.backendUrl}/profile/image/${props.address}`);
-
-    const srcUrl = computed(() => profileImageAvailable.value
-      ? profileImageUrl.value
-      : avatarUrl.value);
-
-    onMounted(async () => {
-      profileImageAvailable.value = (
-        !!profileImageUrl.value
-        && await checkImageAvailability(profileImageUrl.value)
-      );
-    });
-
     return {
-      srcUrl,
+      avatarUrl,
       calculatedColor,
-      profileImageAvailable,
       isLoading,
     };
   },

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -101,18 +101,6 @@ export function calculateFontSize(amountValue: BigNumber | number | string) {
   return '12px';
 }
 
-/**
- * Check if the image is available by making a HEAD request.
- * Needed for Ionic because when using <img /> tag and the image is not available
- * the DOM ready event is not fired.
- */
-export function checkImageAvailability(url: string): Promise<boolean> {
-  // TODO: use { method: 'HEAD'} when backend will introduce a proper response in such case
-  return fetch(url)
-    .then((response) => !!response.ok)
-    .catch(() => false);
-}
-
 export function compareCaseInsensitive(str1?: string, str2?: string) {
   return str1?.toLocaleLowerCase() === str2?.toLocaleLowerCase();
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Display-only change in the popup avatar component with no auth or transaction logic affected.
> 
> **Overview**
> **Avatar** no longer loads profile images from the Æternity network backend (`/profile/image/...`). It always uses the deterministic **`AE_AVATAR_URL`** image for the address, with the same loading skeleton behavior.
> 
> Related cleanup removes **`checkImageAvailability`** (and its `fetch`-based HEAD workaround) from **`common`**, plus unused network settings, contract checks, and mount-time availability probing in **`Avatar`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b06b08b79f5a6744afc526a208e7d95c2e4b8ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->