### PR TITLE
perf: avoid avatars unavailability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,6 +65,7 @@
         "detect-browser": "^5.3.0",
         "ecpair": "^2.1.0",
         "ed25519-hd-key": "^1.3.0",
+        "jdenticon": "^3.3.0",
         "lodash-es": "^4.17.21",
         "node-polyfill-webpack-plugin": "^3.0.0",
         "qr-code-styling": "^1.8.0",
@@ -12847,6 +12848,15 @@
         "canonicalize": "bin/canonicalize.js"
       }
     },
+    "node_modules/canvas-renderer": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/canvas-renderer/-/canvas-renderer-2.2.1.tgz",
+      "integrity": "sha512-RrBgVL5qCEDIXpJ6NrzyRNoTnXxYarqm/cS/W6ERhUJts5UQtt/XPEosGN3rqUkZ4fjBArlnCbsISJ+KCFnIAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/capacitor-native-settings": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/capacitor-native-settings/-/capacitor-native-settings-8.0.0.tgz",
@@ -21474,6 +21484,21 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jdenticon": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/jdenticon/-/jdenticon-3.3.0.tgz",
+      "integrity": "sha512-DhuBRNRIybGPeAjMjdHbkIfiwZCCmf8ggu7C49jhp6aJ7DYsZfudnvnTY5/1vgUhrGA7JaDAx1WevnpjCPvaGg==",
+      "license": "MIT",
+      "dependencies": {
+        "canvas-renderer": "~2.2.0"
+      },
+      "bin": {
+        "jdenticon": "bin/jdenticon.js"
+      },
+      "engines": {
+        "node": ">=6.4.0"
       }
     },
     "node_modules/jest": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "detect-browser": "^5.3.0",
     "ecpair": "^2.1.0",
     "ed25519-hd-key": "^1.3.0",
+    "jdenticon": "^3.3.0",
     "lodash-es": "^4.17.21",
     "node-polyfill-webpack-plugin": "^3.0.0",
     "qr-code-styling": "^1.8.0",

--- a/src/popup/components/AssetIcon.vue
+++ b/src/popup/components/AssetIcon.vue
@@ -39,7 +39,7 @@ import {
 } from '@/types';
 import { ICON_SIZES, PROTOCOLS } from '@/constants';
 import { ProtocolAdapterFactory } from '@/lib/ProtocolAdapterFactory';
-import { AE_AVATAR_URL } from '@/protocols/aeternity/config';
+import { getAvatarDataUrl } from '@/utils';
 
 import AeternityIcon from '@/icons/coin/aeternity.svg?vue-component';
 import BitcoinIcon from '@/icons/coin/bitcoin.svg?vue-component';
