### PR TITLE
Fix tests warnings

### DIFF
--- a/src/composables/transferSendForm.ts
+++ b/src/composables/transferSendForm.ts
@@ -102,7 +102,7 @@ export function useTransferSendForm({
       ...updatedValues,
     };
     await nextTick();
-    Object.keys(updatedValues).forEach((field) => validateField(field));
+    Object.keys(updatedValues).forEach((field) => validateField(field, { warn: false }));
   }
 
   function hasQueryParams(params: Dictionary = {}) {

--- a/src/popup/plugins/i18n.ts
+++ b/src/popup/plugins/i18n.ts
@@ -16,7 +16,7 @@ export type SupportedLanguage = keyof typeof SUPPORTED_LANGUAGES;
 export const FALLBACK_LOCALE = SUPPORTED_LANGUAGES['en-US'];
 
 export const i18n = createI18n({
-  allowComposition: true,
+  legacy: false,
   fallbackLocale: FALLBACK_LOCALE,
   locale: FALLBACK_LOCALE,
   messages: { en },

--- a/src/protocols/solana/composables/solMaxAmount.ts
+++ b/src/protocols/solana/composables/solMaxAmount.ts
@@ -1,5 +1,5 @@
 import {
-  Ref, computed, watch, onMounted,
+  Ref, computed, watch,
 } from 'vue';
 import BigNumber from 'bignumber.js';
 import type { IFormModel } from '@/types';
@@ -43,7 +43,12 @@ export function useSolMaxAmount(formModel: Ref<IFormModel>) {
 
   const debouncedUpdateFee = debounce(() => updateFeeList(), 500);
 
-  onMounted(() => { updateFeeList(); });
+  // Populate the fee immediately so `max` (balance - fee) is correct on first render,
+  // e.g. right after opening the send modal or pressing "max" before editing any field.
+  // Called directly at setup rather than from `onMounted` so it also runs when the
+  // composable is used outside a mounted component (and avoids the "onMounted with no
+  // active component instance" warning when unit-tested directly).
+  updateFeeList();
 
   watch(
     () => [formModel.value?.selectedAsset, formModel.value?.addresses, formModel.value?.amount],

--- a/tests/unit/composables/get-tx-amount-total.spec.js
+++ b/tests/unit/composables/get-tx-amount-total.spec.js
@@ -1,83 +1,331 @@
 import BigNumber from 'bignumber.js';
+import { Tag } from '@aeternity/aepp-sdk';
+
 import { useFungibleTokens } from '@/composables';
-import { PROTOCOLS, TX_DIRECTION } from '../../../src/constants';
-import { STUB_TOKEN_CONTRACT_ADDRESS, STUB_TRANSACTIONS } from '../../../src/constants/stubs';
-import { AE_COIN_PRECISION } from '../../../src/protocols/aeternity/config';
+import { PROTOCOLS, TX_DIRECTION } from '@/constants';
+import {
+  STUB_ADDRESS,
+  STUB_CONTRACT_ADDRESS,
+  STUB_TOKEN_CONTRACT_ADDRESS,
+  STUB_TRANSACTIONS,
+} from '@/constants/stubs';
+import {
+  ACTIVITIES_TYPES,
+  AE_COIN_PRECISION,
+  TX_FUNCTIONS,
+} from '@/protocols/aeternity/config';
+import { ETH_CONTRACT_ID } from '@/protocols/ethereum/config';
 
 const TEST_TOKEN_DECIMALS = 12;
+/** An Æternity token deliberately registered WITHOUT a `decimals` field. */
+const AE_TOKEN_NO_DECIMALS_CONTRACT = 'ct_noDecimalsToken00000000000000000000000000000000000';
+/** An EVM token contract so we can exercise the non-Æternity token branch. */
+const ETH_TOKEN_CONTRACT = '0xtokencontract000000000000000000000000000000';
 
-const tests = [{
-  transaction: STUB_TRANSACTIONS.payForGaAttach,
-  resultSent: new BigNumber(STUB_TRANSACTIONS.payForGaAttach.tx.fee)
-    .plus(STUB_TRANSACTIONS.payForGaAttach.tx.tx.tx.fee).shiftedBy(-AE_COIN_PRECISION),
-  resultReceived: 0,
-}, {
-  transaction: STUB_TRANSACTIONS.gaMetaSpend,
-  resultSent: new BigNumber(STUB_TRANSACTIONS.gaMetaSpend.tx.tx.tx.amount)
-    .plus(STUB_TRANSACTIONS.gaMetaSpend.tx.tx.tx.fee)
-    .plus(STUB_TRANSACTIONS.gaMetaSpend.tx.fee)
-    .shiftedBy(-AE_COIN_PRECISION),
-  resultReceived: new BigNumber(STUB_TRANSACTIONS.gaMetaSpend.tx.tx.tx.amount)
-    .shiftedBy(-AE_COIN_PRECISION),
-}, {
-  transaction: STUB_TRANSACTIONS.nameClaim,
-  resultSent: new BigNumber(STUB_TRANSACTIONS.nameClaim.tx.fee)
-    .plus(STUB_TRANSACTIONS.nameClaim.tx.nameFee).shiftedBy(-AE_COIN_PRECISION),
-},
-...[
-  STUB_TRANSACTIONS.spend,
-  STUB_TRANSACTIONS.tip,
-  STUB_TRANSACTIONS.retip,
-  STUB_TRANSACTIONS.claim,
-]
-  .map((transaction) => ({
+/**
+ * Compare amounts by their canonical decimal string. `getTxAmountTotal` returns a
+ * JS number; comparing `BigNumber(...).toFixed()` sidesteps float noise and gives a
+ * readable diff on failure (unlike a bare `BigNumber.isEqualTo(...)` boolean).
+ */
+const amountStr = (value) => new BigNumber(value).toFixed();
+
+/** The transferred amount for an Æternity token call lives in the last call argument. */
+const lastArgValue = ({ tx }) => tx.arguments[tx.arguments.length - 1].value;
+
+const {
+  tokenBalances,
+  getTxAmountTotal,
+} = useFungibleTokens();
+
+/**
+ * `tokensAvailable` (the map `getTxAmountTotal` reads token decimals from) is a
+ * `computed` derived from the writable `tokenBalances` ref, so seeding must go through
+ * `tokenBalances` - not by mutating the read-only computed in place (which the previous,
+ * skipped, version of this test did and only "worked" by accident of Vue's caching).
+ * Re-seed before every test so an async storage restore can never clobber it mid-run.
+ */
+beforeEach(() => {
+  tokenBalances.value = [
+    {
+      protocol: PROTOCOLS.aeternity,
+      contractId: STUB_TOKEN_CONTRACT_ADDRESS,
+      decimals: TEST_TOKEN_DECIMALS,
+    },
+    {
+      // `decimals` intentionally omitted -> should fall back to AE_COIN_PRECISION.
+      protocol: PROTOCOLS.aeternity,
+      contractId: AE_TOKEN_NO_DECIMALS_CONTRACT,
+    },
+    {
+      protocol: PROTOCOLS.ethereum,
+      contractId: ETH_TOKEN_CONTRACT,
+      decimals: 18,
+    },
+  ];
+});
+
+/**
+ * The original coverage table: one entry per real transaction shape, asserting the
+ * `sent` total (with fees) and, where meaningful, the `received` total (amount only).
+ */
+const coreCases = [
+  // Nested "paying for" tx: only fees, no transferred amount.
+  {
+    transaction: STUB_TRANSACTIONS.payForGaAttach,
+    resultSent: new BigNumber(STUB_TRANSACTIONS.payForGaAttach.tx.fee)
+      .plus(STUB_TRANSACTIONS.payForGaAttach.tx.tx.tx.fee)
+      .shiftedBy(-AE_COIN_PRECISION),
+    resultReceived: new BigNumber(0),
+  },
+  // Generalized-account meta spend: inner amount + both fee layers.
+  {
+    transaction: STUB_TRANSACTIONS.gaMetaSpend,
+    resultSent: new BigNumber(STUB_TRANSACTIONS.gaMetaSpend.tx.tx.tx.amount)
+      .plus(STUB_TRANSACTIONS.gaMetaSpend.tx.tx.tx.fee)
+      .plus(STUB_TRANSACTIONS.gaMetaSpend.tx.fee)
+      .shiftedBy(-AE_COIN_PRECISION),
+    resultReceived: new BigNumber(STUB_TRANSACTIONS.gaMetaSpend.tx.tx.tx.amount)
+      .shiftedBy(-AE_COIN_PRECISION),
+  },
+  // Name claim: the `nameFee` stands in for the amount.
+  {
+    transaction: STUB_TRANSACTIONS.nameClaim,
+    resultSent: new BigNumber(STUB_TRANSACTIONS.nameClaim.tx.fee)
+      .plus(STUB_TRANSACTIONS.nameClaim.tx.nameFee)
+      .shiftedBy(-AE_COIN_PRECISION),
+    resultReceived: undefined,
+  },
+  // Plain coin transactions: amount + fee sent, amount received.
+  ...[
+    STUB_TRANSACTIONS.spend,
+    STUB_TRANSACTIONS.tip,
+    STUB_TRANSACTIONS.retip,
+    STUB_TRANSACTIONS.claim,
+  ].map((transaction) => ({
     transaction,
     resultSent: new BigNumber(transaction.tx.amount)
       .plus(transaction.tx.fee)
       .shiftedBy(-AE_COIN_PRECISION),
     resultReceived: new BigNumber(transaction.tx.amount).shiftedBy(-AE_COIN_PRECISION),
   })),
-...[
-  STUB_TRANSACTIONS.transfer,
-  STUB_TRANSACTIONS.createAllowance,
-  STUB_TRANSACTIONS.changeAllowance,
-  STUB_TRANSACTIONS.tipToken,
-  STUB_TRANSACTIONS.retipToken,
-].map((transaction) => ({
-  transaction,
-  resultSent: new BigNumber(transaction.tx.arguments[transaction.tx.arguments.length - 1].value)
-    .shiftedBy(-TEST_TOKEN_DECIMALS),
-  resultReceived: new BigNumber(transaction.tx.arguments[transaction.tx.arguments.length - 1].value)
-    .shiftedBy(-TEST_TOKEN_DECIMALS),
-})),
+  // Æternity token contract calls: amount taken from the call arguments and shifted by
+  // the token's own decimals; the network fee (paid in coin) is NOT part of the total.
+  ...[
+    STUB_TRANSACTIONS.transfer,
+    STUB_TRANSACTIONS.createAllowance,
+    STUB_TRANSACTIONS.changeAllowance,
+    STUB_TRANSACTIONS.tipToken,
+    STUB_TRANSACTIONS.retipToken,
+  ].map((transaction) => ({
+    transaction,
+    resultSent: new BigNumber(lastArgValue(transaction)).shiftedBy(-TEST_TOKEN_DECIMALS),
+    resultReceived: new BigNumber(lastArgValue(transaction)).shiftedBy(-TEST_TOKEN_DECIMALS),
+  })),
 ];
 
-describe.skip('getTxAmountTotal', () => {
-  // TODO replace with transactionData composable
-  const { tokensAvailable, getTxAmountTotal } = useFungibleTokens();
-
-  tokensAvailable.value[PROTOCOLS.aeternity] = {};
-  tokensAvailable.value[PROTOCOLS.aeternity][STUB_TOKEN_CONTRACT_ADDRESS] = {
-    decimals: TEST_TOKEN_DECIMALS,
-  };
-
-  tests.forEach((test) => it(
-    `should return correct result for each type of transaction: for \
-${test.transaction.tx.type}/${test.transaction.tx.function}`,
+describe('getTxAmountTotal', () => {
+  coreCases.forEach((testCase) => it(
+    `computes the total for ${testCase.transaction.tx.type}/${testCase.transaction.tx.function}`,
     () => {
-      expect(
-        new BigNumber(getTxAmountTotal(test.transaction, TX_DIRECTION.sent))
-          .isEqualTo(test.resultSent),
-      ).toBeTruthy();
-      expect(
-        new BigNumber(getTxAmountTotal(test.transaction)).isEqualTo(test.resultSent),
-      ).toBeTruthy();
-      if (test.resultReceived !== undefined) {
-        expect(
-          new BigNumber(getTxAmountTotal(test.transaction, TX_DIRECTION.received))
-            .isEqualTo(test.resultReceived),
-        ).toBeTruthy();
+      // Explicit `sent` direction.
+      expect(amountStr(getTxAmountTotal(testCase.transaction, TX_DIRECTION.sent)))
+        .toBe(amountStr(testCase.resultSent));
+      // `sent` is also the default direction.
+      expect(amountStr(getTxAmountTotal(testCase.transaction)))
+        .toBe(amountStr(testCase.resultSent));
+
+      if (testCase.resultReceived !== undefined) {
+        expect(amountStr(getTxAmountTotal(testCase.transaction, TX_DIRECTION.received)))
+          .toBe(amountStr(testCase.resultReceived));
       }
     },
   ));
+
+  describe('direction handling', () => {
+    it('excludes the fee from the received total but includes it when sent', () => {
+      const { spend } = STUB_TRANSACTIONS;
+
+      const sent = getTxAmountTotal(spend, TX_DIRECTION.sent);
+      const received = getTxAmountTotal(spend, TX_DIRECTION.received);
+
+      expect(amountStr(sent)).toBe(
+        amountStr(new BigNumber(spend.tx.amount).plus(spend.tx.fee).shiftedBy(-AE_COIN_PRECISION)),
+      );
+      expect(amountStr(received)).toBe(
+        amountStr(new BigNumber(spend.tx.amount).shiftedBy(-AE_COIN_PRECISION)),
+      );
+      expect(new BigNumber(sent).isGreaterThan(received)).toBe(true);
+    });
+  });
+
+  describe('Æternity coin (generic) branch', () => {
+    it('adds contract-call gas cost (gasPrice * gasUsed) to the sent total only', () => {
+      const gasTx = {
+        protocol: PROTOCOLS.aeternity,
+        tx: {
+          amount: 5000000000000000,
+          fee: 100000000000000,
+          gasPrice: 1000000000,
+          gasUsed: 20000,
+          function: 'some_contract_method', // not a categorized token call -> generic branch
+          type: 'ContractCallTx',
+          contractId: STUB_CONTRACT_ADDRESS, // not a known token -> no token branch
+        },
+      };
+      const gasCost = new BigNumber(gasTx.tx.gasPrice).multipliedBy(gasTx.tx.gasUsed);
+
+      expect(amountStr(getTxAmountTotal(gasTx, TX_DIRECTION.sent))).toBe(
+        amountStr(
+          new BigNumber(gasTx.tx.amount)
+            .plus(gasTx.tx.fee)
+            .plus(gasCost)
+            .shiftedBy(-AE_COIN_PRECISION),
+        ),
+      );
+      // Received ignores fee AND gas.
+      expect(amountStr(getTxAmountTotal(gasTx, TX_DIRECTION.received))).toBe(
+        amountStr(new BigNumber(gasTx.tx.amount).shiftedBy(-AE_COIN_PRECISION)),
+      );
+    });
+
+    it('reads the claimed tip amount from the event log when amount/nameFee are absent', () => {
+      const claimedAmount = 7000000000000000;
+      const claimTx = {
+        protocol: PROTOCOLS.aeternity,
+        tx: {
+          amount: 0,
+          fee: 100000000000000,
+          function: TX_FUNCTIONS.claim,
+          type: 'ContractCallTx',
+          contractId: STUB_CONTRACT_ADDRESS,
+          log: [{ topics: ['event', 'address', claimedAmount] }],
+        },
+      };
+
+      expect(amountStr(getTxAmountTotal(claimTx, TX_DIRECTION.sent))).toBe(
+        amountStr(
+          new BigNumber(claimedAmount).plus(claimTx.tx.fee).shiftedBy(-AE_COIN_PRECISION),
+        ),
+      );
+      expect(amountStr(getTxAmountTotal(claimTx, TX_DIRECTION.received))).toBe(
+        amountStr(new BigNumber(claimedAmount).shiftedBy(-AE_COIN_PRECISION)),
+      );
+    });
+
+    it('returns zero for a call with no amount and no fee', () => {
+      const emptyTx = {
+        protocol: PROTOCOLS.aeternity,
+        tx: {
+          amount: 0,
+          fee: 0,
+          function: 'noop',
+          type: 'ContractCallTx',
+          contractId: STUB_CONTRACT_ADDRESS,
+        },
+      };
+
+      expect(amountStr(getTxAmountTotal(emptyTx, TX_DIRECTION.sent))).toBe('0');
+    });
+  });
+
+  describe('token-sale buy (isTokenSaleBuy flag)', () => {
+    const callerId = STUB_ADDRESS;
+    const paidAmount = 10000000000000000;
+    const refundAmount = 3000000000000000;
+    const tokenSaleTx = {
+      protocol: PROTOCOLS.aeternity,
+      tx: {
+        amount: paidAmount,
+        fee: 100000000000000,
+        callerId,
+        function: 'buy',
+        type: 'ContractCallTx',
+        contractId: STUB_CONTRACT_ADDRESS,
+        internalEvents: [{
+          type: ACTIVITIES_TYPES.internalContractCallEvent,
+          payload: { internalTx: { recipientId: callerId, amount: refundAmount } },
+        }],
+      },
+    };
+
+    it('subtracts the refunded amount from the paid amount when the flag is set', () => {
+      expect(amountStr(getTxAmountTotal(tokenSaleTx, TX_DIRECTION.sent, true))).toBe(
+        amountStr(
+          new BigNumber(paidAmount - refundAmount)
+            .plus(tokenSaleTx.tx.fee)
+            .shiftedBy(-AE_COIN_PRECISION),
+        ),
+      );
+    });
+
+    it('uses the raw paid amount when the flag is not set', () => {
+      expect(amountStr(getTxAmountTotal(tokenSaleTx, TX_DIRECTION.sent, false))).toBe(
+        amountStr(
+          new BigNumber(paidAmount).plus(tokenSaleTx.tx.fee).shiftedBy(-AE_COIN_PRECISION),
+        ),
+      );
+    });
+  });
+
+  describe('Æternity token branch', () => {
+    it('falls back to AE_COIN_PRECISION when the token has no registered decimals', () => {
+      const tokenAmount = 1000000000000000000;
+      const transferTx = {
+        protocol: PROTOCOLS.aeternity,
+        tx: {
+          amount: 0,
+          fee: 16780000000000,
+          function: TX_FUNCTIONS.transfer,
+          type: 'ContractCallTx',
+          contractId: AE_TOKEN_NO_DECIMALS_CONTRACT,
+          arguments: [
+            { type: 'address', value: STUB_ADDRESS },
+            { type: 'int', value: tokenAmount },
+          ],
+        },
+      };
+
+      // Token branch ignores the fee and shifts by the fallback precision (18).
+      const expected = amountStr(new BigNumber(tokenAmount).shiftedBy(-AE_COIN_PRECISION));
+      expect(amountStr(getTxAmountTotal(transferTx, TX_DIRECTION.sent))).toBe(expected);
+      expect(amountStr(getTxAmountTotal(transferTx, TX_DIRECTION.received))).toBe(expected);
+    });
+  });
+
+  describe('non-Æternity (EVM) branch', () => {
+    it('adds the fee for a native coin transfer (raw, un-shifted)', () => {
+      const coinTx = {
+        protocol: PROTOCOLS.ethereum,
+        tx: { amount: 1000000, fee: 21000, contractId: ETH_CONTRACT_ID },
+      };
+
+      expect(getTxAmountTotal(coinTx, TX_DIRECTION.sent)).toBe(1000000 + 21000);
+      expect(getTxAmountTotal(coinTx, TX_DIRECTION.received)).toBe(1000000);
+    });
+
+    it('excludes the fee for a known token contract transfer', () => {
+      const tokenTx = {
+        protocol: PROTOCOLS.ethereum,
+        tx: { amount: 500, fee: 21000, contractId: ETH_TOKEN_CONTRACT },
+      };
+
+      expect(getTxAmountTotal(tokenTx, TX_DIRECTION.sent)).toBe(500);
+      expect(getTxAmountTotal(tokenTx, TX_DIRECTION.received)).toBe(500);
+    });
+
+    it('adds the fee for a contract-creation / non-token contract call', () => {
+      const createTx = {
+        protocol: PROTOCOLS.ethereum,
+        tx: {
+          amount: 0,
+          fee: 30000,
+          contractId: 'ct_freshDeploy',
+          tag: Tag.ContractCreateTx,
+        },
+      };
+
+      expect(getTxAmountTotal(createTx, TX_DIRECTION.sent)).toBe(30000);
+      expect(getTxAmountTotal(createTx, TX_DIRECTION.received)).toBe(0);
+    });
+  });
 });

--- a/tests/unit/composables/open-scan-qr-modal.spec.js
+++ b/tests/unit/composables/open-scan-qr-modal.spec.js
@@ -1,5 +1,24 @@
+import { createApp, ref } from 'vue';
 import { useTransferSendForm } from '@/composables/transferSendForm';
 import { STUB_ACCOUNT, STUB_CONTRACT_ADDRESS, STUB_TOKEN_CONTRACT_ADDRESS } from '@/constants/stubs';
+
+/**
+ * `useTransferSendForm` registers an `onMounted` hook (route-query watches) at its top
+ * level, so it needs a real component instance to attach to - calling it bare would warn
+ * "onMounted is called when there is no active component instance". Mounting a throwaway
+ * host component gives it one without pulling in the real router/DOM tree.
+ */
+function withSetup(composable) {
+  let result;
+  const app = createApp({
+    setup() {
+      result = composable();
+      return () => {};
+    },
+  });
+  app.mount(document.createElement('div'));
+  return result;
+}
 
 const testAmount = '11.111';
 const testInvoiceId = '232323123';
@@ -24,6 +43,19 @@ vi.mock('vue-i18n', () => ({
   })),
 }));
 
+vi.mock('vue-router', () => ({
+  useRoute: vi.fn(() => ({ query: {} })),
+  useRouter: vi.fn(() => ({ replace: vi.fn() })),
+}));
+
+vi.mock('vee-validate', () => ({
+  useForm: vi.fn(() => ({
+    errors: { value: {} },
+    validate: vi.fn(),
+    validateField: vi.fn(),
+  })),
+}));
+
 vi.mock('@/composables/transferSendHandler', () => ({
   useTransferSendHandler: vi.fn(() => ({
     save: () => {},
@@ -42,6 +74,9 @@ vi.mock('@/composables', () => ({
   })),
   useAccounts: vi.fn(() => ({
     accounts: [],
+    // Must be a real ref - `transferSendForm`'s onMounted watch uses it as a watch
+    // source, and Vue only accepts refs/reactive objects/getters there.
+    activeAccount: ref({}),
   })),
 }));
 
@@ -62,7 +97,7 @@ describe('scanTransferQrCode', () => {
     invoiceId,
     invoiceContract,
     scanTransferQrCode,
-  } = useTransferSendForm({ transferData, getSelectedAssetValue });
+  } = withSetup(() => useTransferSendForm({ transferData, getSelectedAssetValue }));
 
   it('parses address qr code', async () => {
     await scanTransferQrCode();

--- a/tests/unit/popup/pages/Popups/Connect.spec.ts
+++ b/tests/unit/popup/pages/Popups/Connect.spec.ts
@@ -6,6 +6,7 @@ import Connect from '@/popup/pages/Popups/Connect.vue';
 import ConnectBase from '@/popup/pages/Popups/ConnectBase.vue';
 import { usePopupProps, useAccounts } from '@/composables';
 import { PROTOCOLS } from '@/constants';
+import en from '@/popup/locales/en-US.json';
 
 vi.mock('@/composables', () => ({
   usePopupProps: vi.fn(),
@@ -15,7 +16,7 @@ vi.mock('@/composables', () => ({
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
-  messages: { en: {} },
+  messages: { en },
 });
 
 function mountConnectWithPopupProps(popupProps: any = {}) {

--- a/tests/unit/popup/pages/Popups/ConnectBase.ae.spec.ts
+++ b/tests/unit/popup/pages/Popups/ConnectBase.ae.spec.ts
@@ -4,6 +4,7 @@ import { createI18n } from 'vue-i18n';
 import ConnectBase from '@/popup/pages/Popups/ConnectBase.vue';
 import { usePopupProps, useAccounts } from '@/composables';
 import { PROTOCOLS } from '@/constants';
+import en from '@/popup/locales/en-US.json';
 
 vi.mock('@/composables', () => ({
   usePopupProps: vi.fn(),
@@ -13,7 +14,7 @@ vi.mock('@/composables', () => ({
 const i18n = createI18n({
   legacy: false,
   locale: 'en',
-  messages: { en: {} },
+  messages: { en },
 });
 
 function mountBaseWith(popupProps: any = {}, props: any = {}) {

--- a/tests/unit/solana/solana-composable-fee-max.spec.ts
+++ b/tests/unit/solana/solana-composable-fee-max.spec.ts
@@ -17,15 +17,24 @@ vi.mock('@/composables/networks', () => ({
   }),
 }));
 
-// Provide a deterministic fee composable to avoid network calls and expose a stable fee ref
+const { updateFeeListMock } = vi.hoisted(() => ({ updateFeeListMock: vi.fn() }));
+
+// Deterministic fee composable that mirrors the real one's timing: `fee` starts at 0
+// and only becomes non-zero once `updateFeeList()` is called. This is what lets the
+// tests below detect a regression where `useSolMaxAmount` forgets to prime the fee on
+// setup (which would leave `max` overstated by the fee headroom until a field edit).
 vi.mock('@/protocols/solana/composables/solFeeCalculation', () => ({
-  useSolFeeCalculation: () => ({
-    fee: ref(0.000005),
-    feeSelectedIndex: ref(0),
-    feeList: ref([]),
-    maxFee: ref(0.000005),
-    updateFeeList: vi.fn(),
-  }),
+  useSolFeeCalculation: () => {
+    const fee = ref(0);
+    updateFeeListMock.mockImplementation(() => { fee.value = 0.000005; });
+    return {
+      fee,
+      feeSelectedIndex: ref(0),
+      feeList: ref([]),
+      maxFee: fee,
+      updateFeeList: updateFeeListMock,
+    };
+  },
 }));
 
 // Avoid hitting real network during fee calculation
@@ -49,14 +58,22 @@ web3.Connection.prototype.getLatestBlockhash = () => Promise.resolve({ blockhash
 // eslint-disable-next-line no-param-reassign
 web3.Connection.prototype.getFeeForMessage = () => Promise.resolve({ value: 5000 });
 
+function makeSolForm() {
+  const adapter = ProtocolAdapterFactory.getAdapter(PROTOCOLS.solana);
+  return ref({
+    amount: '0',
+    selectedAsset: { contractId: adapter.coinContractId, decimals: adapter.coinPrecision },
+    addresses: ['A', 'B'],
+  } as any);
+}
+
 describe('Solana composables - useSolMaxAmount', () => {
+  beforeEach(() => {
+    updateFeeListMock.mockClear();
+  });
+
   it('computes max for SOL asset subtracting estimated fee and supports multiple recipients', async () => {
-    const adapter = ProtocolAdapterFactory.getAdapter(PROTOCOLS.solana);
-    const form = ref({
-      amount: '0',
-      selectedAsset: { contractId: adapter.coinContractId, decimals: adapter.coinPrecision },
-      addresses: ['A', 'B'],
-    } as any);
+    const form = makeSolForm();
 
     const { max } = useSolMaxAmount(form as any) as any;
     // With mocked fee of 0.000005 SOL, two recipients => each half of (10 - fee)
@@ -66,5 +83,18 @@ describe('Solana composables - useSolMaxAmount', () => {
     // If token selected, returns token balance unaffected by fee
     form.value.selectedAsset = { contractId: 'TokenMint', decimals: 6, amount: '1000000' } as any;
     expect(max.value).toBe('1');
+  });
+
+  it('primes the fee on setup so max excludes fee headroom before any field edit', () => {
+    const form = makeSolForm();
+
+    const { max } = useSolMaxAmount(form as any) as any;
+
+    // The fee must be fetched immediately, not only after a formModel change.
+    expect(updateFeeListMock).toHaveBeenCalled();
+    // With the fee applied, per-recipient max is strictly below balance/recipients (10/2).
+    // If the setup fetch is dropped, fee stays 0 and this would be exactly 5.
+    expect(Number(max.value)).toBeLessThan(5);
+    expect(Number(max.value)).toBeGreaterThan(4.999);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -38,6 +38,11 @@ export default defineConfig({
           '@stencil/core',
           'ionicons',
           'swiper',
+          // Keeps @capacitor/core's plugin registry inside Vite's per-file module
+          // graph instead of Node's process-wide require cache, so a worker reused
+          // across spec files doesn't see `registerPlugin('NavigationBar')` (called
+          // as a side effect of importing `@/utils/systemBars`) as a re-registration.
+          '@capacitor/core',
         ],
       },
     },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Changes are mostly test infrastructure and minor validation/i18n config; Sol fee priming is a small behavioral fix for send max amounts.
> 
> **Overview**
> **Test stability and warnings** are the main theme: Vitest inlines `@capacitor/core` to avoid duplicate Capacitor plugin registration when workers reuse modules; popup i18n switches from `allowComposition: true` to **`legacy: false`** (Composition API mode).
> 
> **Runtime tweaks** tied to tests and UX: transfer send form calls **`validateField(..., { warn: false })`** when applying QR/route updates so vee-validate does not warn on fields without rules; Solana **`useSolMaxAmount`** runs **`updateFeeList()` at setup** (not `onMounted`) so max amount accounts for fees on first paint and composable unit tests do not hit “no active component instance”.
> 
> **Test suite expansion**: **`getTxAmountTotal`** tests are enabled (removed `describe.skip`), seed **`tokenBalances`** correctly in `beforeEach`, and add coverage for direction, gas, claims, token sales, and EVM branches. QR scan tests mount composables via a throwaway **`withSetup`** host, mock router/vee-validate, and use a real **`activeAccount` ref**. Connect popup specs load real **`en-US`** messages. Sol max-amount tests assert fee is primed on setup with a fee mock that starts at zero.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50456539ea4bfbf67a8042c3dad35831646e38b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->