### PR TITLE
fix: be able to connect wallet when browser initialize

### DIFF
--- a/src/composables/accounts.ts
+++ b/src/composables/accounts.ts
@@ -234,9 +234,12 @@ export const useAccounts = createCustomScopedComposable(() => {
       return activeAccount.value;
     }
     const lastUsedGlobalIdx = protocolLastActiveGlobalIdx.value[protocol];
-    return (lastUsedGlobalIdx)
-      ? getAccountByGlobalIdx(lastUsedGlobalIdx)
-      : accounts.value.find((account) => account.protocol === protocol);
+    // The stored index can be stale or not yet resolvable (e.g. while accounts
+    // are still being restored after the extension is re-enabled). Fall back to
+    // the first account of the protocol so callers don't receive `undefined`
+    // when accounts for the protocol actually exist.
+    return (lastUsedGlobalIdx ? getAccountByGlobalIdx(lastUsedGlobalIdx) : undefined)
+      ?? accounts.value.find((account) => account.protocol === protocol);
   }
 
   function getLastProtocolAccount(protocol: Protocol): IAccount | undefined {

--- a/src/composables/aeSdk.ts
+++ b/src/composables/aeSdk.ts
@@ -92,7 +92,7 @@ export function useAeSdk() {
    * Create Node instance and get connection status
    */
   async function createNodeInstance(url: string) {
-    let nodeInstance;
+    let nodeInstance: Node | null = null;
     isAeNodeReady.value = false;
     isAeNodeError.value = false;
     isAeNodeConnecting.value = true;
@@ -101,11 +101,17 @@ export function useAeSdk() {
       nodeNetworkId.value = (await nodeInstance.getStatus()).networkId;
       isAeNodeReady.value = true;
     } catch (error) {
+      // Only the initial status request failed (e.g. the network stack is not
+      // ready yet right after a fresh browser start). The `Node` instance itself
+      // is still valid and its requests will succeed once connectivity is back,
+      // so we must keep it. Returning `null` here would put a `null` node into
+      // the SDK pool and make `aeSdk.api` null, which crashes dApp connection
+      // (`getWalletInfo` -> `api.getNetworkId()`) before any modal can appear.
       nodeNetworkId.value = undefined;
       isAeNodeError.value = true;
-      return null;
+    } finally {
+      isAeNodeConnecting.value = false;
     }
-    isAeNodeConnecting.value = false;
     return nodeInstance;
   }
 
@@ -154,15 +160,32 @@ export function useAeSdk() {
         },
         async onSubscription(aeppId, _params, origin) {
           const aepp = aeppInfo[aeppId];
-          const host = IS_OFFSCREEN_TAB ? aepp.origin : origin;
+          const host = IS_OFFSCREEN_TAB ? aepp?.origin : origin;
           if (await checkOrAskPermission(METHODS.subscribeAddress, host)) {
-            return getLastActiveProtocolAccount(PROTOCOLS.aeternity)!.address;
+            // The offscreen document may still be restoring accounts (e.g. right
+            // after the extension is re-enabled), so wait for the active account
+            // to become available before reading its address. Without this guard
+            // a missing account crashes the offscreen document and the dApp never
+            // connects even though the user confirmed access.
+            try {
+              await Promise.race([
+                watchUntilTruthy(() => getLastActiveProtocolAccount(PROTOCOLS.aeternity)),
+                new Promise((_resolve, reject) => { setTimeout(reject, 5000); }),
+              ]);
+            } catch (error) {
+              // Intentionally ignoring the timeout; handled by the guard below.
+            }
+            const account = getLastActiveProtocolAccount(PROTOCOLS.aeternity);
+            if (!account) {
+              return Promise.reject(new RpcRejectedByUserError());
+            }
+            return account.address;
           }
           return Promise.reject(new RpcRejectedByUserError());
         },
         async onAskAccounts(aeppId, _params, origin) {
           const aepp = aeppInfo[aeppId];
-          const host = IS_OFFSCREEN_TAB ? aepp.origin : origin;
+          const host = IS_OFFSCREEN_TAB ? aepp?.origin : origin;
           if (await checkOrAskPermission(METHODS.address, host)) {
             return accountsAddressList.value;
           }

--- a/src/protocols/aeternity/libs/AeSdkSuperhero.ts
+++ b/src/protocols/aeternity/libs/AeSdkSuperhero.ts
@@ -68,10 +68,16 @@ export class AeSdkSuperhero extends AeSdkWallet {
   }
 
   async getWalletInfo(): Promise<IWalletInfo> {
+    // Prefer the network id resolved during node setup. Falling back to
+    // `this.api.getNetworkId()` only when it is missing avoids crashing the
+    // connection flow when the node status couldn't be fetched yet (e.g. right
+    // after a fresh browser start), in which case `this.api` may be unavailable.
+    const networkId = this.nodeNetworkId.value
+      ?? (this.isNodeConnected() ? await this.api.getNetworkId() : undefined);
     return {
       id: this.id,
       name: this.name,
-      networkId: await this.api.getNetworkId(),
+      networkId: networkId as IWalletInfo['networkId'],
       origin: window.location.origin === 'file://' ? '*' : window.location.origin,
       type: this._type as any,
     };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core dApp connection paths (node pool, subscribe address, wallet info); behavior is more defensive but wrong fallbacks could still expose wrong account or incomplete wallet info when node status is unknown.
> 
> **Overview**
> Fixes **dApp wallet connection failing on cold browser start** and when the extension is re-enabled before accounts or the node are fully ready.
> 
> **Node setup:** If the initial `getStatus()` fails (e.g. network not up yet), the code **still registers the `Node` instance** instead of returning `null`, so `aeSdk.api` stays usable once connectivity returns. **`getWalletInfo`** prefers the cached `nodeNetworkId` and only calls `api.getNetworkId()` when needed.
> 
> **Accounts:** **`getLastActiveProtocolAccount`** uses nullish coalescing so a stale stored index does not block falling back to the first æternity account while storage is still restoring.
> 
> **dApp RPC (offscreen):** **`onSubscription`** waits up to 5s for an æternity account, rejects cleanly if none, and uses optional chaining on `aepp` origin—avoiding crashes that prevented connect after user approval.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac648eddfc5dad820eec71c9fbbab778b8b74aec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->