### PR TITLE
Realign 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.10.2](https://github.com/Superhero-com/superhero-wallet/compare/v2.10.1...v2.10.2) (2026-05-30)
+
+
+### Bug Fixes
+
+* be able to connect wallet when browser initialize ([ac648ed](https://github.com/Superhero-com/superhero-wallet/commit/ac648eddfc5dad820eec71c9fbbab778b8b74aec))
+* stabilize dApp connect and signing after slow browser/node startup ([d3a64be](https://github.com/Superhero-com/superhero-wallet/commit/d3a64be22dae3bf1015b52331d229f9cebcce294))
+
+
+### Performance
+
+* avoid avatars unavailability ([6898520](https://github.com/Superhero-com/superhero-wallet/commit/689852055b2f43c2bbacaf0f0b490df8d71ac837))
+
 ### [2.10.1](https://github.com/Superhero-com/superhero-wallet/compare/v2.10.0...v2.10.1) (2026-05-26)
 
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "com.superhero.cordova"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 21001
-        versionName "2.10.1"
+        versionCode 21002
+        versionName "2.10.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         ndk {
             abiFilters 'arm64-v8a'

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -365,7 +365,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.10.1;
+				MARKETING_VERSION = 2.10.2;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.superhero.cordova;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -390,7 +390,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 2.10.1;
+				MARKETING_VERSION = 2.10.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.superhero.cordova;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "superhero-wallet",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "superhero-wallet",
-      "version": "2.10.1",
+      "version": "2.10.2",
       "license": "ISC",
       "dependencies": {
         "@aeternity/aepp-calldata": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "superhero-wallet",
-  "version": "2.10.1",
+  "version": "2.10.2",
   "description": "Superhero wallet",
   "author": "Superhero",
   "license": "ISC",

--- a/src/composables/accounts.ts
+++ b/src/composables/accounts.ts
@@ -109,10 +109,17 @@ export const useAccounts = createCustomScopedComposable(() => {
     },
   );
 
+  const isActiveAccountGlobalIdxRestored = ref(false);
+
   const activeAccountGlobalIdx = useStorageRef<number>(
     0,
     STORAGE_KEYS.activeAccountGlobalIdx,
-    { backgroundSync: true },
+    {
+      backgroundSync: true,
+      onRestored: () => {
+        isActiveAccountGlobalIdxRestored.value = true;
+      },
+    },
   );
 
   const protocolLastActiveGlobalIdx = useStorageRef<ProtocolRecord<number>>(
@@ -230,16 +237,28 @@ export const useAccounts = createCustomScopedComposable(() => {
    * related to protocol different than the current account is using.
    */
   function getLastActiveProtocolAccount(protocol: Protocol): IAccount | undefined {
-    if (activeAccount.value.protocol === protocol) {
+    // `activeAccountGlobalIdx` defaults to 0 and is only trustworthy once its
+    // persisted value has been restored. Until then `activeAccount` may point at
+    // account 0, which could expose the wrong address to a dApp (e.g. in the
+    // offscreen document during restore) if account 0 happens to match the
+    // requested protocol. Only short-circuit to the active account once the
+    // stored index has settled; otherwise fall through to the resolvable
+    // last-active index below.
+    if (isActiveAccountGlobalIdxRestored.value && activeAccount.value.protocol === protocol) {
       return activeAccount.value;
     }
     const lastUsedGlobalIdx = protocolLastActiveGlobalIdx.value[protocol];
-    // The stored index can be stale or not yet resolvable (e.g. while accounts
-    // are still being restored after the extension is re-enabled). Fall back to
-    // the first account of the protocol so callers don't receive `undefined`
-    // when accounts for the protocol actually exist.
-    return (lastUsedGlobalIdx ? getAccountByGlobalIdx(lastUsedGlobalIdx) : undefined)
-      ?? accounts.value.find((account) => account.protocol === protocol);
+    if (lastUsedGlobalIdx) {
+      // A specific account was last active for this protocol. Return it only
+      // once it can be resolved; while accounts are still being restored (e.g.
+      // after the extension is re-enabled) this is briefly `undefined`. Callers
+      // should wait for it rather than be handed a different account, otherwise
+      // dApps could be exposed the wrong address on multi-account wallets.
+      return getAccountByGlobalIdx(lastUsedGlobalIdx);
+    }
+    // No account was ever marked active for this protocol (e.g. first use), so
+    // default to the first account of the protocol.
+    return accounts.value.find((account) => account.protocol === protocol);
   }
 
   function getLastProtocolAccount(protocol: Protocol): IAccount | undefined {

--- a/src/composables/aeSdk.ts
+++ b/src/composables/aeSdk.ts
@@ -7,6 +7,7 @@ import {
   Node,
   WALLET_TYPE,
   RpcRejectedByUserError,
+  RpcInternalError,
   RpcMethodNotFoundError,
   METHODS,
   RPC_STATUS,
@@ -47,6 +48,12 @@ type OnAeppConnectionParams = Parameters<
   ConstructorParameters<typeof AeSdkSuperhero>[0]['onConnection']
 >[1];
 type AeppInfoData = OnAeppConnectionParams & { origin: string };
+
+/**
+ * Max time to wait for the active account to be restored before answering a
+ * dApp subscription request (e.g. in the long-lived offscreen document).
+ */
+const ACCOUNT_RESTORE_TIMEOUT = 5000;
 
 let composableInitialized = false;
 let aeSdk: AeSdkSuperhero;
@@ -115,6 +122,29 @@ export function useAeSdk() {
     return nodeInstance;
   }
 
+  /**
+   * Re-resolve the node network id when the initial `getStatus` request failed
+   * (e.g. the network stack was not ready right after a fresh browser start).
+   * The node instance is kept in the pool and becomes usable once connectivity
+   * is restored, but `nodeNetworkId` would otherwise stay empty until the user
+   * switches networks, permanently breaking signing ("Not connected to any
+   * network"). The SDK `Node` does not cache failed status requests, so asking
+   * it again here recovers the network id without requiring a network switch.
+   */
+  async function ensureNodeNetworkId(): Promise<NetworkId | undefined> {
+    if (nodeNetworkId.value || isAeNodeConnecting.value || !aeSdk?.isNodeConnected()) {
+      return nodeNetworkId.value;
+    }
+    try {
+      nodeNetworkId.value = (await aeSdk.api.getNetworkId()) as NetworkId;
+      isAeNodeReady.value = true;
+      isAeNodeError.value = false;
+    } catch (error) {
+      isAeNodeError.value = true;
+    }
+    return nodeNetworkId.value;
+  }
+
   async function resetNode(oldNetwork: INetwork, newNetwork: INetwork) {
     isAeSdkUpdating.value = true;
     const nodeInstance = await createNodeInstance(newNetwork.protocols.aeternity.nodeUrl);
@@ -160,24 +190,25 @@ export function useAeSdk() {
         },
         async onSubscription(aeppId, _params, origin) {
           const aepp = aeppInfo[aeppId];
-          const host = IS_OFFSCREEN_TAB ? aepp?.origin : origin;
+          // In the offscreen document `onSubscription` may run before
+          // `onConnection` populates `aeppInfo`, so fall back to the `origin`
+          // argument to avoid running the permission check with an undefined host.
+          const host = (IS_OFFSCREEN_TAB ? aepp?.origin : origin) ?? origin;
           if (await checkOrAskPermission(METHODS.subscribeAddress, host)) {
             // The offscreen document may still be restoring accounts (e.g. right
-            // after the extension is re-enabled), so wait for the active account
-            // to become available before reading its address. Without this guard
-            // a missing account crashes the offscreen document and the dApp never
-            // connects even though the user confirmed access.
-            try {
-              await Promise.race([
-                watchUntilTruthy(() => getLastActiveProtocolAccount(PROTOCOLS.aeternity)),
-                new Promise((_resolve, reject) => { setTimeout(reject, 5000); }),
-              ]);
-            } catch (error) {
-              // Intentionally ignoring the timeout; handled by the guard below.
-            }
-            const account = getLastActiveProtocolAccount(PROTOCOLS.aeternity);
+            // after the extension is re-enabled), so wait (bounded) for the active
+            // account to become available before reading its address. The timeout
+            // stops the underlying watcher so repeated connect attempts in the
+            // long-lived offscreen document don't leak watchers.
+            const account = await watchUntilTruthy(
+              () => getLastActiveProtocolAccount(PROTOCOLS.aeternity),
+              ACCOUNT_RESTORE_TIMEOUT,
+            );
             if (!account) {
-              return Promise.reject(new RpcRejectedByUserError());
+              // The account is not available yet (slow restore or none exists).
+              // This is a transient/internal wallet state, not an explicit user
+              // denial, so report it as such instead of `RpcRejectedByUserError`.
+              return Promise.reject(new RpcInternalError());
             }
             return account.address;
           }
@@ -185,8 +216,16 @@ export function useAeSdk() {
         },
         async onAskAccounts(aeppId, _params, origin) {
           const aepp = aeppInfo[aeppId];
-          const host = IS_OFFSCREEN_TAB ? aepp?.origin : origin;
+          const host = (IS_OFFSCREEN_TAB ? aepp?.origin : origin) ?? origin;
           if (await checkOrAskPermission(METHODS.address, host)) {
+            // Accounts may still be restoring in the long-lived offscreen
+            // document, so wait (bounded) for the list to be populated before
+            // answering. Without this a dApp listing accounts during a slow
+            // restore could receive an empty list.
+            await watchUntilTruthy(
+              () => accountsAddressList.value.length,
+              ACCOUNT_RESTORE_TIMEOUT,
+            );
             return accountsAddressList.value;
           }
           return Promise.reject(new RpcRejectedByUserError());
@@ -307,6 +346,7 @@ export function useAeSdk() {
     setAeNodeError,
     fetchRespondChallenge,
     createNodeInstance,
+    ensureNodeNetworkId,
     disconnectDapps,
     waitTransactionMined,
   };

--- a/src/protocols/aeternity/libs/AeAccountHdWallet.ts
+++ b/src/protocols/aeternity/libs/AeAccountHdWallet.ts
@@ -29,7 +29,7 @@ import { handleUnknownError, isAccountAirGap } from '@/utils';
 import { useModals } from '@/composables/modals';
 import { useAccounts } from '@/composables/accounts';
 import { useDeepLinkApi } from '@/composables/deepLinkApi';
-import { useLedger } from '@/composables';
+import { useAeSdk, useLedger } from '@/composables';
 import { useAeMiddleware } from '@/protocols/aeternity/composables';
 import { SEED_LENGTH } from '@/protocols/aeternity/config';
 import { usePermissions } from '@/composables/permissions';
@@ -75,6 +75,13 @@ export class AeAccountHdWallet extends MemoryAccount {
     txBase64: Encoded.Transaction,
     options: Parameters<AccountBase['signTransaction']>[1] & InternalOptions,
   ): Promise<Encoded.Transaction> {
+    if (!this.nodeNetworkId.value) {
+      // The initial node status request may have failed (e.g. no connectivity
+      // right after a fresh browser start), leaving `nodeNetworkId` empty even
+      // though the node is now reachable. Try to recover it before giving up so
+      // signing works without forcing the user to switch networks.
+      await useAeSdk().ensureNodeNetworkId();
+    }
     if (!this.nodeNetworkId.value) {
       throw new Error('Not connected to any network');
     }
@@ -270,6 +277,10 @@ export class AeAccountHdWallet extends MemoryAccount {
       if (!permissionGranted) {
         throw new RpcRejectedByUserError();
       }
+    }
+
+    if (!this.nodeNetworkId.value) {
+      await useAeSdk().ensureNodeNetworkId();
     }
 
     this.isSigningAlreadyConfirmed = true;

--- a/src/protocols/aeternity/libs/AeSdkSuperhero.ts
+++ b/src/protocols/aeternity/libs/AeSdkSuperhero.ts
@@ -22,6 +22,15 @@ type ISpendOptions = Omit<Parameters<typeof spend>[2], 'onAccount' | 'onNode'>
 type IWalletPresenceInfo = Pick<IWalletInfo, 'id' | 'name' | 'origin' | 'type'>;
 
 /**
+ * The wallet-info shape required by the aepp-sdk RPC layer. Derived from the
+ * base method so we stay in sync with the SDK without a fragile deep import.
+ * Note its `networkId` is a required `string`: the dApp connection protocol
+ * mandates it, so `getWalletInfo` must satisfy that even though we may not have
+ * resolved a network id yet (see the cast below).
+ */
+type SdkWalletInfo = Awaited<ReturnType<AeSdkWallet['getWalletInfo']>>;
+
+/**
  * Class extends `AeSdkWallet` from aepp-sdk-js
  * provides flexibility to manage the accounts the way wallet would like to handle
  */
@@ -67,20 +76,32 @@ export class AeSdkSuperhero extends AeSdkWallet {
     return super.spend(amount, recipientId, options);
   }
 
-  async getWalletInfo(): Promise<IWalletInfo> {
-    // Prefer the network id resolved during node setup. Falling back to
-    // `this.api.getNetworkId()` only when it is missing avoids crashing the
-    // connection flow when the node status couldn't be fetched yet (e.g. right
-    // after a fresh browser start), in which case `this.api` may be unavailable.
-    const networkId = this.nodeNetworkId.value
-      ?? (this.isNodeConnected() ? await this.api.getNetworkId() : undefined);
-    return {
+  async getWalletInfo(): Promise<SdkWalletInfo> {
+    // Prefer the network id resolved during node setup. Fall back to
+    // `this.api.getNetworkId()` only when it is missing, and tolerate that
+    // request failing: the node may be selected but momentarily unreachable
+    // (e.g. right after a fresh browser start). Letting it throw here would
+    // reject wallet info retrieval and break the dApp connection flow this
+    // fallback is meant to stabilize.
+    let networkId = this.nodeNetworkId.value;
+    if (!networkId && this.isNodeConnected()) {
+      try {
+        networkId = await this.api.getNetworkId();
+      } catch (error) {
+        networkId = undefined;
+      }
+    }
+    const walletInfo: IWalletInfo = {
       id: this.id,
       name: this.name,
       networkId: networkId as IWalletInfo['networkId'],
       origin: window.location.origin === 'file://' ? '*' : window.location.origin,
       type: this._type as any,
     };
+    // The RPC contract requires `networkId: string`; during the brief startup
+    // window it may still be `undefined`. Cast here at the single wire boundary
+    // rather than weakening the SDK type for every caller.
+    return walletInfo as SdkWalletInfo;
   }
 
   getWalletPresenceInfo(): IWalletPresenceInfo {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -853,7 +853,11 @@ export type StorageKeysInput = string | string[];
 export interface IWalletInfo {
   id: string;
   name: string;
-  networkId: NetworkId;
+  /**
+   * May be `undefined` when the node status could not be resolved yet (e.g.
+   * right after a fresh browser start). See `AeSdkSuperhero.getWalletInfo`.
+   */
+  networkId?: NetworkId;
   origin: any;
   type: any;
 }

--- a/src/utils/common.ts
+++ b/src/utils/common.ts
@@ -461,21 +461,55 @@ export function truncateString(text: string, maxLength: number) {
     : '';
 }
 
+export function watchUntilTruthy<T>(getter: WatchSource<T>): Promise<NonNullable<T>>;
+export function watchUntilTruthy<T>(
+  getter: WatchSource<T>,
+  timeout: number,
+): Promise<NonNullable<T> | undefined>;
 /**
  * Watch for the getter to be truthy with the use of the compositionApi.
+ * When `timeout` (in ms) is provided, the promise resolves with `undefined`
+ * once it elapses and the underlying watcher is stopped. This prevents leaking
+ * watchers when waiting for a value that may never become truthy.
  */
-export function watchUntilTruthy<T>(getter: WatchSource<T>): Promise<NonNullable<T>> {
+export function watchUntilTruthy<T>(
+  getter: WatchSource<T>,
+  timeout?: number,
+): Promise<NonNullable<T> | undefined> {
   return new Promise((resolve) => {
-    const unwatch = watch(
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    // `unwatch` is referenced before assignment, but `finish` only invokes it
+    // asynchronously via `defer`, by which point `watch()` has returned.
+    let unwatch: (() => void) | undefined;
+
+    const finish = (value: NonNullable<T> | undefined) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      if (timer !== undefined) {
+        clearTimeout(timer);
+      }
+      resolve(value);
+      defer(() => unwatch?.());
+    };
+
+    unwatch = watch(
       getter,
       (value) => {
         if (value) {
-          resolve(value as NonNullable<T>);
-          defer(() => unwatch());
+          finish(value as NonNullable<T>);
         }
       },
       { immediate: true },
     );
+
+    // The immediate watcher may already have settled the promise above; only
+    // arm the timeout when still pending so the fast path leaves no timer alive.
+    if (timeout !== undefined && !settled) {
+      timer = setTimeout(() => finish(undefined), timeout);
+    }
   });
 }
 

--- a/tests/unit/protocols/aeternity/libs/AeSdkSuperhero.walletInfo.spec.ts
+++ b/tests/unit/protocols/aeternity/libs/AeSdkSuperhero.walletInfo.spec.ts
@@ -21,14 +21,30 @@ describe('AeSdkSuperhero wallet info sharing', () => {
     notify.mockClear();
   });
 
-  it('announces minimal wallet presence without network details', async () => {
+  async function createSdkStub(overrides: Record<string, unknown> = {}) {
     const { AeSdkSuperhero } = await import('@/protocols/aeternity/libs/AeSdkSuperhero');
+    const { api: apiOverride, ...rest } = overrides;
     const sdk = Object.create(AeSdkSuperhero.prototype);
 
-    sdk.id = 'Superhero Wallet';
-    sdk.name = 'Superhero';
-    sdk._type = 'window';
-    sdk._getClient = jest.fn(() => ({ rpc: { notify } }));
+    Object.assign(sdk, {
+      id: 'Superhero Wallet',
+      name: 'Superhero',
+      _type: 'window',
+      nodeNetworkId: { value: undefined },
+      isNodeConnected: () => false,
+      _getClient: jest.fn(() => ({ rpc: { notify } })),
+      ...rest,
+    });
+    // `api` is a getter on AeSdkBase; define it explicitly on the stub.
+    Object.defineProperty(sdk, 'api', {
+      value: apiOverride ?? { getNetworkId: jest.fn() },
+      configurable: true,
+    });
+    return sdk;
+  }
+
+  it('announces minimal wallet presence without network details', async () => {
+    const sdk = await createSdkStub();
 
     await sdk.shareWalletInfo('client-id');
 
@@ -39,5 +55,48 @@ describe('AeSdkSuperhero wallet info sharing', () => {
       type: 'window',
     });
     expect(notify.mock.calls[0][1]).not.toHaveProperty('networkId');
+  });
+
+  it('getWalletInfo prefers nodeNetworkId without calling the node', async () => {
+    const getNetworkId = jest.fn();
+    const sdk = await createSdkStub({
+      nodeNetworkId: { value: 'ae_mainnet' },
+      isNodeConnected: () => true,
+      api: { getNetworkId },
+    });
+
+    const info = await sdk.getWalletInfo();
+
+    expect(info.networkId).toBe('ae_mainnet');
+    expect(getNetworkId).not.toHaveBeenCalled();
+  });
+
+  it('getWalletInfo falls back to api.getNetworkId when nodeNetworkId is missing', async () => {
+    const getNetworkId = jest.fn(async () => 'ae_uat');
+    const sdk = await createSdkStub({
+      nodeNetworkId: { value: undefined },
+      isNodeConnected: () => true,
+      api: { getNetworkId },
+    });
+
+    const info = await sdk.getWalletInfo();
+
+    expect(getNetworkId).toHaveBeenCalled();
+    expect(info.networkId).toBe('ae_uat');
+  });
+
+  it('getWalletInfo does not reject when api.getNetworkId fails', async () => {
+    const getNetworkId = jest.fn(async () => { throw new Error('node unreachable'); });
+    const sdk = await createSdkStub({
+      nodeNetworkId: { value: undefined },
+      isNodeConnected: () => true,
+      api: { getNetworkId },
+    });
+
+    await expect(sdk.getWalletInfo()).resolves.toMatchObject({
+      id: 'Superhero Wallet',
+      name: 'Superhero',
+      networkId: undefined,
+    });
   });
 });

--- a/tests/unit/utils/watchUntilTruthy.spec.ts
+++ b/tests/unit/utils/watchUntilTruthy.spec.ts
@@ -1,0 +1,85 @@
+import {
+  describe,
+  expect,
+  it,
+  jest,
+} from '@jest/globals';
+import { ref } from 'vue';
+import { watchUntilTruthy } from '@/utils/common';
+
+describe('watchUntilTruthy', () => {
+  it('resolves with the first truthy value when no timeout is given', async () => {
+    const value = ref(0);
+
+    const promise = watchUntilTruthy(() => value.value);
+
+    value.value = 42;
+    await expect(promise).resolves.toBe(42);
+  });
+
+  it('resolves with undefined when the timeout elapses before a truthy value', async () => {
+    jest.useFakeTimers();
+    try {
+      const value = ref(0);
+      const promise = watchUntilTruthy(() => value.value, 100);
+
+      jest.advanceTimersByTime(100);
+      await expect(promise).resolves.toBeUndefined();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('stops watching after timeout so a later truthy value does not change the result', async () => {
+    jest.useFakeTimers();
+    try {
+      const value = ref(0);
+      const promise = watchUntilTruthy(() => value.value, 100);
+
+      jest.advanceTimersByTime(100);
+      await expect(promise).resolves.toBeUndefined();
+
+      value.value = 99;
+      jest.advanceTimersByTime(100);
+      await Promise.resolve();
+
+      // Promise was already settled; a leaked watcher would not change this.
+      await expect(promise).resolves.toBeUndefined();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('resolves with a truthy value before the timeout and clears the timer', async () => {
+    jest.useFakeTimers();
+    try {
+      const value = ref('ready');
+      const promise = watchUntilTruthy(() => value.value, 5000);
+
+      await expect(promise).resolves.toBe('ready');
+
+      jest.advanceTimersByTime(5000);
+      await Promise.resolve();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('does not arm a timeout when the value is already truthy (fast path)', async () => {
+    jest.useFakeTimers();
+    const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+    try {
+      const value = ref('ready');
+      const promise = watchUntilTruthy(() => value.value, 5000);
+
+      await expect(promise).resolves.toBe('ready');
+      // The immediate watcher settled synchronously, so the timeout timer
+      // (the one armed with the 5000ms delay) should never be created. Note
+      // lodash `defer` also uses setTimeout, hence asserting on the delay.
+      expect(setTimeoutSpy).not.toHaveBeenCalledWith(expect.any(Function), 5000);
+    } finally {
+      setTimeoutSpy.mockRestore();
+      jest.useRealTimers();
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect dApp RPC account/network responses and signing paths in the offscreen document; behavior is improved for edge cases but alters when addresses are returned and which RPC errors are reported.
> 
> **Overview**
> **Release 2.10.2** bumps app/package versions and documents fixes for dApp connect/signing after slow startup and avatar availability.
> 
> **dApp connection & signing** are hardened for slow browser/node startup and the long-lived offscreen document. `ensureNodeNetworkId` retries resolving the network id when the first node status failed, and signing/delegation call it before failing with “Not connected to any network”. `getWalletInfo` tolerates a missing or failing `getNetworkId` so connect does not crash; `IWalletInfo.networkId` is optional internally with an RPC-boundary cast.
> 
> **Account selection for dApps** no longer treats the default active index (0) as authoritative until `activeAccountGlobalIdx` is restored from storage, and `getLastActiveProtocolAccount` stops falling back to another account while the last-used index is still unresolved—reducing wrong-address exposure on multi-account wallets. Subscription/`onAskAccounts` use bounded `watchUntilTruthy` (with watcher cleanup), wait for account lists where needed, and return `RpcInternalError` instead of user-rejection when restore times out. Offscreen permission checks fall back to the `origin` argument when `aeppInfo` is not populated yet.
> 
> `watchUntilTruthy` gains an optional timeout; new unit tests cover it and `AeSdkSuperhero.getWalletInfo` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d88984561b00013e4fc350574a2e37bda87c40c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->