### PR TITLE
Add several composable tests

### DIFF
--- a/tests/unit/composables/auth.mobile.spec.ts
+++ b/tests/unit/composables/auth.mobile.spec.ts
@@ -1,326 +1,183 @@
 // @ts-nocheck
-import { ref, nextTick } from 'vue';
+import { nextTick } from 'vue';
 
-describe('useAuth mobile biometric login', () => {
-  beforeEach(async () => {
+/**
+ * Exercises `useAuth`'s mobile biometric-login lifecycle against REAL crypto
+ * (Web Crypto via Node's `globalThis.crypto.subtle`) and REAL storage (`useStorageRef`
+ * backed by jsdom `localStorage`, including `SecureMobileStorage`'s web fallback which
+ * is also plain `localStorage` under the hood). Only three things are mocked:
+ *   - `@aparajita/capacitor-biometric-auth` - native hardware, unavailable in jsdom.
+ *   - `@/composables/modals` - real modal *components* aren't mounted here, so the
+ *     three modal openers `auth.ts` calls are stubbed to control resolve/reject timing.
+ *   - `@/lib/logger` - side-effecting telemetry, irrelevant to what's under test.
+ *   - `@/constants` - only to force `IS_MOBILE_APP`/`IS_EXTENSION`/etc, since jsdom has
+ *     no real Ionic native platform to detect; every other constant stays real.
+ * Everything else (`useStorageRef`, `useUi`, migrations, `@/utils` crypto helpers,
+ * `@/composables/defaultPassword`) runs unmocked.
+ *
+ * `useAuth`/`useUi` are per-module singletons (`createCustomScopedComposable`), so an
+ * app restart is simulated with `vi.resetModules()` + a fresh dynamic import - state
+ * carries over via the real, un-cleared `localStorage`, exactly like a real relaunch.
+ */
+const VALID_MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+function flushAsync() {
+  return new Promise((resolve) => { setTimeout(resolve, 0); });
+}
+
+describe('useAuth on mobile', () => {
+  let checkBiometryMock;
+  let biometricAuthenticateMock;
+  let openBiometricLoginModalMock;
+  let openPasswordLoginModalMock;
+  let openEnableBiometricLoginModalMock;
+  let loggerWriteMock;
+
+  beforeEach(() => {
     vi.resetModules();
+    localStorage.clear();
+
+    checkBiometryMock = vi.fn().mockResolvedValue({ isAvailable: true });
+    biometricAuthenticateMock = vi.fn().mockResolvedValue(undefined);
+    openBiometricLoginModalMock = vi.fn().mockResolvedValue(undefined);
+    openPasswordLoginModalMock = vi.fn().mockResolvedValue(undefined);
+    openEnableBiometricLoginModalMock = vi.fn().mockResolvedValue(undefined);
+    loggerWriteMock = vi.fn();
+
+    // All `vi.doMock` calls must be registered here, before any dynamic import below -
+    // vitest's global `registerAdapters` setup file transitively loads the real
+    // `@/composables` barrel (and everything in it, including `auth.ts` and its
+    // dependencies) before this file's tests run; mocking afterwards would be too late.
+    vi.doMock('@aparajita/capacitor-biometric-auth', () => ({
+      BiometricAuth: {
+        checkBiometry: (...args) => checkBiometryMock(...args),
+        authenticate: (...args) => biometricAuthenticateMock(...args),
+      },
+    }));
+    vi.doMock('@/constants', async () => {
+      const actual = await vi.importActual('@/constants');
+      return {
+        ...actual,
+        IS_MOBILE_APP: true,
+        IS_EXTENSION: false,
+        IS_IOS: false,
+        IS_OFFSCREEN_TAB: false,
+        RUNNING_IN_TESTS: false,
+      };
+    });
+    vi.doMock('@/composables/modals', () => ({
+      useModals: () => ({
+        openBiometricLoginModal: (...args) => openBiometricLoginModalMock(...args),
+        openPasswordLoginModal: (...args) => openPasswordLoginModalMock(...args),
+        openEnableBiometricLoginModal: (...args) => openEnableBiometricLoginModalMock(...args),
+      }),
+    }));
+    vi.doMock('@/lib/logger', () => ({
+      __esModule: true,
+      default: { write: (...args) => loggerWriteMock(...args) },
+    }));
+  });
+
+  /** Boots a fresh `useAuth()` + `useUi()` pair against the current module generation. */
+  async function boot() {
+    const { useAuth } = await import('@/composables/auth');
+    const { useUi } = await import('@/composables/ui');
+    return { auth: useAuth(), ui: useUi() };
+  }
+
+  /** Simulates an app restart: fresh module registry, same on-disk state. */
+  async function restart() {
+    vi.resetModules();
+    const booted = await boot();
+    await flushAsync(); // let every storageRef finish restoring from localStorage
+    return booted;
+  }
+
+  it('encrypts a new mnemonic with a fresh per-install mobile key, decryptable back to the original phrase', async () => {
+    const { auth } = await boot();
+
+    await auth.setMnemonicAndInitializeAuthentication(VALID_MNEMONIC);
+
+    expect(auth.isAuthenticated.value).toBe(true);
+    expect(auth.mnemonicDecrypted.value).toBe(VALID_MNEMONIC);
+    expect(auth.isMnemonicEncrypted.value).toBe(true);
+    expect(auth.mnemonic.value).not.toBe(VALID_MNEMONIC);
+
+    const { decrypt } = await import('@/utils/crypto');
+    await expect(decrypt(auth.encryptionKey.value, auth.mnemonic.value))
+      .resolves.toBe(VALID_MNEMONIC);
+  });
+
+  it('restores the encrypted mnemonic and unlocks via biometric auth after a simulated app restart', async () => {
+    const { auth: authGen1, ui: uiGen1 } = await boot();
+    uiGen1.setBiometricLoginEnabled(true);
+    await authGen1.setMnemonicAndInitializeAuthentication(VALID_MNEMONIC);
+
+    const { auth, ui } = await restart();
+    ui.isAppActive.value = true;
+
+    await auth.checkUserAuth();
+
+    expect(openBiometricLoginModalMock).toHaveBeenCalledTimes(1);
+    expect(auth.isAuthenticated.value).toBe(true);
+    expect(auth.mnemonicDecrypted.value).toBe(VALID_MNEMONIC);
   });
 
   it('keeps the wallet locked when the biometric login prompt is dismissed', async () => {
-    const mnemonicRef = ref('encrypted-mnemonic');
-    const encryptionSaltRef = ref(null);
-    const secureLoginTimeoutRef = ref(null);
-    const openBiometricLoginModal = vi.fn().mockRejectedValue(new Error('dismissed'));
+    const { auth: authGen1, ui: uiGen1 } = await boot();
+    uiGen1.setBiometricLoginEnabled(true);
+    await authGen1.setMnemonicAndInitializeAuthentication(VALID_MNEMONIC);
 
-    vi.doMock('@aparajita/capacitor-biometric-auth', () => ({
-      BiometricAuth: {
-        checkBiometry: vi.fn().mockResolvedValue({ isAvailable: true }),
-      },
-    }));
-    vi.doMock('@/constants', () => ({
-      AUTHENTICATION_TIMEOUTS: [1000, 5000, 10000],
-      IS_EXTENSION: false,
-      IS_IOS: false,
-      IS_MOBILE_APP: true,
-      IS_OFFSCREEN_TAB: false,
-      RUNNING_IN_TESTS: false,
-      STORAGE_KEYS: {
-        mnemonic: 'mnemonic',
-        encryptionSalt: 'encryption-salt',
-        secureLoginTimeout: 'secure-login-timeout',
-      },
-    }));
-    vi.doMock('@/popup/plugins/i18n', () => ({ tg: (key: string) => key }));
-    vi.doMock('@/lib/logger', () => ({
-      __esModule: true,
-      default: { write: vi.fn() },
-    }));
-    vi.doMock('@/migrations/002-mnemonic-vuex-to-composable', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/migrations/008-mnemonic-cordova-to-ionic', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/migrations/010-mnemonic-mobile-to-secure-storage', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/migrations/011-mobile-sensitive-data-encryption', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/composables/defaultPassword', () => ({
-      LEGACY_DEFAULT_PASSWORD: 'testPassword123',
-      clearDefaultPasswordSecret: vi.fn(),
-      getDefaultPasswordSecret: vi.fn().mockResolvedValue(null),
-      getOrCreateDefaultPasswordSecret: vi.fn().mockResolvedValue('secret'),
-    }));
-    vi.doMock('@/composables/ui', () => ({
-      useUi: () => ({
-        isBiometricLoginEnabled: ref(true),
-        isAppActive: ref(true),
-        setBiometricLoginEnabled: vi.fn(),
-        setLoaderVisible: vi.fn(),
-      }),
-    }));
-    vi.doMock('@/composables/modals', () => ({
-      useModals: () => ({
-        openBiometricLoginModal,
-        openPasswordLoginModal: vi.fn(),
-        openEnableBiometricLoginModal: vi.fn(),
-      }),
-    }));
-    vi.doMock('@/composables/storageRef', () => ({
-      useStorageRef: (_initialState, key, options = {}) => {
-        const byKey = {
-          mnemonic: mnemonicRef,
-          'encryption-salt': encryptionSaltRef,
-          'secure-login-timeout': secureLoginTimeoutRef,
-        };
-        options.onRestored?.(byKey[key]?.value ?? null);
-        return byKey[key] ?? ref(_initialState);
-      },
-    }));
-    vi.doMock('@/utils', () => ({
-      createCustomScopedComposable: (factory) => {
-        let value;
-        return () => {
-          if (!value) value = factory();
-          return value;
-        };
-      },
-      decodeBase64: vi.fn(),
-      decrypt: vi.fn().mockResolvedValue('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'),
-      decryptedComputed: vi.fn(() => ref('1000')),
-      encodeBase64: vi.fn(),
-      encrypt: vi.fn(),
-      excludeFalsy: Boolean,
-      generateEncryptionKey: vi.fn(),
-      generateSalt: vi.fn(),
-      getOrCreateMobileEncryptionKey: vi.fn().mockResolvedValue({}),
-      getSessionEncryptionKey: vi.fn().mockResolvedValue(null),
-      handleUnknownError: vi.fn(),
-      sessionEnd: vi.fn(),
-      sessionStart: vi.fn(),
-      watchUntilTruthy: vi.fn(async (source) => (typeof source === 'function' ? source() : source.value)),
-    }));
-
-    vi.resetModules();
-    const auth = (await import('@/composables/auth')).useAuth();
+    openBiometricLoginModalMock.mockRejectedValue(new Error('dismissed'));
+    const { auth, ui } = await restart();
+    ui.isAppActive.value = true;
 
     await auth.checkUserAuth();
-    await nextTick();
 
-    expect(openBiometricLoginModal).toHaveBeenCalledTimes(1);
+    expect(auth.isAuthenticated.value).toBe(false);
+    expect(auth.mnemonicDecrypted.value).toBe('');
+  });
+
+  it('unblocks concurrent auth checks when the biometric login prompt is dismissed', async () => {
+    const { auth: authGen1, ui: uiGen1 } = await boot();
+    uiGen1.setBiometricLoginEnabled(true);
+    await authGen1.setMnemonicAndInitializeAuthentication(VALID_MNEMONIC);
+
+    let rejectModal;
+    openBiometricLoginModalMock.mockImplementation(() => new Promise((_resolve, reject) => {
+      rejectModal = reject;
+    }));
+
+    const { auth, ui } = await restart();
+    ui.isAppActive.value = true;
+
+    const firstCheck = auth.checkUserAuth();
+    while (openBiometricLoginModalMock.mock.calls.length === 0) {
+      // eslint-disable-next-line no-await-in-loop
+      await flushAsync();
+    }
+    const secondCheck = auth.checkUserAuth();
+    await flushAsync();
+
+    rejectModal(new Error('dismissed'));
+
+    await expect(firstCheck).resolves.toBeUndefined();
+    await expect(secondCheck).resolves.toBeUndefined();
+    expect(openBiometricLoginModalMock).toHaveBeenCalledTimes(1);
     expect(auth.isAuthenticated.value).toBe(false);
   });
 
-  it('unblocks concurrent auth checks when biometric login is dismissed', async () => {
-    const mnemonicRef = ref('encrypted-mnemonic');
-    const encryptionSaltRef = ref(null);
-    const secureLoginTimeoutRef = ref(null);
-    let rejectBiometricLogin: (error: Error) => void;
-    const openBiometricLoginModal = vi.fn(() => new Promise((_resolve, reject) => {
-      rejectBiometricLogin = reject;
-    }));
-    const waitFor = (predicate: () => boolean): Promise<void> => (
-      predicate()
-        ? Promise.resolve()
-        : new Promise((resolve) => { setTimeout(resolve, 0); })
-          .then(() => waitFor(predicate))
-    );
+  it('forces biometric verification on manual lock/authenticate even when biometric login is disabled', async () => {
+    const { auth: authGen1 } = await boot(); // biometric login stays disabled (default)
+    await authGen1.setMnemonicAndInitializeAuthentication(VALID_MNEMONIC);
 
-    vi.doMock('@aparajita/capacitor-biometric-auth', () => ({
-      BiometricAuth: {
-        checkBiometry: vi.fn().mockResolvedValue({ isAvailable: true }),
-      },
-    }));
-    vi.doMock('@/constants', () => ({
-      AUTHENTICATION_TIMEOUTS: [1000, 5000, 10000],
-      IS_EXTENSION: false,
-      IS_IOS: false,
-      IS_MOBILE_APP: true,
-      IS_OFFSCREEN_TAB: false,
-      RUNNING_IN_TESTS: false,
-      STORAGE_KEYS: {
-        mnemonic: 'mnemonic',
-        encryptionSalt: 'encryption-salt',
-        secureLoginTimeout: 'secure-login-timeout',
-      },
-    }));
-    vi.doMock('@/popup/plugins/i18n', () => ({ tg: (key: string) => key }));
-    vi.doMock('@/lib/logger', () => ({
-      __esModule: true,
-      default: { write: vi.fn() },
-    }));
-    vi.doMock('@/migrations/002-mnemonic-vuex-to-composable', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/migrations/008-mnemonic-cordova-to-ionic', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/migrations/010-mnemonic-mobile-to-secure-storage', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/migrations/011-mobile-sensitive-data-encryption', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/composables/defaultPassword', () => ({
-      LEGACY_DEFAULT_PASSWORD: 'testPassword123',
-      clearDefaultPasswordSecret: vi.fn(),
-      getDefaultPasswordSecret: vi.fn().mockResolvedValue(null),
-      getOrCreateDefaultPasswordSecret: vi.fn().mockResolvedValue('secret'),
-    }));
-    vi.doMock('@/composables/ui', () => ({
-      useUi: () => ({
-        isBiometricLoginEnabled: ref(true),
-        isAppActive: ref(true),
-        setBiometricLoginEnabled: vi.fn(),
-        setLoaderVisible: vi.fn(),
-      }),
-    }));
-    vi.doMock('@/composables/modals', () => ({
-      useModals: () => ({
-        openBiometricLoginModal,
-        openPasswordLoginModal: vi.fn(),
-        openEnableBiometricLoginModal: vi.fn(),
-      }),
-    }));
-    vi.doMock('@/composables/storageRef', () => ({
-      useStorageRef: (_initialState, key, options = {}) => {
-        const byKey = {
-          mnemonic: mnemonicRef,
-          'encryption-salt': encryptionSaltRef,
-          'secure-login-timeout': secureLoginTimeoutRef,
-        };
-        options.onRestored?.(byKey[key]?.value ?? null);
-        return byKey[key] ?? ref(_initialState);
-      },
-    }));
-    vi.doMock('@/utils', () => ({
-      createCustomScopedComposable: (factory) => {
-        let value;
-        return () => {
-          if (!value) value = factory();
-          return value;
-        };
-      },
-      decodeBase64: vi.fn(),
-      decrypt: vi.fn().mockResolvedValue('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'),
-      decryptedComputed: vi.fn(() => ref('1000')),
-      encodeBase64: vi.fn(),
-      encrypt: vi.fn(),
-      excludeFalsy: Boolean,
-      generateEncryptionKey: vi.fn(),
-      generateSalt: vi.fn(),
-      getOrCreateMobileEncryptionKey: vi.fn().mockResolvedValue({}),
-      getSessionEncryptionKey: vi.fn().mockResolvedValue(null),
-      handleUnknownError: vi.fn(),
-      sessionEnd: vi.fn(),
-      sessionStart: vi.fn(),
-      watchUntilTruthy: vi.fn(async (source) => {
-        const getValue = () => (typeof source === 'function' ? source() : source.value);
-        await waitFor(() => !!getValue());
-        return getValue();
-      }),
-    }));
-
-    const auth = (await import('@/composables/auth')).useAuth();
-
-    const firstAuthCheck = auth.checkUserAuth();
-    await waitFor(() => openBiometricLoginModal.mock.calls.length > 0);
-    const secondAuthCheck = auth.checkUserAuth();
-    await Promise.resolve();
-
-    rejectBiometricLogin!(new Error('dismissed'));
-
-    await expect(firstAuthCheck).resolves.toBeUndefined();
-    await expect(secondAuthCheck).resolves.toBeUndefined();
-    expect(openBiometricLoginModal).toHaveBeenCalledTimes(1);
-    expect(auth.isAuthenticated.value).toBe(false);
-  });
-
-  it('forces biometric verification even when biometric login is disabled', async () => {
-    const mnemonicRef = ref('encrypted-mnemonic');
-    const encryptionSaltRef = ref(null);
-    const secureLoginTimeoutRef = ref(null);
-    const isBiometricLoginEnabled = ref(false);
-    const authenticate = vi.fn().mockResolvedValue(undefined);
-    const openBiometricLoginModal = vi.fn().mockResolvedValue(undefined);
-
-    vi.doMock('@aparajita/capacitor-biometric-auth', () => ({
-      BiometricAuth: {
-        authenticate,
-        checkBiometry: vi.fn().mockResolvedValue({ isAvailable: true }),
-      },
-    }));
-    vi.doMock('@/constants', () => ({
-      AUTHENTICATION_TIMEOUTS: [1000, 5000, 10000],
-      IS_EXTENSION: false,
-      IS_IOS: false,
-      IS_MOBILE_APP: true,
-      IS_OFFSCREEN_TAB: false,
-      RUNNING_IN_TESTS: false,
-      STORAGE_KEYS: {
-        mnemonic: 'mnemonic',
-        encryptionSalt: 'encryption-salt',
-        secureLoginTimeout: 'secure-login-timeout',
-      },
-    }));
-    vi.doMock('@/popup/plugins/i18n', () => ({ tg: (key: string) => key }));
-    vi.doMock('@/lib/logger', () => ({
-      __esModule: true,
-      default: { write: vi.fn() },
-    }));
-    vi.doMock('@/migrations/002-mnemonic-vuex-to-composable', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/migrations/008-mnemonic-cordova-to-ionic', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/migrations/010-mnemonic-mobile-to-secure-storage', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/migrations/011-mobile-sensitive-data-encryption', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/composables/defaultPassword', () => ({
-      LEGACY_DEFAULT_PASSWORD: 'testPassword123',
-      clearDefaultPasswordSecret: vi.fn(),
-      getDefaultPasswordSecret: vi.fn().mockResolvedValue(null),
-      getOrCreateDefaultPasswordSecret: vi.fn().mockResolvedValue('secret'),
-    }));
-    vi.doMock('@/composables/ui', () => ({
-      useUi: () => ({
-        isBiometricLoginEnabled,
-        isAppActive: ref(true),
-        setBiometricLoginEnabled: vi.fn(),
-        setLoaderVisible: vi.fn(),
-      }),
-    }));
-    vi.doMock('@/composables/modals', () => ({
-      useModals: () => ({
-        openBiometricLoginModal,
-        openPasswordLoginModal: vi.fn(),
-        openEnableBiometricLoginModal: vi.fn(),
-      }),
-    }));
-    vi.doMock('@/composables/storageRef', () => ({
-      useStorageRef: (_initialState, key, options = {}) => {
-        const byKey = {
-          mnemonic: mnemonicRef,
-          'encryption-salt': encryptionSaltRef,
-          'secure-login-timeout': secureLoginTimeoutRef,
-        };
-        options.onRestored?.(byKey[key]?.value ?? null);
-        return byKey[key] ?? ref(_initialState);
-      },
-    }));
-    vi.doMock('@/utils', () => ({
-      createCustomScopedComposable: (factory) => {
-        let value;
-        return () => {
-          if (!value) value = factory();
-          return value;
-        };
-      },
-      decodeBase64: vi.fn(),
-      decrypt: vi.fn().mockResolvedValue('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'),
-      decryptedComputed: vi.fn(() => ref('1000')),
-      encodeBase64: vi.fn(),
-      encrypt: vi.fn(),
-      excludeFalsy: Boolean,
-      generateEncryptionKey: vi.fn(),
-      generateSalt: vi.fn(),
-      getOrCreateMobileEncryptionKey: vi.fn().mockResolvedValue({}),
-      getSessionEncryptionKey: vi.fn().mockResolvedValue(null),
-      handleUnknownError: vi.fn(),
-      sessionEnd: vi.fn(),
-      sessionStart: vi.fn(),
-      watchUntilTruthy: vi.fn(async (source) => (typeof source === 'function' ? source() : source.value)),
-    }));
-
-    const auth = (await import('@/composables/auth')).useAuth();
-
-    await auth.checkUserAuth();
+    const { auth } = await restart();
+    await auth.checkUserAuth(); // auto-unlocks without a prompt, since it's disabled
     expect(auth.isAuthenticated.value).toBe(true);
+    expect(openBiometricLoginModalMock).not.toHaveBeenCalled();
 
     await auth.lockWallet();
-    expect(openBiometricLoginModal).toHaveBeenCalledWith({
+    expect(openBiometricLoginModalMock).toHaveBeenCalledWith({
       force: true,
       deferAuthStateUpdate: true,
     });
@@ -330,223 +187,78 @@ describe('useAuth mobile biometric login', () => {
     expect(auth.isAuthenticated.value).toBe(false);
 
     await auth.authenticateWithBiometry(true);
-
-    expect(authenticate).toHaveBeenCalledTimes(1);
+    expect(biometricAuthenticateMock).toHaveBeenCalledTimes(1);
     expect(auth.isAuthenticated.value).toBe(true);
   });
 
-  it('does not auto-lock on mobile app resume when biometric login is disabled', async () => {
-    const mnemonicRef = ref('encrypted-mnemonic');
-    const encryptionSaltRef = ref(null);
-    const secureLoginTimeoutRef = ref(null);
-    const isBiometricLoginEnabled = ref(false);
-    const isAppActive = ref(true);
-    const openBiometricLoginModal = vi.fn().mockResolvedValue(undefined);
+  it('does not auto-lock on app resume when biometric login is disabled', async () => {
+    const { auth: authGen1 } = await boot(); // biometric login stays disabled (default)
+    await authGen1.setMnemonicAndInitializeAuthentication(VALID_MNEMONIC);
 
-    vi.doMock('@aparajita/capacitor-biometric-auth', () => ({
-      BiometricAuth: {
-        checkBiometry: vi.fn().mockResolvedValue({ isAvailable: true }),
-      },
-    }));
-    vi.doMock('@/constants', () => ({
-      AUTHENTICATION_TIMEOUTS: [1000, 5000, 10000],
-      IS_EXTENSION: false,
-      IS_IOS: false,
-      IS_MOBILE_APP: true,
-      IS_OFFSCREEN_TAB: false,
-      RUNNING_IN_TESTS: false,
-      STORAGE_KEYS: {
-        mnemonic: 'mnemonic',
-        encryptionSalt: 'encryption-salt',
-        secureLoginTimeout: 'secure-login-timeout',
-      },
-    }));
-    vi.doMock('@/popup/plugins/i18n', () => ({ tg: (key: string) => key }));
-    vi.doMock('@/lib/logger', () => ({
-      __esModule: true,
-      default: { write: vi.fn() },
-    }));
-    vi.doMock('@/migrations/002-mnemonic-vuex-to-composable', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/migrations/008-mnemonic-cordova-to-ionic', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/migrations/010-mnemonic-mobile-to-secure-storage', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/migrations/011-mobile-sensitive-data-encryption', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/composables/defaultPassword', () => ({
-      LEGACY_DEFAULT_PASSWORD: 'testPassword123',
-      clearDefaultPasswordSecret: vi.fn(),
-      getDefaultPasswordSecret: vi.fn().mockResolvedValue(null),
-      getOrCreateDefaultPasswordSecret: vi.fn().mockResolvedValue('secret'),
-    }));
-    vi.doMock('@/composables/ui', () => ({
-      useUi: () => ({
-        isBiometricLoginEnabled,
-        isAppActive,
-        setBiometricLoginEnabled: vi.fn(),
-        setLoaderVisible: vi.fn(),
-      }),
-    }));
-    vi.doMock('@/composables/modals', () => ({
-      useModals: () => ({
-        openBiometricLoginModal,
-        openPasswordLoginModal: vi.fn(),
-        openEnableBiometricLoginModal: vi.fn(),
-      }),
-    }));
-    vi.doMock('@/composables/storageRef', () => ({
-      useStorageRef: (_initialState, key, options = {}) => {
-        const byKey = {
-          mnemonic: mnemonicRef,
-          'encryption-salt': encryptionSaltRef,
-          'secure-login-timeout': secureLoginTimeoutRef,
-        };
-        options.onRestored?.(byKey[key]?.value ?? null);
-        return byKey[key] ?? ref(_initialState);
-      },
-    }));
-    vi.doMock('@/utils', () => ({
-      createCustomScopedComposable: (factory) => {
-        let value;
-        return () => {
-          if (!value) value = factory();
-          return value;
-        };
-      },
-      decodeBase64: vi.fn(),
-      decrypt: vi.fn().mockResolvedValue('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'),
-      decryptedComputed: vi.fn(() => ref('1000')),
-      encodeBase64: vi.fn(),
-      encrypt: vi.fn(),
-      excludeFalsy: Boolean,
-      generateEncryptionKey: vi.fn(),
-      generateSalt: vi.fn(),
-      getOrCreateMobileEncryptionKey: vi.fn().mockResolvedValue({}),
-      getSessionEncryptionKey: vi.fn().mockResolvedValue(null),
-      handleUnknownError: vi.fn(),
-      sessionEnd: vi.fn(),
-      sessionStart: vi.fn(),
-      watchUntilTruthy: vi.fn(async (source) => (typeof source === 'function' ? source() : source.value)),
-    }));
+    const { auth, ui } = await restart();
+    ui.isAppActive.value = true;
+    await auth.checkUserAuth();
+    expect(auth.isAuthenticated.value).toBe(true);
 
-    vi.useFakeTimers();
-    try {
-      const auth = (await import('@/composables/auth')).useAuth();
+    ui.isAppActive.value = false;
+    await nextTick();
+    ui.isAppActive.value = true;
+    await nextTick();
+    await flushAsync();
 
-      await auth.checkUserAuth();
-      expect(auth.isAuthenticated.value).toBe(true);
-
-      isAppActive.value = false;
-      await nextTick();
-      vi.advanceTimersByTime(1000);
-      isAppActive.value = true;
-      await nextTick();
-      await Promise.resolve();
-
-      expect(openBiometricLoginModal).not.toHaveBeenCalled();
-      expect(auth.isAuthenticated.value).toBe(true);
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(openBiometricLoginModalMock).not.toHaveBeenCalled();
+    expect(auth.isAuthenticated.value).toBe(true);
   });
 
-  it('keeps mnemonic encryption on the mobile data key when setPassword is called', async () => {
-    const mnemonicRef = ref('encrypted-mnemonic');
-    const encryptionSaltRef = ref(null);
-    const secureLoginTimeoutRef = ref(null);
-    const mobileKey = { type: 'mobile-key' };
-    const generateEncryptionKey = vi.fn();
-    const generateSalt = vi.fn();
-    const encrypt = vi.fn().mockResolvedValue('mobile-ciphertext');
+  it('auto re-locks and re-prompts biometric when the app is backgrounded and resumed (immediate mobile timeout)', async () => {
+    const { auth: authGen1, ui: uiGen1 } = await boot();
+    uiGen1.setBiometricLoginEnabled(true);
+    await authGen1.setMnemonicAndInitializeAuthentication(VALID_MNEMONIC);
 
-    vi.doMock('@aparajita/capacitor-biometric-auth', () => ({
-      BiometricAuth: {
-        checkBiometry: vi.fn().mockResolvedValue({ isAvailable: false }),
-      },
-    }));
-    vi.doMock('@/constants', () => ({
-      AUTHENTICATION_TIMEOUTS: [1000, 5000, 10000],
-      IS_EXTENSION: false,
-      IS_IOS: false,
-      IS_MOBILE_APP: true,
-      IS_OFFSCREEN_TAB: false,
-      RUNNING_IN_TESTS: false,
-      STORAGE_KEYS: {
-        mnemonic: 'mnemonic',
-        encryptionSalt: 'encryption-salt',
-        secureLoginTimeout: 'secure-login-timeout',
-      },
-    }));
-    vi.doMock('@/popup/plugins/i18n', () => ({ tg: (key: string) => key }));
-    vi.doMock('@/lib/logger', () => ({
-      __esModule: true,
-      default: { write: vi.fn() },
-    }));
-    vi.doMock('@/migrations/002-mnemonic-vuex-to-composable', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/migrations/008-mnemonic-cordova-to-ionic', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/migrations/010-mnemonic-mobile-to-secure-storage', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/migrations/011-mobile-sensitive-data-encryption', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/composables/defaultPassword', () => ({
-      LEGACY_DEFAULT_PASSWORD: 'testPassword123',
-      clearDefaultPasswordSecret: vi.fn(),
-      getDefaultPasswordSecret: vi.fn().mockResolvedValue(null),
-      getOrCreateDefaultPasswordSecret: vi.fn().mockResolvedValue('secret'),
-    }));
-    vi.doMock('@/composables/ui', () => ({
-      useUi: () => ({
-        isBiometricLoginEnabled: ref(false),
-        isAppActive: ref(true),
-        setBiometricLoginEnabled: vi.fn(),
-        setLoaderVisible: vi.fn(),
-      }),
-    }));
-    vi.doMock('@/composables/modals', () => ({
-      useModals: () => ({
-        openBiometricLoginModal: vi.fn(),
-        openPasswordLoginModal: vi.fn(),
-        openEnableBiometricLoginModal: vi.fn(),
-      }),
-    }));
-    vi.doMock('@/composables/storageRef', () => ({
-      useStorageRef: (_initialState, key, options = {}) => {
-        const byKey = {
-          mnemonic: mnemonicRef,
-          'encryption-salt': encryptionSaltRef,
-          'secure-login-timeout': secureLoginTimeoutRef,
-        };
-        options.onRestored?.(byKey[key]?.value ?? null);
-        return byKey[key] ?? ref(_initialState);
-      },
-    }));
-    vi.doMock('@/utils', () => ({
-      createCustomScopedComposable: (factory) => {
-        let value;
-        return () => {
-          if (!value) value = factory();
-          return value;
-        };
-      },
-      decodeBase64: vi.fn(),
-      decrypt: vi.fn().mockResolvedValue('abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'),
-      decryptedComputed: vi.fn(() => ref('1000')),
-      encodeBase64: vi.fn(),
-      encrypt,
-      excludeFalsy: Boolean,
-      generateEncryptionKey,
-      generateSalt,
-      getOrCreateMobileEncryptionKey: vi.fn().mockResolvedValue(mobileKey),
-      getSessionEncryptionKey: vi.fn().mockResolvedValue(null),
-      handleUnknownError: vi.fn(),
-      sessionEnd: vi.fn(),
-      sessionStart: vi.fn(),
-      watchUntilTruthy: vi.fn(async (source) => (typeof source === 'function' ? source() : source.value)),
-    }));
+    const { auth, ui } = await restart();
+    ui.isAppActive.value = true;
+    await auth.checkUserAuth();
+    expect(auth.isAuthenticated.value).toBe(true);
+    expect(openBiometricLoginModalMock).toHaveBeenCalledTimes(1);
 
-    const auth = (await import('@/composables/auth')).useAuth();
+    // Mobile's default authentication timeout is 0ms (AUTHENTICATION_TIMEOUTS[0]), so
+    // backgrounding expires the session immediately; resuming should auto re-lock and
+    // re-prompt biometric without any explicit `checkUserAuth()` call from the test.
+    ui.isAppActive.value = false;
+    await nextTick();
+    ui.isAppActive.value = true;
+    await nextTick();
 
-    await Promise.resolve();
-    await auth.setPassword('user-password', 'plain mobile mnemonic');
+    // Wait for both the second prompt AND the resulting re-authentication to settle -
+    // checking only the call count races `markAuthenticated()`, which runs a few
+    // microtask hops after the mock is invoked (and after the mock's own promise
+    // resolves), and can lose that race under heavy parallel test-suite load.
+    while (openBiometricLoginModalMock.mock.calls.length < 2 || !auth.isAuthenticated.value) {
+      // eslint-disable-next-line no-await-in-loop
+      await flushAsync();
+    }
 
-    expect(generateSalt).not.toHaveBeenCalled();
-    expect(generateEncryptionKey).not.toHaveBeenCalled();
-    expect(encrypt).toHaveBeenCalledWith(mobileKey, 'plain mobile mnemonic');
-    expect(mnemonicRef.value).toBe('mobile-ciphertext');
+    expect(auth.isAuthenticated.value).toBe(true);
+  });
+
+  it('surfaces an error and stays locked when the persisted mnemonic cannot be decrypted with the current mobile key', async () => {
+    const { auth: authGen1 } = await boot();
+    await authGen1.setMnemonicAndInitializeAuthentication(VALID_MNEMONIC);
+
+    // Simulate a Keychain wipe: the mobile encryption key is gone, but the mnemonic
+    // ciphertext (encrypted under the OLD key) is still on disk.
+    const { SecureMobileStorage } = await import('@/lib/SecureMobileStorage');
+    const { STORAGE_KEYS } = await import('@/constants');
+    await SecureMobileStorage.remove(STORAGE_KEYS.mobileDataKey);
+
+    const { auth } = await restart(); // mints a NEW mobile key that won't match the old ciphertext
+    await auth.checkUserAuth();
+
+    expect(auth.isAuthenticated.value).toBe(false);
+    expect(auth.mnemonicDecrypted.value).toBe('');
+    expect(loggerWriteMock).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'api-response',
+      modal: true,
+    }));
   });
 });

--- a/tests/unit/composables/auth.offscreenSessionSync.spec.ts
+++ b/tests/unit/composables/auth.offscreenSessionSync.spec.ts
@@ -12,259 +12,147 @@
  * The fix wires `browser.storage.session.onChanged` as a second wake-up
  * source via `subscribeToSessionEncryptionKey`. This test asserts that
  * subscription is registered when running in the offscreen context and
- * that triggering the listener restarts the sync.
+ * that triggering the listener restarts the sync — using REAL crypto
+ * (`@/utils/crypto`) and REAL `useStorageRef`/`useUi`/`useModals`. The only
+ * thing mocked is `@/offscreen/popupHandler`'s `getSessionEncryptionKey`,
+ * the actual cross-context messaging boundary that can't run for real
+ * without a live background script, plus `@/constants` (to force the
+ * offscreen-tab flags jsdom has no real equivalent for) and `@/lib/logger`
+ * (side-effecting telemetry, irrelevant here).
  */
-import { ref } from 'vue';
+const getSessionEncryptionKeyOffscreenMock = vi.fn();
 
-describe('useAuth offscreen session-key wake-up', () => {
-  beforeEach(async () => {
-    vi.resetModules();
-  });
-
-  it('subscribes to session-key updates and restarts the sync on storage change', async () => {
-    const subscribeToSessionEncryptionKey = vi.fn();
-    const getSessionEncryptionKey = vi.fn().mockResolvedValue(null);
-
-    const mnemonicRef = ref('encrypted-mnemonic-blob');
-    const encryptionSaltRef = ref(null);
-    const secureLoginTimeoutRef = ref(null);
-
-    vi.doMock('@aparajita/capacitor-biometric-auth', () => ({
-      BiometricAuth: {
-        checkBiometry: vi.fn().mockResolvedValue({ isAvailable: false }),
-      },
-    }));
-    vi.doMock('@/constants', () => ({
-      AUTHENTICATION_TIMEOUTS: [1000, 5000, 10000],
+function mockConstants(overrides) {
+  vi.doMock('@/constants', async () => {
+    const actual = await vi.importActual('@/constants');
+    return {
+      ...actual,
+      IS_MOBILE_APP: false,
       IS_EXTENSION: false,
       IS_IOS: false,
-      IS_MOBILE_APP: false,
       IS_OFFSCREEN_TAB: true,
       RUNNING_IN_TESTS: false,
-      STORAGE_KEYS: {
-        mnemonic: 'mnemonic',
-        encryptionSalt: 'encryption-salt',
-        secureLoginTimeout: 'secure-login-timeout',
-      },
+      ...overrides,
+    };
+  });
+}
+
+describe('useAuth offscreen session-key wake-up', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    localStorage.clear();
+    getSessionEncryptionKeyOffscreenMock.mockReset().mockResolvedValue(null);
+
+    // Registered before any dynamic import below - `registerAdapters` (vitest's
+    // global setup file) transitively loads the real `@/composables` barrel first,
+    // so mocking these afterwards would be too late for this module generation.
+    vi.doMock('@/offscreen/popupHandler', () => ({
+      getSessionEncryptionKey: (...args) => getSessionEncryptionKeyOffscreenMock(...args),
     }));
-    vi.doMock('@/popup/plugins/i18n', () => ({ tg: (key: string) => key }));
     vi.doMock('@/lib/logger', () => ({
       __esModule: true,
       default: { write: vi.fn() },
     }));
-    vi.doMock('@/migrations/002-mnemonic-vuex-to-composable', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/migrations/008-mnemonic-cordova-to-ionic', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/migrations/010-mnemonic-mobile-to-secure-storage', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/migrations/011-mobile-sensitive-data-encryption', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/composables/defaultPassword', () => ({
-      LEGACY_DEFAULT_PASSWORD: 'testPassword123',
-      clearDefaultPasswordSecret: vi.fn(),
-      getDefaultPasswordSecret: vi.fn().mockResolvedValue(null),
-      getOrCreateDefaultPasswordSecret: vi.fn().mockResolvedValue('secret'),
-    }));
-    vi.doMock('@/composables/ui', () => ({
-      useUi: () => ({
-        isBiometricLoginEnabled: ref(false),
-        isAppActive: ref(true),
-        setBiometricLoginEnabled: vi.fn(),
-        setLoaderVisible: vi.fn(),
-      }),
-    }));
-    vi.doMock('@/composables/modals', () => ({
-      useModals: () => ({
-        openBiometricLoginModal: vi.fn(),
-        openPasswordLoginModal: vi.fn(),
-        openEnableBiometricLoginModal: vi.fn(),
-      }),
-    }));
-    vi.doMock('@/composables/storageRef', () => ({
-      useStorageRef: (_initialState: any, key: string, options: any = {}) => {
-        const byKey: Record<string, any> = {
-          mnemonic: mnemonicRef,
-          'encryption-salt': encryptionSaltRef,
-          'secure-login-timeout': secureLoginTimeoutRef,
-        };
-        options.onRestored?.(byKey[key]?.value ?? null);
-        return byKey[key] ?? ref(_initialState);
-      },
-    }));
-    vi.doMock('@/utils', () => ({
-      createCustomScopedComposable: (factory: any) => {
-        let value: any;
-        return () => {
-          if (!value) value = factory();
-          return value;
-        };
-      },
-      decodeBase64: vi.fn(),
-      decrypt: vi.fn().mockResolvedValue('decrypted'),
-      decryptedComputed: vi.fn(() => ref('1000')),
-      encodeBase64: vi.fn(),
-      encrypt: vi.fn(),
-      excludeFalsy: Boolean,
-      generateEncryptionKey: vi.fn(),
-      generateSalt: vi.fn(),
-      getOrCreateMobileEncryptionKey: vi.fn(),
-      getSessionEncryptionKey,
-      handleUnknownError: vi.fn(),
-      sessionEnd: vi.fn(),
-      sessionStart: vi.fn(),
-      subscribeToSessionEncryptionKey,
-      watchUntilTruthy: vi.fn(async (source: any) => (
-        typeof source === 'function' ? source() : source.value
-      )),
-    }));
+    mockConstants();
+
+    // Extend (not replace) the global `browser` stub with `storage.onChanged`,
+    // needed by the real `subscribeToSessionEncryptionKey` - keeps `runtime`/
+    // `storage.local` from `config/vitest/setup.ts` intact.
+    globalThis.browser.storage.onChanged = { addListener: vi.fn(), removeListener: vi.fn() };
+  });
+
+  it('subscribes to session-key updates and restarts the sync on storage change', async () => {
+    const { useAuth } = await import('@/composables/auth');
+    const auth = useAuth();
+
+    const { addListener } = globalThis.browser.storage.onChanged;
+    expect(addListener).toHaveBeenCalledTimes(1);
+    const onSessionKeyChanged = addListener.mock.calls[0][0];
 
     vi.useFakeTimers();
     try {
-      vi.resetModules();
-      // eslint-disable-next-line global-require
-      (await import('@/composables/auth')).useAuth();
+      // Drive the salt watcher: setting `encryptionSalt` kicks off the first,
+      // bounded (30s) poll.
+      auth.encryptionSalt.value = new Uint8Array([1, 2, 3]);
 
-      // Wire-up assertion: the offscreen branch must register the listener
-      // alongside the salt watcher.
-      expect(subscribeToSessionEncryptionKey).toHaveBeenCalledTimes(1);
-      const onSessionKey = subscribeToSessionEncryptionKey.mock.calls[0][0];
-      expect(typeof onSessionKey).toBe('function');
+      await vi.advanceTimersByTimeAsync(30000); // exhausts CHECK_FOR_SESSION_KEY_TIMEOUT
 
-      // The callback must restart the sync — i.e. begin polling
-      // `getSessionEncryptionKey` again — even after the original
-      // salt-driven poll has already given up.
-      onSessionKey();
-      vi.advanceTimersByTime(5000);
-      await Promise.resolve();
-      await Promise.resolve();
-      expect(getSessionEncryptionKey).toHaveBeenCalled();
+      getSessionEncryptionKeyOffscreenMock.mockClear();
+
+      // Simulate the popup writing the session key into browser.storage.session -
+      // the secondary wake-up source must restart polling even though the first
+      // poll already gave up.
+      onSessionKeyChanged({ exportedEncryptionKey: { newValue: 'abc' } }, 'session');
+      await vi.advanceTimersByTimeAsync(5000); // CHECK_FOR_SESSION_KEY_INTERVAL
+
+      expect(getSessionEncryptionKeyOffscreenMock).toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
     }
   });
 
+  it('recovers the encryption key and decrypts the mnemonic once the popup publishes a session key', async () => {
+    const { useAuth } = await import('@/composables/auth');
+    const auth = useAuth();
+
+    const { generateSalt, encrypt, importEncryptionKey } = await import('@/utils/crypto');
+    const salt = generateSalt();
+    // Raw AES-256 key bytes, as if generated by the popup and shipped to the
+    // offscreen tab via `browser.storage.session` (that's what `sessionStart()`/
+    // `getSessionEncryptionKey()` actually transmit - `exportEncryptionKey()` only
+    // works on a key generated as extractable, which requires `IS_EXTENSION` true;
+    // this test's `@/constants` mock forces `IS_EXTENSION` false to simulate the
+    // *offscreen* side importing it instead).
+    const rawKeyBytes = globalThis.crypto.getRandomValues(new Uint8Array(32));
+    const key = await importEncryptionKey(rawKeyBytes);
+    const plaintext = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+    const ciphertext = await encrypt(key, plaintext);
+    const exportedKeyBase64 = Buffer.from(rawKeyBytes).toString('base64');
+
+    auth.mnemonic.value = ciphertext;
+    getSessionEncryptionKeyOffscreenMock.mockResolvedValue(exportedKeyBase64);
+
+    vi.useFakeTimers();
+    auth.encryptionSalt.value = salt; // triggers the salt-driven poll
+    await vi.advanceTimersByTimeAsync(5000); // first CHECK_FOR_SESSION_KEY_INTERVAL tick
+    // `decrypt()`'s native WebCrypto call settles via a real Node microtask/threadpool
+    // completion rather than a fake timer - switch back to real timers and give it an
+    // actual tick to resolve before asserting.
+    vi.useRealTimers();
+    await new Promise((resolve) => { setTimeout(resolve, 0); });
+
+    expect(auth.mnemonicDecrypted.value).toBe(plaintext);
+    expect(auth.encryptionKey.value).toBeTruthy();
+  });
+
   it('does not subscribe when not running in the offscreen tab', async () => {
-    const subscribeToSessionEncryptionKey = vi.fn();
+    mockConstants({ IS_OFFSCREEN_TAB: false });
 
-    const mnemonicRef = ref('');
-    const encryptionSaltRef = ref(null);
-    const secureLoginTimeoutRef = ref(null);
+    const { useAuth } = await import('@/composables/auth');
+    useAuth();
 
-    vi.doMock('@aparajita/capacitor-biometric-auth', () => ({
-      BiometricAuth: {
-        checkBiometry: vi.fn().mockResolvedValue({ isAvailable: false }),
-      },
-    }));
-    vi.doMock('@/constants', () => ({
-      AUTHENTICATION_TIMEOUTS: [1000, 5000, 10000],
-      IS_EXTENSION: false,
-      IS_IOS: false,
-      IS_MOBILE_APP: false,
-      IS_OFFSCREEN_TAB: false,
-      RUNNING_IN_TESTS: false,
-      STORAGE_KEYS: {
-        mnemonic: 'mnemonic',
-        encryptionSalt: 'encryption-salt',
-        secureLoginTimeout: 'secure-login-timeout',
-      },
-    }));
-    vi.doMock('@/popup/plugins/i18n', () => ({ tg: (key: string) => key }));
-    vi.doMock('@/lib/logger', () => ({
-      __esModule: true,
-      default: { write: vi.fn() },
-    }));
-    vi.doMock('@/migrations/002-mnemonic-vuex-to-composable', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/migrations/008-mnemonic-cordova-to-ionic', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/migrations/010-mnemonic-mobile-to-secure-storage', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/migrations/011-mobile-sensitive-data-encryption', () => ({ __esModule: true, default: vi.fn() }));
-    vi.doMock('@/composables/defaultPassword', () => ({
-      LEGACY_DEFAULT_PASSWORD: 'testPassword123',
-      clearDefaultPasswordSecret: vi.fn(),
-      getDefaultPasswordSecret: vi.fn().mockResolvedValue(null),
-      getOrCreateDefaultPasswordSecret: vi.fn().mockResolvedValue('secret'),
-    }));
-    vi.doMock('@/composables/ui', () => ({
-      useUi: () => ({
-        isBiometricLoginEnabled: ref(false),
-        isAppActive: ref(true),
-        setBiometricLoginEnabled: vi.fn(),
-        setLoaderVisible: vi.fn(),
-      }),
-    }));
-    vi.doMock('@/composables/modals', () => ({
-      useModals: () => ({
-        openBiometricLoginModal: vi.fn(),
-        openPasswordLoginModal: vi.fn(),
-        openEnableBiometricLoginModal: vi.fn(),
-      }),
-    }));
-    vi.doMock('@/composables/storageRef', () => ({
-      useStorageRef: (_initialState: any, key: string, options: any = {}) => {
-        const byKey: Record<string, any> = {
-          mnemonic: mnemonicRef,
-          'encryption-salt': encryptionSaltRef,
-          'secure-login-timeout': secureLoginTimeoutRef,
-        };
-        options.onRestored?.(byKey[key]?.value ?? null);
-        return byKey[key] ?? ref(_initialState);
-      },
-    }));
-    vi.doMock('@/utils', () => ({
-      createCustomScopedComposable: (factory: any) => {
-        let value: any;
-        return () => {
-          if (!value) value = factory();
-          return value;
-        };
-      },
-      decodeBase64: vi.fn(),
-      decrypt: vi.fn(),
-      decryptedComputed: vi.fn(() => ref('1000')),
-      encodeBase64: vi.fn(),
-      encrypt: vi.fn(),
-      excludeFalsy: Boolean,
-      generateEncryptionKey: vi.fn(),
-      generateSalt: vi.fn(),
-      getOrCreateMobileEncryptionKey: vi.fn(),
-      getSessionEncryptionKey: vi.fn().mockResolvedValue(null),
-      handleUnknownError: vi.fn(),
-      sessionEnd: vi.fn(),
-      sessionStart: vi.fn(),
-      subscribeToSessionEncryptionKey,
-      watchUntilTruthy: vi.fn(async (source: any) => (
-        typeof source === 'function' ? source() : source.value
-      )),
-    }));
-
-    vi.resetModules();
-    // eslint-disable-next-line global-require
-    (await import('@/composables/auth')).useAuth();
-
-    expect(subscribeToSessionEncryptionKey).not.toHaveBeenCalled();
+    expect(globalThis.browser.storage.onChanged.addListener).not.toHaveBeenCalled();
   });
 });
 
 describe('subscribeToSessionEncryptionKey helper', () => {
-  beforeEach(async () => {
+  beforeEach(() => {
     vi.resetModules();
+
+    vi.doMock('@/constants', async () => {
+      const actual = await vi.importActual('@/constants');
+      return {
+        ...actual, CONNECTION_TYPES: { SESSION: 'session' }, IS_EXTENSION: false, IS_OFFSCREEN_TAB: true,
+      };
+    });
+    vi.doMock('@/offscreen/popupHandler', () => ({ getSessionEncryptionKey: vi.fn() }));
   });
 
   it('only invokes the callback for session-area writes with a truthy newValue', async () => {
     const addListener = vi.fn();
     const removeListener = vi.fn();
-    (global as any).browser = {
-      storage: {
-        onChanged: { addListener, removeListener },
-      },
-    };
+    globalThis.browser.storage.onChanged = { addListener, removeListener };
 
-    vi.doMock('@/constants', () => ({
-      CONNECTION_TYPES: { SESSION: 'session' },
-      IS_EXTENSION: false,
-      IS_OFFSCREEN_TAB: true,
-    }));
-    vi.doMock('@/offscreen/popupHandler', () => ({
-      getSessionEncryptionKey: vi.fn(),
-    }));
-
-    vi.resetModules();
     const { subscribeToSessionEncryptionKey } = await import('@/utils/session');
 
     const callback = vi.fn();
@@ -294,18 +182,8 @@ describe('subscribeToSessionEncryptionKey helper', () => {
   });
 
   it('returns a no-op when storage.onChanged is unavailable', async () => {
-    (global as any).browser = { storage: {} };
+    globalThis.browser.storage.onChanged = undefined;
 
-    vi.doMock('@/constants', () => ({
-      CONNECTION_TYPES: { SESSION: 'session' },
-      IS_EXTENSION: false,
-      IS_OFFSCREEN_TAB: true,
-    }));
-    vi.doMock('@/offscreen/popupHandler', () => ({
-      getSessionEncryptionKey: vi.fn(),
-    }));
-
-    vi.resetModules();
     const { subscribeToSessionEncryptionKey } = await import('@/utils/session');
 
     const teardown = subscribeToSessionEncryptionKey(vi.fn());

--- a/tests/unit/composables/balances.spec.ts
+++ b/tests/unit/composables/balances.spec.ts
@@ -1,0 +1,141 @@
+// @ts-nocheck
+import { ref } from 'vue';
+
+/**
+ * `useBalances` is tested against the real `ProtocolAdapterFactory` singleton (with
+ * `fetchBalance` spied per test, since that is the actual network boundary). `useAccounts`,
+ * `useNetworks` and `useCurrencies` are mocked with plain Vue refs so each test can drive
+ * account lists / active network / currency rate deterministically.
+ */
+let activeAccountRef;
+let accountsRef;
+let activeNetworkRef;
+let onNetworkChangeMock;
+let getCurrentCurrencyRateMock;
+
+describe('useBalances', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    localStorage.clear();
+
+    activeAccountRef = ref({ protocol: 'aeternity', address: 'ak_active' });
+    accountsRef = ref([
+      { protocol: 'aeternity', address: 'ak_active' },
+      { protocol: 'aeternity', address: 'ak_other' },
+    ]);
+    activeNetworkRef = ref({ name: 'Mainnet' });
+    onNetworkChangeMock = vi.fn();
+    getCurrentCurrencyRateMock = vi.fn(() => 1);
+
+    // These mocks must be registered *before* `registerAdapters` is imported below:
+    // `registerAdapters` transitively loads the real `accounts`/`networks`/`currencies`
+    // composables (via aeSdk.ts -> accounts.ts -> the `@/composables` barrel), so
+    // mocking them afterwards would be too late - the real modules would already be
+    // cached and linked against each other for this module generation.
+    vi.doMock('@/composables/accounts', () => ({
+      useAccounts: () => ({ activeAccount: activeAccountRef, accounts: accountsRef }),
+    }));
+    vi.doMock('@/composables/networks', () => ({
+      useNetworks: () => ({
+        activeNetwork: activeNetworkRef,
+        onNetworkChange: onNetworkChangeMock,
+      }),
+    }));
+    vi.doMock('@/composables/currencies', () => ({
+      useCurrencies: () => ({ getCurrentCurrencyRate: getCurrentCurrencyRateMock }),
+    }));
+
+    await import('@/protocols/registerAdapters');
+  });
+
+  it('fetches and stores the balance of every account', async () => {
+    const { ProtocolAdapterFactory } = await import('@/lib/ProtocolAdapterFactory');
+    const adapter = ProtocolAdapterFactory.getAdapter('aeternity');
+    vi.spyOn(adapter, 'fetchBalance').mockImplementation(
+      async (address) => (address === 'ak_active' ? '1000000000000000000' : '2000000000000000000'),
+    );
+
+    const { useBalances } = await import('@/composables/balances');
+    const { updateBalances, balance, getAccountBalance } = useBalances();
+
+    await updateBalances();
+
+    expect(balance.value.toString()).toBe('1000000000000000000');
+    expect(getAccountBalance('aeternity', 'ak_other').toString()).toBe('2000000000000000000');
+    expect(adapter.fetchBalance).toHaveBeenCalledTimes(2);
+  });
+
+  it('discards the fetch result if the active network changed while it was in flight', async () => {
+    const { ProtocolAdapterFactory } = await import('@/lib/ProtocolAdapterFactory');
+    const adapter = ProtocolAdapterFactory.getAdapter('aeternity');
+    const fetchBalanceSpy = vi.spyOn(adapter, 'fetchBalance')
+      .mockResolvedValueOnce('5')
+      .mockResolvedValueOnce('7');
+
+    const { useBalances } = await import('@/composables/balances');
+    const { updateBalances, balances } = useBalances();
+
+    // Establish an initial, settled balance snapshot on "Mainnet".
+    await updateBalances();
+    expect(balances.value.aeternity.ak_active.toString()).toBe('5');
+
+    let resolveFetch;
+    const pendingFetch = new Promise((resolve) => { resolveFetch = resolve; });
+    fetchBalanceSpy.mockImplementation(() => pendingFetch);
+
+    const updatePromise = updateBalances();
+    activeNetworkRef.value = { name: 'Testnet' }; // switch network mid-flight
+    resolveFetch('999');
+    await updatePromise;
+
+    // The stale-network result must be discarded - balances stay at the last good snapshot.
+    expect(balances.value.aeternity.ak_active.toString()).toBe('5');
+  });
+
+  it('dedupes concurrent updateBalances() calls into a single fetch batch', async () => {
+    const { ProtocolAdapterFactory } = await import('@/lib/ProtocolAdapterFactory');
+    const adapter = ProtocolAdapterFactory.getAdapter('aeternity');
+    const fetchBalanceSpy = vi.spyOn(adapter, 'fetchBalance').mockResolvedValue('1');
+
+    const { useBalances } = await import('@/composables/balances');
+    const { updateBalances } = useBalances();
+
+    await Promise.all([updateBalances(), updateBalances()]);
+
+    // 2 accounts x 1 batch, not x2 batches.
+    expect(fetchBalanceSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats a 404 (not-found) balance response as zero, without logging a warning', async () => {
+    const { ProtocolAdapterFactory } = await import('@/lib/ProtocolAdapterFactory');
+    const adapter = ProtocolAdapterFactory.getAdapter('aeternity');
+    vi.spyOn(adapter, 'fetchBalance').mockRejectedValue(
+      Object.assign(new Error('not found'), { statusCode: 404 }),
+    );
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const { useBalances } = await import('@/composables/balances');
+    const { updateBalances, balance } = useBalances();
+
+    await updateBalances();
+
+    expect(balance.value.toString()).toBe('0');
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('sums every account balance converted to the current currency rate', async () => {
+    const { ProtocolAdapterFactory } = await import('@/lib/ProtocolAdapterFactory');
+    const adapter = ProtocolAdapterFactory.getAdapter('aeternity');
+    vi.spyOn(adapter, 'fetchBalance').mockImplementation(
+      async (address) => (address === 'ak_active' ? '2' : '3'),
+    );
+    getCurrentCurrencyRateMock.mockReturnValue(2);
+
+    const { useBalances } = await import('@/composables/balances');
+    const { updateBalances, accountsTotalBalance } = useBalances();
+
+    await updateBalances();
+
+    expect(accountsTotalBalance.value).toBe('10.00'); // (2 + 3) * 2
+  });
+});

--- a/tests/unit/composables/connection.spec.ts
+++ b/tests/unit/composables/connection.spec.ts
@@ -1,0 +1,45 @@
+// @ts-nocheck
+/**
+ * `useConnection` keeps its `isOnline` ref and "already watching" flag at module scope,
+ * so each test re-imports it fresh to avoid stale listeners/state leaking between tests.
+ */
+describe('useConnection', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('reflects the current navigator.onLine value on creation', async () => {
+    const { useConnection } = await import('@/composables/connection');
+    const { isOnline } = useConnection();
+
+    expect(isOnline.value).toBe(window.navigator.onLine);
+  });
+
+  it('only updates isOnline on window online/offline events after watchConnectionStatus() is called', async () => {
+    const { useConnection } = await import('@/composables/connection');
+    const { isOnline, watchConnectionStatus } = useConnection();
+
+    // Not watching yet - dispatching events has no effect.
+    window.dispatchEvent(new Event('offline'));
+    expect(isOnline.value).toBe(window.navigator.onLine);
+
+    watchConnectionStatus();
+
+    window.dispatchEvent(new Event('offline'));
+    expect(isOnline.value).toBe(false);
+
+    window.dispatchEvent(new Event('online'));
+    expect(isOnline.value).toBe(true);
+  });
+
+  it('shares the isOnline state between multiple useConnection() calls', async () => {
+    const { useConnection } = await import('@/composables/connection');
+    const first = useConnection();
+    const second = useConnection();
+
+    first.watchConnectionStatus();
+    window.dispatchEvent(new Event('offline'));
+
+    expect(second.isOnline.value).toBe(false);
+  });
+});

--- a/tests/unit/composables/copy.spec.ts
+++ b/tests/unit/composables/copy.spec.ts
@@ -1,0 +1,80 @@
+// @ts-nocheck
+/**
+ * `useCopy` needs only its native clipboard bridge mocked - everything else (the
+ * `copied` flag, the reset timeout) is real composable logic.
+ *
+ * `@capacitor/clipboard` is already loaded for real by the time this file's own
+ * (hoisted) `vi.mock` runs - the global `registerAdapters` setup file transitively
+ * pulls it in via the `@/composables` barrel before any test file executes. So each
+ * test resets the module registry and re-imports `useCopy` fresh, ensuring it binds
+ * to the mocked `Clipboard` instead of the one cached during setup.
+ */
+const { clipboardWriteMock } = vi.hoisted(() => ({
+  clipboardWriteMock: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock('@capacitor/clipboard', () => ({ Clipboard: { write: clipboardWriteMock } }));
+
+describe('useCopy', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.useFakeTimers();
+    clipboardWriteMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('copies the given text and flips `copied` back to false after the timeout', async () => {
+    const { useCopy } = await import('@/composables/copy');
+    const { copy, copied } = useCopy({ timeout: 500 });
+
+    expect(copied.value).toBe(false);
+    await copy('some text');
+
+    expect(clipboardWriteMock).toHaveBeenCalledWith({ string: 'some text' });
+    expect(copied.value).toBe(true);
+
+    vi.advanceTimersByTime(499);
+    expect(copied.value).toBe(true);
+
+    vi.advanceTimersByTime(1);
+    expect(copied.value).toBe(false);
+  });
+
+  it('does nothing for empty/undefined text', async () => {
+    const { useCopy } = await import('@/composables/copy');
+    const { copy, copied } = useCopy();
+
+    await copy();
+    await copy('');
+
+    expect(copied.value).toBe(false);
+    expect(clipboardWriteMock).not.toHaveBeenCalled();
+  });
+
+  it('defaults the reset timeout to 1000ms', async () => {
+    const { useCopy } = await import('@/composables/copy');
+    const { copy, copied } = useCopy();
+
+    await copy('x');
+    expect(copied.value).toBe(true);
+
+    vi.advanceTimersByTime(999);
+    expect(copied.value).toBe(true);
+
+    vi.advanceTimersByTime(1);
+    expect(copied.value).toBe(false);
+  });
+
+  it('creates an independent `copied` flag per call, not a shared singleton', async () => {
+    const { useCopy } = await import('@/composables/copy');
+    const first = useCopy();
+    const second = useCopy();
+
+    await first.copy('a');
+
+    expect(first.copied.value).toBe(true);
+    expect(second.copied.value).toBe(false);
+  });
+});

--- a/tests/unit/composables/currencies.spec.ts
+++ b/tests/unit/composables/currencies.spec.ts
@@ -1,0 +1,133 @@
+// @ts-nocheck
+import { ref, nextTick } from 'vue';
+
+/**
+ * `useCurrencies` now only needs two mocks: `useAccounts` (to control which protocols
+ * are "in use" and whether the user is logged in) and `@/lib/CoinGecko` (the actual
+ * network boundary). Everything else - `useStorageRef`, `ProtocolAdapterFactory`
+ * (for `coinGeckoCoinId`), `Intl.NumberFormat` - runs for real.
+ */
+const fetchCoinMarketDataMock = vi.fn();
+const fetchCoinCurrencyRatesMock = vi.fn();
+
+let protocolsInUseRef;
+let isLoggedInRef;
+
+function flushPromises() {
+  return new Promise((resolve) => { setTimeout(resolve, 0); });
+}
+
+describe('useCurrencies', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    localStorage.clear();
+    fetchCoinMarketDataMock.mockReset().mockResolvedValue([]);
+    fetchCoinCurrencyRatesMock.mockReset().mockResolvedValue({});
+
+    protocolsInUseRef = ref(['aeternity']);
+    isLoggedInRef = ref(true);
+
+    // Must be registered before `registerAdapters` is imported: it transitively loads
+    // the real `accounts` composable (via aeSdk.ts -> accounts.ts -> the `@/composables`
+    // barrel), so mocking it afterwards would be too late for this module generation.
+    vi.doMock('@/composables/accounts', () => ({
+      useAccounts: () => ({
+        protocolsInUse: protocolsInUseRef,
+        isLoggedIn: isLoggedInRef,
+      }),
+    }));
+    vi.doMock('@/lib/CoinGecko', () => ({
+      CoinGecko: {
+        fetchCoinMarketData: fetchCoinMarketDataMock,
+        fetchCoinCurrencyRates: fetchCoinCurrencyRatesMock,
+      },
+    }));
+
+    await import('@/protocols/registerAdapters');
+  });
+
+  it('returns a 0 rate for a protocol with no fetched data yet', async () => {
+    const { useCurrencies } = await import('@/composables/currencies');
+    const { getCurrentCurrencyRate } = useCurrencies({ pollingDisabled: true });
+
+    expect(getCurrentCurrencyRate('aeternity')).toBe(0);
+  });
+
+  it('loadCurrencyRates fetches by the coingecko ids of protocols in use and stores the rate', async () => {
+    fetchCoinCurrencyRatesMock.mockResolvedValue({ aeternity: { usd: 0.05, eur: 0.04 } });
+
+    const { useCurrencies } = await import('@/composables/currencies');
+    const { loadCurrencyRates, getCurrentCurrencyRate, currentCurrencyCode } = useCurrencies({
+      pollingDisabled: true,
+    });
+    currentCurrencyCode.value = 'usd';
+
+    await loadCurrencyRates();
+
+    expect(fetchCoinCurrencyRatesMock).toHaveBeenCalledWith('aeternity');
+    expect(getCurrentCurrencyRate('aeternity')).toBe(0.05);
+  });
+
+  it('preserves a protocol previous rate when a later fetch omits it', async () => {
+    fetchCoinCurrencyRatesMock.mockResolvedValueOnce({ aeternity: { usd: 0.05 } });
+
+    const { useCurrencies } = await import('@/composables/currencies');
+    const { loadCurrencyRates, getCurrentCurrencyRate } = useCurrencies({ pollingDisabled: true });
+
+    await loadCurrencyRates();
+    expect(getCurrentCurrencyRate('aeternity')).toBe(0.05);
+
+    fetchCoinCurrencyRatesMock.mockResolvedValueOnce({});
+    await loadCurrencyRates();
+
+    expect(getCurrentCurrencyRate('aeternity')).toBe(0.05);
+  });
+
+  it('setCurrentCurrency switches the currency code and reloads coin market data once logged in', async () => {
+    fetchCoinMarketDataMock.mockResolvedValue([{ id: 'aeternity', currentPrice: 0.1 }]);
+
+    const { useCurrencies } = await import('@/composables/currencies');
+    const { setCurrentCurrency, currentCurrencyCode, marketData } = useCurrencies({
+      pollingDisabled: true,
+    });
+
+    setCurrentCurrency('eur');
+    await flushPromises();
+
+    expect(currentCurrencyCode.value).toBe('eur');
+    expect(fetchCoinMarketDataMock).toHaveBeenCalledWith('aeternity', 'eur');
+    expect(marketData.value.aeternity.currentPrice).toBe(0.1);
+  });
+
+  it('formats fiat values, falling back to "no rate" and rounding tiny fractions to <0.01', async () => {
+    fetchCoinCurrencyRatesMock.mockResolvedValue({ aeternity: { usd: 2 } });
+
+    const { useCurrencies } = await import('@/composables/currencies');
+    const {
+      loadCurrencyRates, getFormattedFiat, getFormattedAndRoundedFiat, noCurrencyRateFiat,
+    } = useCurrencies({ pollingDisabled: true });
+
+    // Before any rate is loaded, formatted fiat falls back to the "no rate" placeholder.
+    expect(getFormattedFiat(10, 'aeternity')).toBe(noCurrencyRateFiat.value);
+
+    await loadCurrencyRates();
+
+    expect(getFormattedFiat(10, 'aeternity')).toContain('20.00');
+    // 0.001 AE * 2 USD = 0.002, below the 1 cent threshold.
+    expect(getFormattedAndRoundedFiat(0.001, 'aeternity')).toMatch(/^</);
+    expect(getFormattedAndRoundedFiat(0, 'aeternity')).toContain('0.00');
+  });
+
+  it('automatically reloads rates when a new protocol is added to protocolsInUse', async () => {
+    fetchCoinCurrencyRatesMock.mockResolvedValue({});
+
+    const { useCurrencies } = await import('@/composables/currencies');
+    useCurrencies({ pollingDisabled: true });
+
+    protocolsInUseRef.value = ['aeternity', 'ethereum'];
+    await nextTick();
+    await flushPromises();
+
+    expect(fetchCoinCurrencyRatesMock).toHaveBeenCalledWith('aeternity,ethereum');
+  });
+});

--- a/tests/unit/composables/networks.spec.ts
+++ b/tests/unit/composables/networks.spec.ts
@@ -1,0 +1,134 @@
+// @ts-nocheck
+/**
+ * `useNetworks` is exercised almost end-to-end here: `useStorageRef` runs against the
+ * real jsdom `localStorage` and `ProtocolAdapterFactory` uses the real protocol adapters
+ * (registered via the `registerAdapters` setup file). The only thing mocked is
+ * `useModals`, since `deleteCustomNetwork` depends on a user confirming a modal.
+ *
+ * Every composable under test keeps state at module scope, so each test re-imports it
+ * fresh (`vi.resetModules()`) after clearing `localStorage`, and re-registers the real
+ * protocol adapters (registerAdapters.ts is normally loaded once, globally, before any
+ * reset).
+ */
+const flushAsync = () => new Promise((resolve) => { setTimeout(resolve, 0); });
+
+const openConfirmModalMock = vi.fn();
+
+describe('useNetworks', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    localStorage.clear();
+    openConfirmModalMock.mockReset();
+
+    // Must be registered before `registerAdapters` is imported: it transitively loads
+    // the real `modals` composable (via aeSdk.ts -> accounts.ts -> the `@/composables`
+    // barrel), so mocking it afterwards would be too late for this module generation.
+    vi.doMock('@/composables/modals', () => ({
+      useModals: () => ({ openConfirmModal: openConfirmModalMock }),
+    }));
+
+    await import('@/protocols/registerAdapters');
+  });
+
+  it('initializes with the default Mainnet/Testnet networks and switches to Mainnet', async () => {
+    const { useNetworks } = await import('@/composables/networks');
+    const { networks, activeNetwork, activeNetworkName } = useNetworks();
+    await flushAsync();
+
+    expect(Object.keys(networks.value)).toEqual(['Mainnet', 'Testnet']);
+    expect(activeNetworkName.value).toBe('Mainnet');
+    expect(activeNetwork.value.type).toBe('mainnet');
+    expect(activeNetwork.value.protocols.aeternity).toBeTruthy();
+  });
+
+  it('switches network and notifies onNetworkChange callbacks with old/new network', async () => {
+    const { useNetworks } = await import('@/composables/networks');
+    const { switchNetwork, onNetworkChange, activeNetwork } = useNetworks();
+    await flushAsync();
+
+    const callback = vi.fn();
+    onNetworkChange(callback);
+
+    switchNetwork('Testnet');
+
+    expect(activeNetwork.value.name).toBe('Testnet');
+    expect(callback).toHaveBeenCalledTimes(1);
+    const [newNetwork, oldNetwork] = callback.mock.calls[0];
+    expect(newNetwork.name).toBe('Testnet');
+    expect(oldNetwork.name).toBe('Mainnet');
+  });
+
+  it('throws when switching to a network that does not exist', async () => {
+    const { useNetworks } = await import('@/composables/networks');
+    const { switchNetwork } = useNetworks();
+    await flushAsync();
+
+    expect(() => switchNetwork('DoesNotExist')).toThrow(
+      'Could not switch to "DoesNotExist" network as it does not exist',
+    );
+  });
+
+  it('adds a custom network and updates it by index, rejecting out-of-range indexes', async () => {
+    const { useNetworks } = await import('@/composables/networks');
+    const {
+      addCustomNetwork, updateCustomNetwork, customNetworks, networks,
+    } = useNetworks();
+    await flushAsync();
+
+    const customNetwork = { name: 'My Custom', type: 'testnet', protocols: {} };
+    addCustomNetwork(customNetwork);
+
+    expect(customNetworks.value).toHaveLength(1);
+    expect(networks.value['My Custom']).toEqual(customNetwork);
+
+    const updated = { ...customNetwork, type: 'mainnet' };
+    expect(updateCustomNetwork(0, updated)).toBe(true);
+    expect(customNetworks.value[0]).toEqual(updated);
+
+    expect(updateCustomNetwork(5, updated)).toBe(false);
+  });
+
+  it('deletes a custom network on confirmation, switching to Mainnet first if it was active', async () => {
+    openConfirmModalMock.mockResolvedValue(undefined);
+
+    const { useNetworks } = await import('@/composables/networks');
+    const {
+      addCustomNetwork,
+      switchNetwork,
+      deleteCustomNetwork,
+      onNetworkRemoved,
+      customNetworks,
+      activeNetworkName,
+    } = useNetworks();
+    await flushAsync();
+
+    const customNetwork = { name: 'My Custom', type: 'testnet', protocols: {} };
+    addCustomNetwork(customNetwork);
+    switchNetwork('My Custom');
+
+    const removedCallback = vi.fn();
+    onNetworkRemoved(removedCallback);
+
+    const result = await deleteCustomNetwork('My Custom');
+
+    expect(result).toBe(true);
+    expect(customNetworks.value).toHaveLength(0);
+    expect(activeNetworkName.value).toBe('Mainnet');
+    expect(removedCallback).toHaveBeenCalledWith(customNetwork);
+  });
+
+  it('keeps the network when the user rejects the confirmation modal', async () => {
+    openConfirmModalMock.mockRejectedValue(new Error('cancelled by user'));
+
+    const { useNetworks } = await import('@/composables/networks');
+    const { addCustomNetwork, deleteCustomNetwork, customNetworks } = useNetworks();
+    await flushAsync();
+
+    addCustomNetwork({ name: 'My Custom', type: 'testnet', protocols: {} });
+
+    const result = await deleteCustomNetwork('My Custom');
+
+    expect(result).toBe(false);
+    expect(customNetworks.value).toHaveLength(1);
+  });
+});

--- a/tests/unit/popup/components/TransferSend/TransferSendAmount.spec.js
+++ b/tests/unit/popup/components/TransferSend/TransferSendAmount.spec.js
@@ -1,0 +1,139 @@
+import { mount } from '@vue/test-utils';
+import { Field, defineRule } from 'vee-validate';
+import TransferSendAmount from '@/popup/components/TransferSend/TransferSendAmount.vue';
+import { PROTOCOLS } from '@/constants';
+import { tg } from '@/popup/plugins/i18n';
+
+/**
+ * The real rule implementations live behind `src/popup/plugins/veeValidate.ts`'s
+ * default export, which also boots `useBalances`/`useCurrencies`/`useAeSdk` - overkill
+ * for testing how `TransferSendAmount` *builds* its rules object. Trivial pass-through
+ * rules are enough to stop vee-validate's `Field` from throwing "no such validator"
+ * while it validates in the background; none of the assertions below depend on the
+ * validation outcome, only on props/computed values.
+ */
+beforeAll(() => {
+  defineRule('required', () => true);
+  defineRule('min_value_exclusive', () => true);
+  defineRule('does_not_exceed_decimals', () => true);
+  defineRule('max_value', () => true);
+});
+
+/**
+ * `InputAmount` pulls in `useBalances`/`useCurrencies` (and, through those, live
+ * currency rates) which are irrelevant to what `TransferSendAmount` itself is
+ * responsible for: building the vee-validate `rules` object (decimals-aware) and
+ * mapping the `errors` prop to a message. Stubbing it keeps the test focused and
+ * lets us inspect exactly what props it receives.
+ */
+const InputAmountStub = {
+  name: 'InputAmount',
+  props: [
+    'modelValue', 'name', 'label', 'message', 'protocol',
+    'readonly', 'blinkOnChange', 'selectedAsset', 'withBalanceOnly',
+  ],
+  emits: ['update:modelValue', 'asset-selected'],
+  template: '<div class="input-amount-stub" />',
+};
+
+function mountComponent(props = {}) {
+  return mount(TransferSendAmount, {
+    props: {
+      protocol: PROTOCOLS.aeternity,
+      errors: {},
+      ...props,
+    },
+    global: {
+      stubs: { InputAmount: InputAmountStub },
+      mocks: { $t: (key) => key },
+    },
+  });
+}
+
+describe('TransferSendAmount', () => {
+  it('forwards modelValue/protocol/readonly/blinkOnChange to InputAmount', () => {
+    const wrapper = mountComponent({
+      modelValue: '12.5',
+      protocol: PROTOCOLS.bitcoin,
+      readonly: true,
+      blinkOnChange: true,
+    });
+    const input = wrapper.findComponent(InputAmountStub);
+
+    expect(input.props('modelValue')).toBe('12.5');
+    expect(input.props('protocol')).toBe(PROTOCOLS.bitcoin);
+    expect(input.props('readonly')).toBe(true);
+    expect(input.props('blinkOnChange')).toBe(true);
+  });
+
+  it('re-emits update:modelValue and asset-selected from InputAmount', async () => {
+    const wrapper = mountComponent();
+    const input = wrapper.findComponent(InputAmountStub);
+
+    await input.vm.$emit('update:modelValue', '3');
+    await input.vm.$emit('asset-selected', { symbol: 'AE' });
+
+    expect(wrapper.emitted('update:modelValue')[0]).toEqual(['3']);
+    expect(wrapper.emitted('asset-selected')[0]).toEqual([{ symbol: 'AE' }]);
+  });
+
+  it("falls back to the protocol adapter's coin precision when no asset is selected", () => {
+    const wrapperAe = mountComponent({ protocol: PROTOCOLS.aeternity });
+    expect(wrapperAe.findComponent(Field).props('rules').does_not_exceed_decimals).toBe(18);
+
+    const wrapperBtc = mountComponent({ protocol: PROTOCOLS.bitcoin });
+    expect(wrapperBtc.findComponent(Field).props('rules').does_not_exceed_decimals).toBe(8);
+  });
+
+  it('uses the selected asset decimals instead of the protocol default when provided', () => {
+    const wrapper = mountComponent({
+      protocol: PROTOCOLS.aeternity,
+      selectedAsset: { symbol: 'USDT', decimals: 6 },
+    });
+
+    expect(wrapper.findComponent(Field).props('rules').does_not_exceed_decimals).toBe(6);
+    expect(wrapper.findComponent(InputAmountStub).props('selectedAsset')).toEqual({ symbol: 'USDT', decimals: 6 });
+  });
+
+  it('treats a selected asset with 0 decimals as explicit, not a missing value', () => {
+    const wrapper = mountComponent({
+      selectedAsset: { symbol: 'NFT', decimals: 0 },
+    });
+
+    expect(wrapper.findComponent(Field).props('rules').does_not_exceed_decimals).toBe(0);
+  });
+
+  it('always requires the amount and rejects non-positive values, merging in caller-provided rules', () => {
+    const wrapper = mountComponent({
+      validationRules: { max_value: [100] },
+    });
+    const rules = wrapper.findComponent(Field).props('rules');
+
+    expect(rules.required).toBe(true);
+    expect(rules.min_value_exclusive).toBe(0);
+    expect(rules.max_value).toEqual([100]);
+  });
+
+  it('maps an empty errors.amount to a success message', () => {
+    const wrapper = mountComponent({ errors: {} });
+    expect(wrapper.findComponent(InputAmountStub).props('message')).toEqual({ status: 'success' });
+  });
+
+  it('maps a plain errors.amount to an error message', () => {
+    const wrapper = mountComponent({ errors: { amount: tg('validation.required') } });
+    expect(wrapper.findComponent(InputAmountStub).props('message')).toEqual({
+      status: 'error',
+      text: tg('validation.required'),
+    });
+  });
+
+  it('flags a maxValueVault rule violation as a warning rather than a hard error', () => {
+    const warningMessage = tg('validation.maxValueVault', ['1000']);
+    const wrapper = mountComponent({ errors: { amount: warningMessage } });
+
+    expect(wrapper.findComponent(InputAmountStub).props('message')).toEqual({
+      status: 'warning',
+      text: warningMessage,
+    });
+  });
+});

--- a/tests/unit/popup/components/TransferSend/TransferSendRecipient.spec.js
+++ b/tests/unit/popup/components/TransferSend/TransferSendRecipient.spec.js
@@ -1,0 +1,192 @@
+import { mount } from '@vue/test-utils';
+import { defineRule } from 'vee-validate';
+import TransferSendRecipient from '@/popup/components/TransferSend/TransferSendRecipient.vue';
+import {
+  PROTOCOLS,
+  MODAL_ADDRESS_BOOK_ACCOUNT_SELECTOR,
+  MODAL_RECIPIENT_INFO,
+} from '@/constants';
+
+/**
+ * These rules are only registered for real by `src/popup/plugins/veeValidate.ts`'s
+ * default export, which also boots `useBalances`/`useAeSdk` - overkill here. Trivial
+ * pass-through rules stop vee-validate's `useField` from throwing "no such validator"
+ * in the background; the component's own `errors` prop (not vee-validate's internal
+ * state) drives every assertion below.
+ */
+beforeAll(() => {
+  defineRule('required', () => true);
+  defineRule('max_recipients', () => true);
+  defineRule('address_not_same_as', () => true);
+});
+
+const {
+  mockOpenModal,
+  mockGetTippingUrlStatus,
+  mockUseAeTippingUrls,
+} = vi.hoisted(() => {
+  const getTippingUrlStatus = vi.fn(() => 'default');
+  return {
+    mockOpenModal: vi.fn(),
+    mockGetTippingUrlStatus: getTippingUrlStatus,
+    mockUseAeTippingUrls: vi.fn(() => ({ getTippingUrlStatus })),
+  };
+});
+
+/**
+ * `@/composables` is the real barrel (spread via `importActual`) with only
+ * `useAccounts`/`useModals` swapped out - everything else transitively needed by
+ * real code loaded elsewhere in the same module graph (e.g. protocol adapters) stays
+ * real. Same for the aeternity composables barrel: only `useAeTippingUrls` is
+ * replaced, since a real one would trigger a live network fetch on mount.
+ */
+vi.mock('@/composables', async () => {
+  const actual = await vi.importActual('@/composables');
+  return {
+    ...actual,
+    useAccounts: () => ({ activeAccount: { value: { address: 'ak_activeAccount' } } }),
+    useModals: () => ({ openModal: mockOpenModal }),
+  };
+});
+vi.mock('@/protocols/aeternity/composables', async () => {
+  const actual = await vi.importActual('@/protocols/aeternity/composables');
+  return { ...actual, useAeTippingUrls: mockUseAeTippingUrls };
+});
+
+/** Renders the `label-after` slot (address-book/QR buttons)
+ * without FormAccountInput's own logic. */
+const FormAccountInputStub = {
+  name: 'FormAccountInput',
+  props: [
+    'modelValue', 'name', 'showHelp', 'showMessageHelp', 'isRecipient',
+    'singleDefaultFormat', 'isTipUrlEnabled', 'protocol', 'label', 'placeholder', 'message',
+  ],
+  emits: ['update:modelValue', 'help', 'blur'],
+  template: '<div class="form-account-input-stub"><slot name="label-after" /></div>',
+};
+const UrlStatusStub = {
+  name: 'UrlStatus',
+  props: ['status'],
+  template: '<div class="url-status-stub" />',
+};
+
+function mountComponent(props = {}) {
+  return mount(TransferSendRecipient, {
+    props: {
+      protocol: PROTOCOLS.aeternity,
+      errors: {},
+      ...props,
+    },
+    global: {
+      stubs: { FormAccountInput: FormAccountInputStub, UrlStatus: UrlStatusStub },
+      mocks: { $t: (key) => key },
+    },
+  });
+}
+
+describe('TransferSendRecipient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetTippingUrlStatus.mockReturnValue('default');
+  });
+
+  it('only eagerly fetches tipping URL data for the aeternity protocol', () => {
+    mountComponent({ protocol: PROTOCOLS.aeternity });
+    expect(mockUseAeTippingUrls).toHaveBeenCalledWith({ ensureFetchedOnInit: true });
+
+    mountComponent({ protocol: PROTOCOLS.bitcoin });
+    expect(mockUseAeTippingUrls).toHaveBeenCalledWith({ ensureFetchedOnInit: false });
+  });
+
+  it('surfaces a field validation error regardless of tip-url status', () => {
+    mockGetTippingUrlStatus.mockReturnValue('verified');
+    const wrapper = mountComponent({
+      isTipUrl: true,
+      errors: { addresses: 'validation.required' },
+    });
+
+    expect(wrapper.findComponent(FormAccountInputStub).props('message')).toEqual({
+      status: 'error',
+      text: 'validation.required',
+    });
+  });
+
+  it('reports success when there are no errors and the field is not a tip URL', () => {
+    const wrapper = mountComponent({ isTipUrl: false });
+    expect(wrapper.findComponent(FormAccountInputStub).props('message')).toEqual({ status: 'success' });
+  });
+
+  it.each([
+    ['verified', 'success'],
+    ['not-secure', 'warning'],
+    ['not-verified', 'warning'],
+    ['blacklisted', 'error'],
+  ])('maps tip-url status "%s" to a hidden %s message and forwards it to UrlStatus', (status, expectedStatus) => {
+    mockGetTippingUrlStatus.mockReturnValue(status);
+    const wrapper = mountComponent({ isTipUrl: true, modelValue: ['https://x.com/foo'] });
+
+    expect(wrapper.findComponent(FormAccountInputStub).props('message')).toEqual({
+      status: expectedStatus,
+      text: '',
+      hideMessage: true,
+    });
+    expect(wrapper.findComponent(UrlStatusStub).props('status')).toBe(status);
+  });
+
+  it('throws for an unrecognized tip-url status instead of silently misreporting trust', () => {
+    mockGetTippingUrlStatus.mockReturnValue('made-up-status');
+    expect(() => mountComponent({ isTipUrl: true, modelValue: ['https://x.com/foo'] }))
+      .toThrow('Unknown url status: made-up-status');
+  });
+
+  it('opens the recipient help modal for the current protocol', async () => {
+    mockOpenModal.mockResolvedValue(undefined);
+    const wrapper = mountComponent({ protocol: PROTOCOLS.bitcoin });
+
+    await wrapper.findComponent(FormAccountInputStub).vm.$emit('help');
+
+    expect(mockOpenModal).toHaveBeenCalledWith(MODAL_RECIPIENT_INFO, {
+      protocol: PROTOCOLS.bitcoin,
+    });
+  });
+
+  it('opens the address book and emits the selected addresses', async () => {
+    mockOpenModal.mockResolvedValue(['ak_one', 'ak_two']);
+    const wrapper = mountComponent({ modelValue: ['ak_preexisting'], maxRecipients: 2 });
+
+    await wrapper.find('[data-cy=address-book-button]').trigger('click');
+    await wrapper.vm.$nextTick();
+    await Promise.resolve();
+
+    expect(mockOpenModal).toHaveBeenCalledWith(MODAL_ADDRESS_BOOK_ACCOUNT_SELECTOR, {
+      preSelectedAddresses: ['ak_preexisting'],
+      allowMultiple: true,
+    });
+    expect(wrapper.emitted('update:modelValue')[0]).toEqual([['ak_one', 'ak_two']]);
+  });
+
+  it('does not emit when the address book modal resolves without a selection', async () => {
+    mockOpenModal.mockResolvedValue(undefined);
+    const wrapper = mountComponent();
+
+    await wrapper.vm.selectFromAddressBook();
+
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+  });
+
+  it('propagates a rejection when the address book modal is dismissed (no update emitted)', async () => {
+    mockOpenModal.mockRejectedValue(new Error('modal closed'));
+    const wrapper = mountComponent();
+
+    await expect(wrapper.vm.selectFromAddressBook()).rejects.toThrow('modal closed');
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+  });
+
+  it('emits openQrModal when the scan button is clicked', async () => {
+    const wrapper = mountComponent();
+
+    await wrapper.find('[data-cy=scan-button]').trigger('click');
+
+    expect(wrapper.emitted('openQrModal')).toHaveLength(1);
+  });
+});

--- a/tests/unit/protocols/aeternity/composables/aeNames.spec.js
+++ b/tests/unit/protocols/aeternity/composables/aeNames.spec.js
@@ -1,5 +1,45 @@
 import { ref } from 'vue';
 
+/**
+ * `useAeNames` is exercised against REAL `useStorageRef`/`localStorage`,
+ * `useNetworks`, `ProtocolAdapterFactory` (real adapter, `fetchPendingTransactions`
+ * spied per test - the actual network boundary), `@/protocols/aeternity/config`
+ * (plain constants), `@/protocols/aeternity/helpers`'s `isInsufficientBalanceError`
+ * (simple predicate), `@/protocols/aeternity/composables/aeNetworkSettings` and
+ * `aeTippingBackend` (both just route through the mocked `fetchJson` below), and
+ * real `tg()` i18n.
+ *
+ * Still mocked, since they're either the aeternity SDK/network boundary itself or
+ * genuinely heavy to run for real:
+ *   - `@aeternity/aepp-sdk`'s `Name` class (constructs/signs real transactions)
+ *   - `fetchAllPages`/`fetchJson` (`@/utils`) - the actual HTTP boundary
+ *   - `useAccounts`/`useAeSdk`/`useAuth`/`useModals`/`useTopHeaderData` - mocked by
+ *     their specific module path (never the `@/composables` barrel, which real
+ *     composables like `accounts.ts` also import `useAuth` from - overriding the
+ *     barrel would leak these fakes into code that isn't under test). Precise
+ *     control over "who is logged in"/node connection/current block height is
+ *     central to these test scenarios, not incidental
+ *   - `decryptedComputed` (`@/utils`) - kept as a pass-through; the AES-GCM round trip
+ *     for preclaimed names has its own dedicated coverage elsewhere and isn't the
+ *     focus of these tests
+ *   - `@/lib/logger` - side-effecting telemetry, plus it dodges `Logger.ts`'s own
+ *     direct (non-barrel) imports of `useUi`/`useModals`
+ *   - `AeAccountHdWallet` - real HD-wallet signing needs a real mnemonic seed
+ *   - `useAeMiddleware` - a real GraphQL/swagger client built from a fetched spec;
+ *     too heavy for what these tests need (deterministic `getNames()` results)
+ */
+
+/**
+ * `pendingAutoExtendTxs`/`pendingNameTransferTxs` are real `useStorageRef`s: a
+ * mutation (e.g. `upsertPendingNameTransferTx`) updates `.value` synchronously, but
+ * persisting that back to `localStorage` happens via the ref's own internal deep
+ * watcher, which settles a tick later. Reading raw storage back for assertions
+ * needs to wait for that.
+ */
+function flushAsync() {
+  return new Promise((resolve) => { setTimeout(resolve, 0); });
+}
+
 const createTestContext = async ({
   topBlockHeight = 100,
   preclaimedNames = {},
@@ -7,10 +47,9 @@ const createTestContext = async ({
   pendingNameTransferTxs = {},
 } = {}) => {
   vi.resetModules();
+  localStorage.clear();
 
-  const storage = new Map();
   const openDefaultModal = vi.fn();
-  const handleUnknownError = vi.fn();
   const fetchAllPages = vi.fn().mockResolvedValue([]);
   const fetchJson = vi.fn().mockResolvedValue({});
   const fetchPendingTransactions = vi.fn().mockResolvedValue([]);
@@ -30,160 +69,131 @@ const createTestContext = async ({
     },
   };
 
-  storage.set('names-owned', ref([]));
-  storage.set('preclaimed-names', ref(
-    Object.keys(preclaimedNames).length ? JSON.stringify(preclaimedNames) : '{}',
-  ));
-  storage.set('pending-name-auto-extend-txs', ref(pendingAutoExtendTxs));
-  storage.set('pending-name-transfer-txs', ref(pendingNameTransferTxs));
-  storage.set('names-default', ref({}));
+  // All `vi.doMock` calls must be registered here, before `registerAdapters` is
+  // imported below - it transitively loads the real `@/composables` barrel (and
+  // everything in it, including `aeNames.ts` and its dependencies), so mocking
+  // afterwards would be too late for this module generation.
+  vi.doMock('@aeternity/aepp-sdk', async () => {
+    const actual = await vi.importActual('@aeternity/aepp-sdk');
+    return {
+      ...actual,
+      // Constructed via `new Name(...)`; Vitest 4 requires a constructable
+      // implementation (an arrow function is not a constructor).
+      Name: class {
+        constructor(name, context) {
+          this.name = name;
+          this.context = context;
+        }
 
-  vi.doMock('@aeternity/aepp-sdk', () => ({
-    Name: class {
-      constructor(name, context) {
-        this.name = name;
-        this.context = context;
-      }
+        extendTtl = nameExtendTtl;
 
-      extendTtl = nameExtendTtl;
+        update = nameUpdate;
 
-      update = nameUpdate;
+        preclaim = namePreclaim;
 
-      preclaim = namePreclaim;
+        claim = nameClaim;
 
-      claim = nameClaim;
+        getState = nameGetState;
 
-      getState = nameGetState;
+        transfer = nameTransfer;
+      },
+    };
+  });
 
-      transfer = nameTransfer;
-    },
-  }));
+  vi.doMock('@/utils', async () => {
+    const actual = await vi.importActual('@/utils');
+    return {
+      ...actual,
+      decryptedComputed: (_key, encryptedState) => encryptedState,
+      fetchAllPages,
+      fetchJson,
+    };
+  });
 
-  vi.doMock('@/utils', () => ({
-    decryptedComputed: vi.fn((_key, encryptedState) => encryptedState),
-    fetchAllPages,
-    fetchJson,
-    handleUnknownError,
-  }));
-
-  vi.doMock('@/composables', () => ({
-    useAccounts: vi.fn(() => ({
+  // Mocked by their specific module path, NOT the `@/composables` barrel: the barrel
+  // is imported (for real) by plenty of other real composables (e.g. `accounts.ts`
+  // itself imports `useAuth` from the barrel) - overriding the barrel would leak
+  // these incomplete fakes into code that isn't under test here. `useNetworks` and
+  // `useStorageRef` are deliberately left real (see the file-level comment above).
+  vi.doMock('@/composables/accounts', () => ({
+    useAccounts: () => ({
       aeAccounts: ref([{ address: 'ak_test' }]),
       activeAccount: ref({ address: 'ak_test' }),
-      isLocalAccountAddress: vi.fn(() => true),
-      getLastActiveProtocolAccount: vi.fn(() => ({ address: 'ak_test' })),
-    })),
-    useAeSdk: vi.fn(() => ({
+      isLocalAccountAddress: () => true,
+      getLastActiveProtocolAccount: () => ({ address: 'ak_test' }),
+    }),
+  }));
+  vi.doMock('@/composables/aeSdk', () => ({
+    useAeSdk: () => ({
       nodeNetworkId: ref('ae_testnet'),
       getAeSdk: vi.fn().mockResolvedValue(sdk),
-    })),
-    useAuth: vi.fn(() => ({
-      encryptionKey: ref('mock-encryption-key'),
-    })),
-    useModals: vi.fn(() => ({
-      openDefaultModal,
-    })),
-    useNetworks: vi.fn(() => ({
-      onNetworkChange: vi.fn(),
-    })),
-    useStorageRef: vi.fn((defaultValue, key) => {
-      if (!storage.has(key)) {
-        storage.set(key, ref(defaultValue));
-      }
-      return storage.get(key);
     }),
-    useTopHeaderData: vi.fn(() => ({
-      topBlockHeight: ref(topBlockHeight),
-    })),
-    useUi: vi.fn(() => ({
-      saveErrorLog: ref(false),
-    })),
   }));
-
-  vi.doMock('@/composables/ui', () => ({
-    useUi: vi.fn(() => ({
-      saveErrorLog: ref(false),
-    })),
+  vi.doMock('@/composables/auth', () => ({
+    useAuth: () => ({ encryptionKey: ref('irrelevant-key-decryptedComputed-is-a-passthrough') }),
   }));
-
   vi.doMock('@/composables/modals', () => ({
-    useModals: vi.fn(() => ({
-      openDefaultModal,
-    })),
+    useModals: () => ({ openDefaultModal }),
+  }));
+  vi.doMock('@/composables/topHeader', () => ({
+    useTopHeaderData: () => ({ topBlockHeight: ref(topBlockHeight) }),
   }));
 
-  vi.doMock('@/composables/composablesHelpers', () => ({
-    createPollingBasedOnMountedComponents: vi.fn(() => vi.fn()),
-  }));
-
-  vi.doMock('@/popup/plugins/i18n', () => ({
-    tg: vi.fn((key) => key),
-  }));
-
-  vi.doMock('@/lib/ProtocolAdapterFactory', () => ({
-    ProtocolAdapterFactory: {
-      getAdapter: vi.fn(() => ({
-        fetchPendingTransactions,
-      })),
-    },
+  vi.doMock('@/lib/logger', () => ({
+    __esModule: true,
+    default: { write: vi.fn() },
   }));
 
   vi.doMock('@/protocols/aeternity/libs/AeAccountHdWallet', () => ({
-    // Constructed via `new AeAccountHdWallet(...)`; Vitest 4 requires a
-    // constructable implementation (an arrow function is not a constructor).
     AeAccountHdWallet: vi.fn(function AeAccountHdWallet() {
       this.sign = vi.fn();
       this.signTransaction = vi.fn();
     }),
   }));
 
-  vi.doMock('@/protocols/aeternity/helpers', () => ({
-    isInsufficientBalanceError: vi.fn(() => false),
-  }));
-
-  vi.doMock('@/protocols/aeternity/config', () => ({
-    UPDATE_POINTER_ACTION: {
-      update: 'update',
-      extend: 'extend',
-      transfer: 'transfer',
-    },
-    AE_AENS_NAME_AUCTION_MAX_LENGTH: 12 + '.chain'.length,
-  }));
-
-  vi.doMock('@/protocols/aeternity/composables/aeNetworkSettings', () => ({
-    useAeNetworkSettings: vi.fn(() => ({
-      aeActiveNetworkSettings: ref({ backendUrl: 'https://example.test' }),
-    })),
-  }));
-
-  vi.doMock('@/protocols/aeternity/composables/aeTippingBackend', () => ({
-    useAeTippingBackend: vi.fn(() => ({
-      fetchCachedChainNames: vi.fn().mockResolvedValue(null),
-    })),
-  }));
-
   vi.doMock('@/protocols/aeternity/composables/aeMiddleware', () => ({
-    useAeMiddleware: vi.fn(() => ({
+    useAeMiddleware: () => ({
       isMiddlewareReady: ref(false),
-      getMiddleware: vi.fn().mockResolvedValue({
-        getNames,
-      }),
+      getMiddleware: vi.fn().mockResolvedValue({ getNames }),
       fetchFromMiddlewareCamelCased: vi.fn(),
-    })),
+    }),
   }));
 
-  // eslint-disable-next-line global-require
-  const aeNamesModule = (await import('@/protocols/aeternity/composables/aeNames'));
+  // Seed real `localStorage` BEFORE `registerAdapters` (below) is imported.
+  // `AeternityAdapter` -> the aeternity composables barrel -> `aeTokenSales.ts`
+  // imports `useNetworks` from the `@/composables` barrel, which transitively
+  // (via `accountSelector.ts`) evaluates `aeNames.ts` itself - its module-level
+  // `useStorageRef`s call `storage.get()` (and settle) the moment that happens,
+  // not when this file later `import()`s `aeNames.ts` directly. Seeding has to
+  // happen before that first, incidental load, or it's too late.
+  const { WalletStorage } = await import('@/lib/WalletStorage');
+  const { STORAGE_KEYS } = await import('@/constants');
+  if (Object.keys(preclaimedNames).length) {
+    // `decryptedComputed` is a passthrough above, so the "encrypted" storage
+    // slot just holds the plain JSON string aeNames.ts expects to decode.
+    WalletStorage.set(STORAGE_KEYS.preclaimedNames, JSON.stringify(preclaimedNames));
+  }
+  WalletStorage.set(STORAGE_KEYS.pendingNameAutoExtendTxs, pendingAutoExtendTxs);
+  WalletStorage.set(STORAGE_KEYS.pendingNameTransferTxs, pendingNameTransferTxs);
+
+  await import('@/protocols/registerAdapters');
+
+  const { ProtocolAdapterFactory } = await import('@/lib/ProtocolAdapterFactory');
+  const adapter = ProtocolAdapterFactory.getAdapter('aeternity');
+  vi.spyOn(adapter, 'fetchPendingTransactions').mockImplementation(fetchPendingTransactions);
+
+  const aeNamesModule = await import('@/protocols/aeternity/composables/aeNames');
   const aeNames = aeNamesModule.useAeNames({ pollingDisabled: true });
+
+  // Let every storageRef finish restoring from localStorage before the test drives it.
+  await new Promise((resolve) => { setTimeout(resolve, 0); });
 
   return {
     aeNames,
     fetchPendingTransactions,
     fetchAllPages,
     sdk,
-    storage,
     openDefaultModal,
-    handleUnknownError,
     NAME_CLAIM_STATUS: aeNamesModule.NAME_CLAIM_STATUS,
     nameClaim,
     nameGetState,
@@ -191,6 +201,8 @@ const createTestContext = async ({
     nameTransfer,
     namePreclaim,
     nameUpdate,
+    getPendingAutoExtendTxs: () => WalletStorage.get(STORAGE_KEYS.pendingNameAutoExtendTxs),
+    getPendingNameTransferTxs: () => WalletStorage.get(STORAGE_KEYS.pendingNameTransferTxs),
   };
 };
 
@@ -462,7 +474,7 @@ describe('useAeNames auto-extend', () => {
       aeNames,
       fetchPendingTransactions,
       nameExtendTtl,
-      storage,
+      getPendingAutoExtendTxs,
     } = await createTestContext({ topBlockHeight: 100 });
     aeNames.ownedNames.value = [{
       name: pendingName,
@@ -486,7 +498,7 @@ describe('useAeNames auto-extend', () => {
     await aeNames.extendExpiringOwnedNames();
 
     expect(nameExtendTtl).not.toHaveBeenCalled();
-    expect(storage.get('pending-name-auto-extend-txs').value.ae_testnet[pendingName]).toMatchObject({
+    expect(getPendingAutoExtendTxs().ae_testnet[pendingName]).toMatchObject({
       txHash: pendingTxHash,
     });
   });
@@ -497,7 +509,7 @@ describe('useAeNames auto-extend', () => {
       aeNames,
       fetchPendingTransactions,
       nameExtendTtl,
-      storage,
+      getPendingAutoExtendTxs,
     } = await createTestContext({
       topBlockHeight: 100,
       pendingAutoExtendTxs: {
@@ -527,14 +539,14 @@ describe('useAeNames auto-extend', () => {
     await aeNames.extendExpiringOwnedNames();
 
     expect(nameExtendTtl).toHaveBeenCalledTimes(1);
-    expect(storage.get('pending-name-auto-extend-txs').value.ae_testnet[pendingName]).toMatchObject({
+    expect(getPendingAutoExtendTxs().ae_testnet[pendingName]).toMatchObject({
       txHash: 'th_retry',
     });
   });
 
   it('cleans stale pending auto-extend entries for non-expiring names', async () => {
     const pendingName = 'not-expiring.chain';
-    const { aeNames, storage } = await createTestContext({
+    const { aeNames, getPendingAutoExtendTxs } = await createTestContext({
       topBlockHeight: 100,
       pendingAutoExtendTxs: {
         ae_testnet: {
@@ -560,7 +572,7 @@ describe('useAeNames auto-extend', () => {
 
     await aeNames.extendExpiringOwnedNames();
 
-    expect(storage.get('pending-name-auto-extend-txs').value.ae_testnet).toBeUndefined();
+    expect(getPendingAutoExtendTxs().ae_testnet).toBeUndefined();
   });
 
   it('does not reject or resend when pending transaction lookup fails', async () => {
@@ -569,7 +581,7 @@ describe('useAeNames auto-extend', () => {
       aeNames,
       fetchPendingTransactions,
       nameExtendTtl,
-      storage,
+      getPendingAutoExtendTxs,
     } = await createTestContext({
       topBlockHeight: 100,
       pendingAutoExtendTxs: {
@@ -598,7 +610,7 @@ describe('useAeNames auto-extend', () => {
     await expect(aeNames.extendExpiringOwnedNames()).resolves.toBeUndefined();
 
     expect(nameExtendTtl).not.toHaveBeenCalled();
-    expect(storage.get('pending-name-auto-extend-txs').value.ae_testnet[pendingName]).toMatchObject({
+    expect(getPendingAutoExtendTxs().ae_testnet[pendingName]).toMatchObject({
       txHash: 'th_lookup_unknown',
     });
   });
@@ -646,7 +658,7 @@ describe('useAeNames auto-extend', () => {
       aeNames,
       fetchPendingTransactions,
       nameExtendTtl,
-      storage,
+      getPendingAutoExtendTxs,
     } = await createTestContext({
       topBlockHeight: 100,
       pendingAutoExtendTxs: {
@@ -675,7 +687,7 @@ describe('useAeNames auto-extend', () => {
 
     await aeNames.extendExpiringOwnedNames();
 
-    expect(storage.get('pending-name-auto-extend-txs').value.ae_testnet[pendingName]).toMatchObject({
+    expect(getPendingAutoExtendTxs().ae_testnet[pendingName]).toMatchObject({
       txHash: 'th_old_pending',
     });
   });
@@ -714,7 +726,7 @@ describe('useAeNames name transfers', () => {
     const {
       aeNames,
       nameTransfer,
-      storage,
+      getPendingNameTransferTxs,
     } = await createTestContext();
 
     await aeNames.updateNamePointer({
@@ -722,9 +734,10 @@ describe('useAeNames name transfers', () => {
       address: 'ak_recipient',
       type: 'transfer',
     });
+    await flushAsync();
 
     expect(nameTransfer).toHaveBeenCalledWith('ak_recipient', { waitMined: false });
-    expect(storage.get('pending-name-transfer-txs').value.ae_testnet['transfer.chain'])
+    expect(getPendingNameTransferTxs().ae_testnet['transfer.chain'])
       .toMatchObject({
         address: 'ak_test',
         name: 'transfer.chain',
@@ -780,7 +793,7 @@ describe('useAeNames name transfers', () => {
       aeNames,
       fetchAllPages,
       fetchPendingTransactions,
-      storage,
+      getPendingNameTransferTxs,
     } = await createTestContext({
       pendingNameTransferTxs: {
         ae_testnet: {
@@ -800,8 +813,9 @@ describe('useAeNames name transfers', () => {
       .mockResolvedValueOnce([]);
 
     await aeNames.updateOwnedNames();
+    await flushAsync();
 
-    expect(storage.get('pending-name-transfer-txs').value.ae_testnet).toBeUndefined();
+    expect(getPendingNameTransferTxs().ae_testnet).toBeUndefined();
     expect(aeNames.ownedNames.value[0]).toMatchObject({
       name: pendingName,
       pending: false,


### PR DESCRIPTION
part of #1445 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code modified; risk is limited to CI/runtime and test maintenance, not user-facing behavior.
> 
> **Overview**
> This PR **adds and rewrites unit tests** so composables and a few send-flow components are exercised with **real crypto, storage, and adapters**, mocking only native/network/UI boundaries.
> 
> **`auth.mobile.spec.ts`** is refactored from per-test heavy mocks into shared **`boot()` / `restart()`** helpers with real Web Crypto and `localStorage`; new cases cover mnemonic encryption, post-restart biometric unlock, dismiss/concurrency, resume re-lock, and keychain-wipe decrypt failure.
> 
> **`auth.offscreenSessionSync.spec.ts`** drops stubbed `subscribeToSessionEncryptionKey` in favor of real **`browser.storage.onChanged`** wiring, plus an end-to-end decrypt path when the popup publishes a session key.
> 
> **New composable specs:** `balances`, `connection`, `copy`, `currencies`, `networks` — covering fetch/dedupe/stale-network handling, online events, clipboard timeout, CoinGecko rates/formatting, and custom network CRUD.
> 
> **New component specs:** `TransferSendAmount` and `TransferSendRecipient` — validation rules, error/warning mapping, tip-URL status, address book/QR modals.
> 
> **`aeNames.spec.js`** moves pending-tx assertions to **real `WalletStorage`**, seeds storage before `registerAdapters`, and mocks composables by **module path** (not the `@/composables` barrel) to avoid leaking fakes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f4617477749b05d7372a1130f4a0d6c6a71fa27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->