@@ -95,8 +95,7 @@ export default defineComponent({
     const isSolana = computed(() => contractId.value === PROTOCOLS.solana);
 
     function getTokenPlaceholderUrl(token: ITokenResolved) {
-      // TODO Should not be protocol specific
-      return `${AE_AVATAR_URL}${token.contractId}`;
+      return getAvatarDataUrl(token.contractId || '');
     }
 
     return {

--- a/src/popup/components/Avatar.vue
+++ b/src/popup/components/Avatar.vue
@@ -15,28 +15,22 @@
     <slot>
       <img
         v-if="!isPlaceholder && avatarUrl"
-        v-show="!isLoading"
         class="avatar-img"
         :src="avatarUrl"
         alt="Avatar"
-        @load="isLoading = false"
       >
-      <ion-skeleton-text v-if="isLoading" animated />
     </slot>
   </div>
 </template>
 
 <script lang="ts">
-import { IonSkeletonText } from '@ionic/vue';
 import {
   computed,
   defineComponent,
   PropType,
-  ref,
 } from 'vue';
 
-import { getAddressColor } from '@/utils';
-import { AE_AVATAR_URL } from '@/protocols/aeternity/config';
+import { getAddressColor, getAvatarDataUrl } from '@/utils';
 
 const SIZES = ['xs', 'sm', 'rg', 'md', 'lg', 'xl'] as const;
 export type AvatarSize = typeof SIZES[number];
@@ -45,9 +39,6 @@ const VARIANTS = ['primary', 'grey'] as const;
 type AvatarVariant = typeof VARIANTS[number];
 
 export default defineComponent({
-  components: {
-    IonSkeletonText,
-  },
   props: {
     address: { type: String, default: '' },
     name: { type: String, default: null },
@@ -65,9 +56,9 @@ export default defineComponent({
     isPlaceholder: Boolean,
   },
   setup(props) {
-    const isLoading = ref(true);
-
-    const avatarUrl = computed(() => `${AE_AVATAR_URL}${props.address}`);
+    const avatarUrl = computed(() => (
+      props.address ? getAvatarDataUrl(props.address) : ''
+    ));
 
     const calculatedColor = computed(() => (props.address)
       ? getAddressColor(props.address)
@@ -76,7 +67,6 @@ export default defineComponent({
     return {
       avatarUrl,
       calculatedColor,
-      isLoading,
     };
   },
 });
@@ -161,15 +151,6 @@ $size-xl: 56px;
 
   &.borderless {
     border: none;
-  }
-
-  ion-skeleton-text {
-    --border-radius: 16px;
-    --background: rgba(#{$color-white-rgb}, 0.1);
-    --background-rgb: #{$color-white-rgb};
-    width: 100%;
-    height: 100%;
-    margin: 0;
   }
 }
 </style>

--- a/src/protocols/aeternity/config.ts
+++ b/src/protocols/aeternity/config.ts
@@ -66,7 +66,6 @@ export const AE_NETWORK_ADDITIONAL_SETTINGS: IDefaultNetworkTypeData<
   },
 };
 
-export const AE_AVATAR_URL = 'https://avatars.superherowallet.com/';
 export const AE_BLOG_CLAIM_TIP_URL = 'https://blog.aeternity.com/superhero-how-to-send-receive-superhero-tips-34971b18c919#024e';
 export const AE_COMMIT_URL = 'https://github.com/aeternity/superhero-wallet/commit/';
 export const AE_DEX_URL = 'https://aepp.dex.superhero.com';

--- a/src/utils/avatar.js
+++ b/src/utils/avatar.js
@@ -1,4 +1,6 @@
 /* eslint-disable */
+import { toSvg } from 'jdenticon';
+
 // Helper methods from https://github.com/dmester/jdenticon/blob/master/dist/jdenticon-module.js
 
 /**
@@ -236,17 +238,50 @@ function isValidHash(hashCandidate) {
   return /^[0-9a-f]{11,}$/i.test(hashCandidate) && hashCandidate;
 }
 
+// Card/border accent colors (wallet UI)
 export const JDENTICON_CONFIG = {
   lightness: {
     color: 0.57,
-    grayscale: [0.47, 0.58]
+    grayscale: [0.47, 0.58],
   },
   saturation: {
     color: 0.83,
-    grayscale: 0.42
+    grayscale: 0.42,
   },
   backColor: '#12121bff',
 };
+
+// Avatar icons — matches https://avatars.superherowallet.com/
+// https://jdenticon.com/icon-designer.html?config=12121bff014a646428643264
+const AVATAR_JDENTICON_CONFIG = {
+  lightness: {
+    color: [0.4, 1.0],
+    grayscale: [0.5, 1.0],
+  },
+  saturation: {
+    color: 1.0,
+    grayscale: 1.0,
+  },
+  backColor: '#12121bff',
+};
+
+/**
+ * @param {string} value
+ * @param {number} [size=300]
+ * @returns {string}
+ */
+export function getAvatarSvg(value, size = 300) {
+  return toSvg(value || '', size, AVATAR_JDENTICON_CONFIG);
+}
+
+/**
+ * @param {string} value
+ * @param {number} [size=300]
+ * @returns {string}
+ */
+export function getAvatarDataUrl(value, size = 300) {
+  return `data:image/svg+xml,${encodeURIComponent(getAvatarSvg(value, size))}`;
+}
 
 /**
  * @param {string} color  Color value to parse. Currently hexadecimal strings on the format #rgb[a] and #rrggbb[aa] are supported.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> UI-only change for avatar/placeholder rendering; no auth, payments, or transaction logic affected.
> 
> **Overview**
> Replaces **remote** avatar and token-placeholder images from `avatars.superherowallet.com` with **client-generated** identicons so the UI no longer depends on that service being up.
> 
> Adds the **`jdenticon`** dependency and new helpers in `avatar.js` (`getAvatarSvg`, `getAvatarDataUrl`) using an avatar-specific config intended to match the former hosted icons. **`Avatar.vue`** and **`AssetIcon.vue`** now use `getAvatarDataUrl` for address/contract-based images; **`AE_AVATAR_URL`** is removed from æternity config. **`Avatar.vue`** also drops the Ionic skeleton loading path tied to fetching external avatar URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 689852055b2f43c2bbacaf0f0b490df8d71ac837. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->