### PR TITLE
Realign v2.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.10.1](https://github.com/Superhero-com/superhero-wallet/compare/v2.10.0...v2.10.1) (2026-05-26)
+
+
+### Bug Fixes
+
+* **mobile:** be able to use deep link with security login enabled ([da4ed22](https://github.com/Superhero-com/superhero-wallet/commit/da4ed2260e219deffad21c55c64144ee8a8b3618))
+
 ## [2.10.0](https://github.com/Superhero-com/superhero-wallet/compare/v2.9.6...v2.10.0) (2026-05-25)
 
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.superhero.cordova"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 21000
-        versionName "2.10.0"
+        versionCode 21001
+        versionName "2.10.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         ndk {
             abiFilters 'arm64-v8a'

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -365,7 +365,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.10.0;
+				MARKETING_VERSION = 2.10.1;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.superhero.cordova;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -390,7 +390,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.10.0;
+				MARKETING_VERSION = 2.10.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.superhero.cordova;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "superhero-wallet",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "superhero-wallet",
-      "version": "2.10.0",
+      "version": "2.10.1",
       "license": "ISC",
       "dependencies": {
         "@aeternity/aepp-calldata": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superhero-wallet",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "Superhero wallet",
   "author": "Superhero",
   "license": "ISC",

--- a/src/composables/auth.ts
+++ b/src/composables/auth.ts
@@ -81,6 +81,7 @@ export const useAuth = createCustomScopedComposable(() => {
 
   let isSessionExpired = false;
   let isManualMobileLockActive = false;
+  let sessionExpiresAt: number | null = null;
   let expirationTimeout: NodeJS.Timeout;
 
   /** Common state for both biometric or password protection */
@@ -226,6 +227,24 @@ export const useAuth = createCustomScopedComposable(() => {
     return key;
   }
 
+  function markAuthenticated() {
+    isSessionExpired = false;
+    sessionExpiresAt = null;
+    isAuthenticated.value = true;
+  }
+
+  function updateSessionExpiredFromDeadline() {
+    if (sessionExpiresAt !== null && Date.now() >= sessionExpiresAt) {
+      isSessionExpired = true;
+    }
+  }
+
+  async function logout() {
+    setEncryptionKey(undefined);
+    mnemonicDecrypted.value = '';
+    isAuthenticated.value = false;
+  }
+
   async function setPassword(password: string, plaintextToEncrypt = mnemonicDecrypted.value) {
     if (IS_MOBILE_APP) {
       /**
@@ -239,7 +258,7 @@ export const useAuth = createCustomScopedComposable(() => {
         setEncryptionKey(mobileKey);
       }
       mnemonic.value = await encrypt(encryptionKey.value!, plaintextToEncrypt);
-      isAuthenticated.value = true;
+      markAuthenticated();
       return;
     }
 
@@ -262,7 +281,7 @@ export const useAuth = createCustomScopedComposable(() => {
     encryptionSalt.value = newSalt;
     setEncryptionKey(newEncryptionKey);
     mnemonic.value = newMnemonicCiphertext;
-    isAuthenticated.value = true;
+    markAuthenticated();
   }
 
   async function setMnemonicAndInitializeAuthentication(newMnemonic: string, isRestored = false) {
@@ -308,7 +327,7 @@ export const useAuth = createCustomScopedComposable(() => {
      * back to a login flow for an install they just created. Asserting the
      * flag once here covers both environments and is idempotent.
      */
-    isAuthenticated.value = true;
+    markAuthenticated();
   }
 
   /**
@@ -375,7 +394,7 @@ export const useAuth = createCustomScopedComposable(() => {
       }
 
       mnemonicDecrypted.value = decryptionResult;
-      isAuthenticated.value = true;
+      markAuthenticated();
     }
     return true;
   }
@@ -402,7 +421,7 @@ export const useAuth = createCustomScopedComposable(() => {
         androidConfirmationRequired: false,
       }).then(() => {
         if (setAuthenticated) {
-          isAuthenticated.value = true;
+          markAuthenticated();
         }
         return true;
       });
@@ -417,6 +436,18 @@ export const useAuth = createCustomScopedComposable(() => {
    */
   async function checkUserAuth(): Promise<any> {
     await watchUntilTruthy(isMnemonicRestored);
+    updateSessionExpiredFromDeadline();
+
+    if (
+      IS_MOBILE_APP
+      && mnemonic.value
+      && isAuthenticated.value
+      && isSessionExpired
+      && isAutoLockEnabled.value
+    ) {
+      isManualMobileLockActive = true;
+      await logout();
+    }
 
     if (!mnemonic.value || isAuthenticated.value) {
       return;
@@ -495,7 +526,7 @@ export const useAuth = createCustomScopedComposable(() => {
         } else {
           mnemonicDecrypted.value = mnemonic.value;
         }
-        isAuthenticated.value = true;
+        markAuthenticated();
       } else if (isMnemonicEncrypted.value) {
         // Environments that will always ask user about password
         const autoLoginDisabledEnv = IS_OFFSCREEN_TAB || RUNNING_IN_TESTS;
@@ -597,7 +628,7 @@ export const useAuth = createCustomScopedComposable(() => {
           if (sessionEncryptionKey) {
             setEncryptionKey(sessionEncryptionKey);
             mnemonicDecrypted.value = await decrypt(sessionEncryptionKey, mnemonic.value);
-            isAuthenticated.value = true;
+            markAuthenticated();
           }
           setLoaderVisible(false);
         }
@@ -613,12 +644,6 @@ export const useAuth = createCustomScopedComposable(() => {
     } finally {
       isAuthenticating.value = false;
     }
-  }
-
-  async function logout() {
-    setEncryptionKey(undefined);
-    mnemonicDecrypted.value = '';
-    isAuthenticated.value = false;
   }
 
   async function lockWallet() {
@@ -709,6 +734,8 @@ export const useAuth = createCustomScopedComposable(() => {
 
       if (isActive && !wasActive) {
         clearInterval(expirationTimeout);
+        updateSessionExpiredFromDeadline();
+        sessionExpiresAt = null;
 
         // If session exists user needs to stay logged in
         if (!isAuthenticating.value) {
@@ -723,13 +750,20 @@ export const useAuth = createCustomScopedComposable(() => {
       } else if (wasActive && !isActive) {
         if (!isAutoLockEnabled.value) {
           isSessionExpired = false;
+          sessionExpiresAt = null;
+          return;
+        }
+        const expirationTimeoutMs = +secureLoginTimeoutDecrypted.value!;
+        sessionExpiresAt = Date.now() + expirationTimeoutMs;
+        if (expirationTimeoutMs <= 0) {
+          isSessionExpired = true;
           return;
         }
         expirationTimeout = setTimeout(
           () => {
             isSessionExpired = true;
           },
-          +secureLoginTimeoutDecrypted.value!,
+          expirationTimeoutMs,
         );
       }
     },

--- a/src/popup/router/index.ts
+++ b/src/popup/router/index.ts
@@ -62,7 +62,7 @@ const {
 } = useAccounts();
 const { setPopupProps } = usePopupProps();
 const { setLoginTargetLocation } = useUi();
-const { checkUserAuth } = useAuth();
+const { checkUserAuth, isAuthenticated } = useAuth();
 const { openModal, openConfirmModal } = useModals();
 
 RouteQueryActionsController.init(router);
@@ -170,12 +170,23 @@ if (IS_MOBILE_APP) {
 
       const deepLinkUrl = new URL(event.url);
       if (deepLinkUrl.origin === 'wc://' || event.url.startsWith('superhero://wc')) {
-        setIsOpenUsingDeeplink(true);
-        router.push({ name: ROUTE_ACCOUNT });
+        (async () => {
+          const uri = deepLinkUrl.searchParams.get('uri') as WalletConnectUri | null;
 
-        if (!wcSession.value) {
-          connect(deepLinkUrl.searchParams.get('uri') as WalletConnectUri, true);
-        }
+          setIsOpenUsingDeeplink(true);
+          try {
+            await router.push({ name: ROUTE_ACCOUNT });
+            await checkUserAuth();
+
+            if (!wcSession.value && isAuthenticated.value && isLoggedIn.value && uri) {
+              await connect(uri, true);
+            } else {
+              setIsOpenUsingDeeplink(false);
+            }
+          } catch {
+            setIsOpenUsingDeeplink(false);
+          }
+        })();
         return;
       }
       const isCustomSchemeLink = event.url.startsWith('superhero://')


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes touch mobile authentication/session expiry and WalletConnect entry when the wallet is locked; incorrect timing could block connects or leave sessions unlocked, but scope is narrow.
> 
> **Overview**
> **v2.10.1** bumps app/package versions (Android `versionCode`/`versionName`, iOS `MARKETING_VERSION`, npm) and documents a mobile deep-link fix in the changelog.
> 
> **Mobile secure login / auto-lock:** Session expiry now tracks a **`sessionExpiresAt` deadline** when the app goes to the background, and **`checkUserAuth`** re-evaluates expiry on resume—including a path that **logs out** an still-“authenticated” mobile session when auto-lock says the session timed out, so biometric/password can run again. Successful auth goes through **`markAuthenticated()`**, which clears expiry state.
> 
> **WalletConnect deep links:** On `appUrlOpen` for WC URLs, the router **awaits navigation**, **`checkUserAuth()`**, and only **`connect(uri)`** when the user is **authenticated and logged in**; otherwise it clears the deeplink flag and avoids connecting in a locked state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 851c04a72b6d1715ff603065d5dccde62c2129d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->