### PR TITLE
feat: be able to set default name using new contract

### DIFF
--- a/src/constants/common.ts
+++ b/src/constants/common.ts
@@ -139,6 +139,7 @@ export const STORAGE_KEYS = {
   multisigAccountsPending: 'multisig-pending',
   activeMultisigAccount: 'active-multisig-account',
   namesOwned: 'names-owned',
+  namesOwnedNetworkId: 'names-owned-network-id',
   namesDefault: 'names-default',
   notificationsSettings: 'notifications-settings',
   lastRoute: 'last-route',
@@ -148,6 +149,7 @@ export const STORAGE_KEYS = {
   preclaimedNames: 'preclaimed-names',
   pendingNameAutoExtendTxs: 'pending-name-auto-extend-txs',
   pendingNameTransferTxs: 'pending-name-transfer-txs',
+  pendingDefaultNames: 'pending-default-names',
   permissions: 'permissions',
   appsBrowserHistory: 'apps-browser-history',
 

--- a/src/popup/components/NameItem.vue
+++ b/src/popup/components/NameItem.vue
@@ -165,6 +165,7 @@
 
 <script lang="ts">
 import {
+  Encoded,
   Encoding,
   isAddressValid,
 } from '@aeternity/aepp-sdk';
@@ -177,6 +178,7 @@ import {
   watch,
 } from 'vue';
 import { useI18n } from 'vue-i18n';
+
 import { IName } from '@/types';
 import {
   AUTO_EXTEND_NAME_BLOCKS_INTERVAL,
@@ -186,7 +188,6 @@ import { RejectedByUserError } from '@/lib/errors';
 import {
   blocksToRelativeTime,
   handleUnknownError,
-  postJson,
 } from '@/utils';
 import {
   useAccounts,
@@ -196,7 +197,7 @@ import {
 } from '@/composables';
 import { checkAddressOrChannel } from '@/protocols/aeternity/helpers';
 import { NAME_CLAIM_STATUS, useAeNames } from '@/protocols/aeternity/composables/aeNames';
-import { useAeNetworkSettings } from '@/protocols/aeternity/composables';
+import { useAeAddressLinkBackend } from '@/protocols/aeternity/composables';
 import { UPDATE_POINTER_ACTION } from '@/protocols/aeternity/config';
 
 import InputField from './InputField.vue';
@@ -232,15 +233,15 @@ export default defineComponent({
     const {
       setAutoExtend,
       updateNamePointer,
-      getName,
+      getDefaultName,
       getNameExtendFee,
       extendExpiringOwnedNames,
       ownedNames,
       updateOwnedNames,
-      setDefaultName,
+      setDefaultNameOptimistic,
     } = useAeNames();
-    const { aeActiveNetworkSettings } = useAeNetworkSettings();
-    const { nodeNetworkId, fetchRespondChallenge } = useAeSdk();
+    const { linkPreferredAensName, unlinkPreferredAensName } = useAeAddressLinkBackend();
+    const { nodeNetworkId } = useAeSdk();
 
     const expand = ref(false);
     const newPointer = ref<string>('');
@@ -252,8 +253,11 @@ export default defineComponent({
     const pointerInput = ref();
     const transferInput = ref();
 
+    // Compares against the explicitly linked default, not `getName`: the latter falls
+    // back to the last claimed name, which would otherwise mark a name as "default"
+    // (and disable the button) while no default is actually set on-chain.
     const isDefault = computed(
-      () => getName(activeAccount.value.address).value === props.nameEntry.name,
+      () => getDefaultName(activeAccount.value.address).value === props.nameEntry.name,
     );
     const hasPointer = computed(
       (): boolean => !!props.nameEntry.pointers?.accountPubkey,
@@ -324,29 +328,24 @@ export default defineComponent({
     async function updateDefaultName(name: IName['name']) {
       try {
         const { address } = activeAccount.value;
-        const url = `${aeActiveNetworkSettings.value.backendUrl}/profile/${address}`;
         const currentNetworkId = nodeNetworkId.value;
 
-        const response = await postJson(url, {
-          body: {
-            preferredChainName: name,
-          },
-        });
-
-        let respondChallenge;
-        try {
-          respondChallenge = await fetchRespondChallenge(response);
-        } catch (error: any) {
-          handleUnknownError(error);
-          return;
+        // Set/clear the preferred `.chain` name through the Superhero API: the
+        // wallet signs a backend-issued challenge to prove ownership and the
+        // backend broadcasts (and pays for) the on-chain AddressLink transaction.
+        if (name) {
+          await linkPreferredAensName(address as Encoded.AccountAddress, name);
+        } else {
+          await unlinkPreferredAensName(address as Encoded.AccountAddress);
         }
-        await postJson(url, { body: respondChallenge });
 
         if (currentNetworkId !== nodeNetworkId.value) {
           return;
         }
 
-        setDefaultName({ address, name });
+        // Apply optimistically and mark pending so the on-chain poll does not
+        // revert it before the backend-sponsored transaction is mined.
+        setDefaultNameOptimistic({ address, name });
       } catch (error: any) {
         handleUnknownError(error);
       }

--- a/src/protocols/aeternity/aci/AddressLinkACI.json
+++ b/src/protocols/aeternity/aci/AddressLinkACI.json
@@ -1,0 +1,544 @@
+[
+  {
+    "namespace": {
+      "name": "ListInternal",
+      "typedefs": []
+    }
+  },
+  {
+    "namespace": {
+      "name": "List",
+      "typedefs": []
+    }
+  },
+  {
+    "namespace": {
+      "name": "String",
+      "typedefs": []
+    }
+  },
+  {
+    "contract": {
+      "event": {
+        "variant": [
+          {
+            "ProviderRegistered": [
+              "address",
+              "string"
+            ]
+          },
+          {
+            "Link": [
+              "address",
+              "string"
+            ]
+          },
+          {
+            "Unlink": [
+              "address",
+              "string"
+            ]
+          },
+          {
+            "PrincipalLink": [
+              "address",
+              "string"
+            ]
+          },
+          {
+            "PrincipalUnlink": [
+              "address",
+              "string"
+            ]
+          }
+        ]
+      },
+      "functions": [
+        {
+          "arguments": [],
+          "name": "init",
+          "payable": false,
+          "returns": "AddressLink.state",
+          "stateful": false
+        },
+        {
+          "arguments": [
+            {
+              "name": "provider",
+              "type": "string"
+            }
+          ],
+          "name": "register_provider",
+          "payable": false,
+          "returns": "unit",
+          "stateful": true
+        },
+        {
+          "arguments": [
+            {
+              "name": "addr",
+              "type": "address"
+            },
+            {
+              "name": "provider",
+              "type": "string"
+            },
+            {
+              "name": "value",
+              "type": "string"
+            },
+            {
+              "name": "nonce",
+              "type": "int"
+            },
+            {
+              "name": "sig",
+              "type": "signature"
+            }
+          ],
+          "name": "link",
+          "payable": false,
+          "returns": "unit",
+          "stateful": true
+        },
+        {
+          "arguments": [
+            {
+              "name": "addr",
+              "type": "address"
+            },
+            {
+              "name": "provider",
+              "type": "string"
+            },
+            {
+              "name": "nonce",
+              "type": "int"
+            },
+            {
+              "name": "sig",
+              "type": "signature"
+            }
+          ],
+          "name": "unlink",
+          "payable": false,
+          "returns": "unit",
+          "stateful": true
+        },
+        {
+          "arguments": [
+            {
+              "name": "principal",
+              "type": "string"
+            },
+            {
+              "name": "signer",
+              "type": "address"
+            },
+            {
+              "name": "provider",
+              "type": "string"
+            },
+            {
+              "name": "value",
+              "type": "string"
+            },
+            {
+              "name": "nonce",
+              "type": "int"
+            },
+            {
+              "name": "sig",
+              "type": "signature"
+            }
+          ],
+          "name": "link_principal",
+          "payable": false,
+          "returns": "unit",
+          "stateful": true
+        },
+        {
+          "arguments": [
+            {
+              "name": "principal",
+              "type": "string"
+            },
+            {
+              "name": "signer",
+              "type": "address"
+            },
+            {
+              "name": "provider",
+              "type": "string"
+            },
+            {
+              "name": "nonce",
+              "type": "int"
+            },
+            {
+              "name": "sig",
+              "type": "signature"
+            }
+          ],
+          "name": "unlink_principal",
+          "payable": false,
+          "returns": "unit",
+          "stateful": true
+        },
+        {
+          "arguments": [
+            {
+              "name": "did",
+              "type": "string"
+            },
+            {
+              "name": "controller",
+              "type": "address"
+            },
+            {
+              "name": "provider",
+              "type": "string"
+            },
+            {
+              "name": "value",
+              "type": "string"
+            },
+            {
+              "name": "nonce",
+              "type": "int"
+            },
+            {
+              "name": "sig",
+              "type": "signature"
+            }
+          ],
+          "name": "link_did",
+          "payable": false,
+          "returns": "unit",
+          "stateful": true
+        },
+        {
+          "arguments": [
+            {
+              "name": "did",
+              "type": "string"
+            },
+            {
+              "name": "controller",
+              "type": "address"
+            },
+            {
+              "name": "provider",
+              "type": "string"
+            },
+            {
+              "name": "nonce",
+              "type": "int"
+            },
+            {
+              "name": "sig",
+              "type": "signature"
+            }
+          ],
+          "name": "unlink_did",
+          "payable": false,
+          "returns": "unit",
+          "stateful": true
+        },
+        {
+          "arguments": [
+            {
+              "name": "addr",
+              "type": "address"
+            }
+          ],
+          "name": "get_nonce",
+          "payable": false,
+          "returns": "int",
+          "stateful": false
+        },
+        {
+          "arguments": [
+            {
+              "name": "principal",
+              "type": "string"
+            },
+            {
+              "name": "signer",
+              "type": "address"
+            }
+          ],
+          "name": "get_nonce_principal",
+          "payable": false,
+          "returns": "int",
+          "stateful": false
+        },
+        {
+          "arguments": [
+            {
+              "name": "did",
+              "type": "string"
+            },
+            {
+              "name": "controller",
+              "type": "address"
+            }
+          ],
+          "name": "get_nonce_did",
+          "payable": false,
+          "returns": "int",
+          "stateful": false
+        },
+        {
+          "arguments": [
+            {
+              "name": "provider",
+              "type": "string"
+            }
+          ],
+          "name": "get_provider_owner",
+          "payable": false,
+          "returns": {
+            "option": [
+              "address"
+            ]
+          },
+          "stateful": false
+        },
+        {
+          "arguments": [
+            {
+              "name": "addr",
+              "type": "address"
+            }
+          ],
+          "name": "get_links",
+          "payable": false,
+          "returns": {
+            "map": [
+              "string",
+              "string"
+            ]
+          },
+          "stateful": false
+        },
+        {
+          "arguments": [
+            {
+              "name": "principal",
+              "type": "string"
+            },
+            {
+              "name": "signer",
+              "type": "address"
+            }
+          ],
+          "name": "get_links_principal",
+          "payable": false,
+          "returns": {
+            "map": [
+              "string",
+              "string"
+            ]
+          },
+          "stateful": false
+        },
+        {
+          "arguments": [
+            {
+              "name": "did",
+              "type": "string"
+            },
+            {
+              "name": "controller",
+              "type": "address"
+            }
+          ],
+          "name": "get_links_did",
+          "payable": false,
+          "returns": {
+            "map": [
+              "string",
+              "string"
+            ]
+          },
+          "stateful": false
+        },
+        {
+          "arguments": [
+            {
+              "name": "addr",
+              "type": "address"
+            },
+            {
+              "name": "provider",
+              "type": "string"
+            }
+          ],
+          "name": "get_link",
+          "payable": false,
+          "returns": {
+            "option": [
+              "string"
+            ]
+          },
+          "stateful": false
+        },
+        {
+          "arguments": [
+            {
+              "name": "principal",
+              "type": "string"
+            },
+            {
+              "name": "signer",
+              "type": "address"
+            },
+            {
+              "name": "provider",
+              "type": "string"
+            }
+          ],
+          "name": "get_link_principal",
+          "payable": false,
+          "returns": {
+            "option": [
+              "string"
+            ]
+          },
+          "stateful": false
+        },
+        {
+          "arguments": [
+            {
+              "name": "did",
+              "type": "string"
+            },
+            {
+              "name": "controller",
+              "type": "address"
+            },
+            {
+              "name": "provider",
+              "type": "string"
+            }
+          ],
+          "name": "get_link_did",
+          "payable": false,
+          "returns": {
+            "option": [
+              "string"
+            ]
+          },
+          "stateful": false
+        },
+        {
+          "arguments": [
+            {
+              "name": "provider",
+              "type": "string"
+            },
+            {
+              "name": "value",
+              "type": "string"
+            }
+          ],
+          "name": "resolve",
+          "payable": false,
+          "returns": {
+            "option": [
+              "address"
+            ]
+          },
+          "stateful": false
+        },
+        {
+          "arguments": [
+            {
+              "name": "principal",
+              "type": "string"
+            }
+          ],
+          "name": "resolve_signer",
+          "payable": false,
+          "returns": {
+            "option": [
+              "address"
+            ]
+          },
+          "stateful": false
+        },
+        {
+          "arguments": [
+            {
+              "name": "did",
+              "type": "string"
+            }
+          ],
+          "name": "resolve_did_controller",
+          "payable": false,
+          "returns": {
+            "option": [
+              "address"
+            ]
+          },
+          "stateful": false
+        }
+      ],
+      "kind": "contract_main",
+      "name": "AddressLink",
+      "payable": false,
+      "state": {
+        "record": [
+          {
+            "name": "providers",
+            "type": {
+              "map": [
+                "string",
+                "address"
+              ]
+            }
+          },
+          {
+            "name": "links",
+            "type": {
+              "map": [
+                "address",
+                {
+                  "map": [
+                    "string",
+                    "string"
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "reverse",
+            "type": {
+              "map": [
+                "string",
+                {
+                  "map": [
+                    "string",
+                    "address"
+                  ]
+                }
+              ]
+            }
+          },
+          {
+            "name": "nonce_seq",
+            "type": {
+              "map": [
+                "address",
+                "int"
+              ]
+            }
+          }
+        ]
+      },
+      "typedefs": []
+    }
+  }
+]

--- a/src/protocols/aeternity/composables/aeAddressLinkBackend.ts
+++ b/src/protocols/aeternity/composables/aeAddressLinkBackend.ts
@@ -1,0 +1,121 @@
+import { Buffer } from 'buffer';
+import type { Encoded } from '@aeternity/aepp-sdk';
+
+import type { ChainName } from '@/types';
+import type {
+  AeAddressLinkClaimResponse,
+  AeAddressLinkSubmitResponse,
+  AeAddressLinkUnclaimResponse,
+} from '@/protocols/aeternity/types';
+import { postJson } from '@/utils';
+import { useAeSdk } from '@/composables';
+import { useAeNetworkSettings } from './aeNetworkSettings';
+
+/**
+ * Base path of the preferred-AENS-name address-link endpoints.
+ * NOTE: the backend route is intentionally spelled `prefered-aens-name`.
+ */
+const PREFERRED_AENS_NAME_LINK_PATH = '/api/address-links/prefered-aens-name';
+
+/**
+ * Wraps the Superhero API (`api.superhero.com`) address-link flow used to set an
+ * account's preferred (default) `.chain` name. Instead of the account paying for
+ * an on-chain `link` transaction itself, the wallet signs a challenge message and
+ * the backend verifies name ownership, then broadcasts and pays for the tx.
+ */
+export function useAeAddressLinkBackend() {
+  const { getAeSdk } = useAeSdk();
+  const { aeActiveNetworkPredefinedSettings } = useAeNetworkSettings();
+
+  function getBaseUrl(): string {
+    const baseUrl = aeActiveNetworkPredefinedSettings.value.superheroApiUrl;
+    if (!baseUrl) {
+      throw new Error('Superhero API URL is not configured for the active network');
+    }
+    return baseUrl.replace(/\/$/, '');
+  }
+
+  /** Sign a backend-provided challenge with the active account, hex-encoded. */
+  async function signChallengeMessage(message: string): Promise<string> {
+    const aeSdk = await getAeSdk();
+    return Buffer.from(await aeSdk.signMessage(message)).toString('hex');
+  }
+
+  function claimPreferredAensName(
+    address: Encoded.AccountAddress,
+    value: ChainName,
+  ): Promise<AeAddressLinkClaimResponse> {
+    return postJson(`${getBaseUrl()}${PREFERRED_AENS_NAME_LINK_PATH}/claim`, {
+      body: { address, value },
+    });
+  }
+
+  function submitPreferredAensName(payload: {
+    address: Encoded.AccountAddress;
+    value: ChainName;
+    nonce: number;
+    signature: string;
+    verification_token: string;
+  }): Promise<AeAddressLinkSubmitResponse> {
+    return postJson(`${getBaseUrl()}${PREFERRED_AENS_NAME_LINK_PATH}/submit`, {
+      body: payload,
+    });
+  }
+
+  function unclaimPreferredAensName(
+    address: Encoded.AccountAddress,
+  ): Promise<AeAddressLinkUnclaimResponse> {
+    return postJson(`${getBaseUrl()}${PREFERRED_AENS_NAME_LINK_PATH}/unclaim`, {
+      body: { address },
+    });
+  }
+
+  function submitPreferredAensNameUnclaim(payload: {
+    address: Encoded.AccountAddress;
+    nonce: number;
+    signature: string;
+  }): Promise<AeAddressLinkSubmitResponse> {
+    return postJson(`${getBaseUrl()}${PREFERRED_AENS_NAME_LINK_PATH}/unclaim/submit`, {
+      body: payload,
+    });
+  }
+
+  /**
+   * Set `address`'s preferred `.chain` name: request a challenge, sign it, and let
+   * the backend broadcast (and pay for) the on-chain link. Returns the tx hash.
+   */
+  async function linkPreferredAensName(
+    address: Encoded.AccountAddress,
+    name: ChainName,
+  ): Promise<string> {
+    const claim = await claimPreferredAensName(address, name);
+    const signature = await signChallengeMessage(claim.message);
+    const { txHash } = await submitPreferredAensName({
+      address,
+      value: claim.value as ChainName,
+      nonce: claim.nonce,
+      signature,
+      verification_token: claim.verification_token,
+    });
+    return txHash;
+  }
+
+  /** Remove `address`'s preferred `.chain` name via the signed unclaim flow. */
+  async function unlinkPreferredAensName(
+    address: Encoded.AccountAddress,
+  ): Promise<string> {
+    const unclaim = await unclaimPreferredAensName(address);
+    const signature = await signChallengeMessage(unclaim.message);
+    const { txHash } = await submitPreferredAensNameUnclaim({
+      address,
+      nonce: unclaim.nonce,
+      signature,
+    });
+    return txHash;
+  }
+
+  return {
+    linkPreferredAensName,
+    unlinkPreferredAensName,
+  };
+}

--- a/src/protocols/aeternity/composables/aeAddressLinkContract.ts
+++ b/src/protocols/aeternity/composables/aeAddressLinkContract.ts
@@ -1,0 +1,111 @@
+import { computed } from 'vue';
+import { Contract, Encoded } from '@aeternity/aepp-sdk';
+
+import type { ChainName, NetworkTypeDefault } from '@/types';
+import { NETWORK_TYPE_CUSTOM, NETWORK_TYPE_TESTNET } from '@/constants';
+import { useAeSdk, useNetworks } from '@/composables';
+import AddressLinkACI from '@/protocols/aeternity/aci/AddressLinkACI.json';
+import type { AeAddressLinkContractApi } from '@/protocols/aeternity/types';
+import {
+  AE_ADDRESS_LINK_CONTRACTS,
+  AE_ADDRESS_LINK_PREFERRED_NAME_PROVIDER,
+} from '@/protocols/aeternity/config';
+
+let addressLinkContract: Contract<AeAddressLinkContractApi> | undefined;
+/**
+ * In-flight initialization, shared so that resolving names for many accounts at
+ * once (e.g. `Promise.all` over all local accounts) initializes the contract a
+ * single time instead of once per concurrent caller.
+ */
+let addressLinkContractPromise: Promise<Contract<AeAddressLinkContractApi>> | null = null;
+/**
+ * The contract address the in-flight `addressLinkContractPromise` targets. Bound
+ * so that a network switch mid-init does not hand a caller the previous network's
+ * deployment - callers wanting a different address start their own init instead.
+ */
+let initializingAddress: Encoded.ContractAddress | undefined;
+
+/**
+ * Reads account data stored in the on-chain AddressLink contract.
+ * Currently used to resolve an account's preferred (default) `.chain` name,
+ * previously served by the tipping backend as `preferredChainName`.
+ */
+export function useAeAddressLinkContract() {
+  const { activeNetwork } = useNetworks();
+  const { getAeSdk } = useAeSdk();
+
+  const addressLinkContractAddress = computed(
+    (): Encoded.ContractAddress | undefined => {
+      // Custom networks point at testnet infra (matching how the Superhero API URL
+      // is resolved), so read the preferred name from the testnet deployment there.
+      const networkType: NetworkTypeDefault = (activeNetwork.value.type === NETWORK_TYPE_CUSTOM)
+        ? NETWORK_TYPE_TESTNET
+        : activeNetwork.value.type;
+      return AE_ADDRESS_LINK_CONTRACTS[networkType];
+    },
+  );
+
+  async function getAddressLinkContract(): Promise<Contract<AeAddressLinkContractApi> | undefined> {
+    const contractAddress = addressLinkContractAddress.value;
+    if (!contractAddress) {
+      return undefined;
+    }
+    // Reuse the cached instance while the active network's contract is unchanged.
+    if (addressLinkContract?.$options.address === contractAddress) {
+      return addressLinkContract;
+    }
+    // Reuse the in-flight init only when it targets the same deployment, so a
+    // network switch mid-init doesn't return the previous network's contract.
+    if (!addressLinkContractPromise || initializingAddress !== contractAddress) {
+      initializingAddress = contractAddress;
+      const promise = (async () => {
+        const aeSdk = await getAeSdk();
+        return Contract.initialize<AeAddressLinkContractApi>({
+          ...aeSdk.getContext(),
+          aci: AddressLinkACI,
+          address: contractAddress,
+        });
+      })();
+      addressLinkContractPromise = promise;
+      promise
+        .then((contract) => {
+          // Cache for reuse only while the network hasn't moved on since.
+          if (initializingAddress === contractAddress) {
+            addressLinkContract = contract;
+          }
+        })
+        .catch(() => {})
+        .finally(() => {
+          if (addressLinkContractPromise === promise) {
+            addressLinkContractPromise = null;
+          }
+        });
+    }
+    return addressLinkContractPromise;
+  }
+
+  /**
+   * Resolve the preferred (default) `.chain` name for an address from the
+   * AddressLink contract. Returns `undefined` when the account has no preferred
+   * name set or the contract is not available on the active network.
+   */
+  async function getPreferredName(
+    address: Encoded.AccountAddress,
+  ): Promise<ChainName | undefined> {
+    const contract = await getAddressLinkContract();
+    if (!contract) {
+      return undefined;
+    }
+    const { decodedResult } = await contract.get_link(
+      address,
+      AE_ADDRESS_LINK_PREFERRED_NAME_PROVIDER,
+    );
+    return (decodedResult as ChainName) || undefined;
+  }
+
+  return {
+    addressLinkContractAddress,
+    getAddressLinkContract,
+    getPreferredName,
+  };
+}

--- a/src/protocols/aeternity/composables/aeNames.ts
+++ b/src/protocols/aeternity/composables/aeNames.ts
@@ -28,7 +28,6 @@ import type {
 import {
   decryptedComputed,
   fetchAllPages,
-  fetchJson,
   handleUnknownError,
 } from '@/utils';
 import {
@@ -55,7 +54,7 @@ import { UPDATE_POINTER_ACTION, AE_AENS_NAME_AUCTION_MAX_LENGTH } from '@/protoc
 import { aettosToAe, isInsufficientBalanceError } from '@/protocols/aeternity/helpers';
 import { AeAccountHdWallet } from '@/protocols/aeternity/libs/AeAccountHdWallet';
 
-import { useAeNetworkSettings } from './aeNetworkSettings';
+import { useAeAddressLinkContract } from './aeAddressLinkContract';
 import { useAeTippingBackend } from './aeTippingBackend';
 import { useAeMiddleware } from './aeMiddleware';
 
@@ -64,6 +63,12 @@ const FEE_ESTIMATION_ADDRESS = 'ak_enAPooFqpTQKkhJmU47J16QZu9HbPQQPwWBVeGnzDbDnv
 const FEE_ESTIMATION_NONCE = 10000;
 const PENDING_NAME_TRANSFER_TX_MAX_AGE = 5 * 60 * 1000;
 const EXTERNAL_NAME_CACHE_TTL = 10 * 60 * 1000;
+/**
+ * How long an optimistically-applied default-name change is protected from being
+ * overwritten by the on-chain polling while its `link`/`unlink` transaction is
+ * still being mined. After this the chain value is treated as authoritative again.
+ */
+const PENDING_DEFAULT_NAME_MAX_AGE = 5 * 60 * 1000;
 
 interface IUpdateNamePointerParams {
   name: ChainName;
@@ -124,11 +129,22 @@ interface IPendingNameTransferTx {
   createdAt: number;
 }
 
+/**
+ * An optimistically-applied default (preferred) name change awaiting its on-chain
+ * `link`/`unlink` transaction. `name` is an empty string when the default is being
+ * cleared. Kept so polling does not revert the change before it is mined.
+ */
+interface IPendingDefaultName {
+  name: ChainName | '';
+  createdAt: number;
+}
+
 interface aeNamesOptions {
   pollingDisabled?: boolean;
 }
 
 type NamesRegistry = Record<NetworkId, Record<AccountAddress, ChainName>>;
+type PendingDefaultNamesRegistry = Record<NetworkId, Record<AccountAddress, IPendingDefaultName>>;
 
 let composableInitialized = false;
 let claimPreclaimedNamesPromise: Promise<void> | null = null;
@@ -148,6 +164,16 @@ const externalNameLastFetchTime = new Map<string, number>();
 const externalNameInFlight = new Map<string, Promise<void>>();
 
 const ownedNames = useStorageRef<IName[]>([], STORAGE_KEYS.namesOwned);
+/**
+ * The network `ownedNames` was last fetched for. `ownedNames` is a flat list (not
+ * keyed by network), so anything derived from it - notably the last-claimed-name
+ * fallback - must check this first, or it would surface the previous network's
+ * names in the window between a network switch and the refetch landing.
+ */
+const ownedNamesNetworkId = useStorageRef<NetworkId | null>(
+  null,
+  STORAGE_KEYS.namesOwnedNetworkId,
+);
 const preclaimedNamesEncrypted = useStorageRef<string | null>(
   null,
   STORAGE_KEYS.preclaimedNames,
@@ -181,6 +207,45 @@ const areNamesFetching = ref(false);
  */
 const defaultNamesRegistry = useStorageRef<NamesRegistry>({}, STORAGE_KEYS.namesDefault);
 /**
+ * Optimistically-applied default-name changes whose `link`/`unlink` transaction
+ * is still being mined, protecting them from being reverted by the on-chain poll.
+ */
+const pendingDefaultNames = useStorageRef<PendingDefaultNamesRegistry>(
+  {},
+  STORAGE_KEYS.pendingDefaultNames,
+);
+/**
+ * Most recently claimed name per owner address, used to display a name for accounts
+ * that have no preferred name linked on-chain.
+ *
+ * Derived from `ownedNames`, which is already fetched and cached for the names list,
+ * so the fallback costs no extra requests. Recomputed only when `ownedNames` changes
+ * (not per render), keeping the `getName` lookup O(1).
+ */
+const latestClaimedNames = computed((): Record<AccountAddress, ChainName> => {
+  const latest: Record<AccountAddress, { name: ChainName; height: number }> = {};
+
+  ownedNames.value.forEach(({
+    name,
+    owner,
+    pending,
+    createdAtHeight,
+  }) => {
+    // Skip names that aren't confirmed on-chain yet (pending claims/transfers).
+    if (!owner || pending) {
+      return;
+    }
+    const height = createdAtHeight ?? 0;
+    if (!latest[owner] || height > latest[owner].height) {
+      latest[owner] = { name, height };
+    }
+  });
+
+  return Object.fromEntries(
+    Object.entries(latest).map(([address, { name }]) => [address, name]),
+  );
+});
+/**
  * Stores default names for a certain external account addresses in selected network
  */
 const externalNamesRegistry = ref<NamesRegistry>({});
@@ -203,10 +268,10 @@ export function useAeNames({ pollingDisabled = false }: aeNamesOptions = {}) {
     getLastActiveProtocolAccount,
   } = useAccounts();
   const { onNetworkChange } = useNetworks();
-  const { aeActiveNetworkSettings } = useAeNetworkSettings();
   const { openDefaultModal } = useModals();
   const { nodeNetworkId, getAeSdk } = useAeSdk();
   const { fetchCachedChainNames } = useAeTippingBackend();
+  const { getPreferredName } = useAeAddressLinkContract();
   const { topBlockHeight } = useTopHeaderData();
 
   const {
@@ -262,9 +327,9 @@ export function useAeNames({ pollingDisabled = false }: aeNamesOptions = {}) {
     }
 
     const promise = (async () => {
-      let response: { preferredChainName?: ChainName } | null;
+      let preferredName: ChainName | undefined;
       try {
-        response = await fetchJson(`${aeActiveNetworkSettings.value.backendUrl}/profile/${address}`);
+        preferredName = await getPreferredName(address as Encoded.AccountAddress);
       } catch {
         return;
       }
@@ -275,8 +340,8 @@ export function useAeNames({ pollingDisabled = false }: aeNamesOptions = {}) {
         return;
       }
 
-      if (response?.preferredChainName) {
-        externalNamesRegistry.value[networkId][address] = response.preferredChainName;
+      if (preferredName) {
+        externalNamesRegistry.value[networkId][address] = preferredName;
       } else {
         delete externalNamesRegistry.value[networkId][address];
       }
@@ -289,6 +354,18 @@ export function useAeNames({ pollingDisabled = false }: aeNamesOptions = {}) {
     return promise;
   }
 
+  /**
+   * The preferred (default) name explicitly linked on-chain for an address, with no
+   * fallback. Use this to tell whether a default is actually set (e.g. to decide if a
+   * name can still be made the default); use `getName` for display.
+   */
+  function getDefaultName(address?: AccountAddress): ComputedRef<ChainName | string> {
+    if (!address || !nodeNetworkId.value) {
+      return computed(() => '');
+    }
+    return computed(() => defaultNamesRegistry.value[nodeNetworkId.value!]?.[address] || '');
+  }
+
   // This function returns computed value to have reactive state and show proper data after fetching
   function getName(address?: AccountAddress): ComputedRef<ChainName | string> {
     if (!address || !nodeNetworkId.value) {
@@ -299,7 +376,19 @@ export function useAeNames({ pollingDisabled = false }: aeNamesOptions = {}) {
       isLocalAccountAddress(address)
       || getLastActiveProtocolAccount(PROTOCOLS.aeternity)?.address === address
     ) {
-      return computed(() => defaultNamesRegistry.value[nodeNetworkId.value!]?.[address] || '');
+      // Without a linked preferred name, fall back to the account's most recently
+      // claimed name so the account still displays a name instead of nothing. Only
+      // usable while `ownedNames` belongs to the active network - otherwise the
+      // previous network's names would leak through until the refetch lands.
+      return computed(() => (
+        defaultNamesRegistry.value[nodeNetworkId.value!]?.[address]
+        || (
+          (ownedNamesNetworkId.value === nodeNetworkId.value)
+            ? latestClaimedNames.value[address]
+            : undefined
+        )
+        || ''
+      ));
     }
 
     updateExternalName(address);
@@ -328,7 +417,9 @@ export function useAeNames({ pollingDisabled = false }: aeNamesOptions = {}) {
       .reduce((a, b) => (a.nameFee.isGreaterThan(b.nameFee) ? a : b));
   }
 
-  function setDefaultName({ address, name }: IAddressNamePair) {
+  function setDefaultName(
+    { address, name }: Partial<IAddressNamePair> & { address: AccountAddress },
+  ) {
     if (!nodeNetworkId.value) {
       return;
     }
@@ -341,6 +432,32 @@ export function useAeNames({ pollingDisabled = false }: aeNamesOptions = {}) {
     } else {
       delete defaultNamesRegistry.value[nodeNetworkId.value][address];
     }
+  }
+
+  function removePendingDefaultName(networkId: NetworkId, address: AccountAddress) {
+    delete pendingDefaultNames.value[networkId]?.[address];
+    if (isEmpty(pendingDefaultNames.value[networkId])) {
+      delete pendingDefaultNames.value[networkId];
+    }
+  }
+
+  /**
+   * Optimistically apply a default-name change (set or, with an empty `name`,
+   * clear) and record a pending marker so the on-chain poll does not revert it
+   * before the backend-sponsored `link`/`unlink` transaction is mined.
+   */
+  function setDefaultNameOptimistic(
+    { address, name }: { address: AccountAddress; name: ChainName | '' },
+  ) {
+    const networkId = nodeNetworkId.value;
+    if (!networkId) {
+      return;
+    }
+    if (!pendingDefaultNames.value[networkId]) {
+      pendingDefaultNames.value[networkId] = {};
+    }
+    pendingDefaultNames.value[networkId][address] = { name, createdAt: Date.now() };
+    setDefaultName({ address, name: name || undefined });
   }
 
   function setAutoExtend(name: ChainName) {
@@ -673,6 +790,12 @@ export function useAeNames({ pollingDisabled = false }: aeNamesOptions = {}) {
         }
       });
 
+      // The network may have changed while the names were being fetched - publishing
+      // them now would show the previous network's names on the new one.
+      if (nodeNetworkId.value !== currentNetworkId) {
+        return;
+      }
+
       const pendingTransfers = pendingNameTransferTxs.value[currentNetworkId] || {};
       ownedNames.value = names.map((ownedName) => {
         const pendingTransfer = pendingTransfers[ownedName.name];
@@ -686,6 +809,7 @@ export function useAeNames({ pollingDisabled = false }: aeNamesOptions = {}) {
             : ownedName.pendingStatus,
         };
       });
+      ownedNamesNetworkId.value = currentNetworkId;
     } catch (error: any) {
       handleUnknownError(error);
     } finally {
@@ -695,16 +819,28 @@ export function useAeNames({ pollingDisabled = false }: aeNamesOptions = {}) {
 
   async function processDefaultNamesUpdate() {
     await Promise.all(aeAccounts.value.map(async ({ address }) => {
-      const currentNodeId = nodeNetworkId.value;
-      const response = await fetchJson(
-        `${aeActiveNetworkSettings.value.backendUrl}/profile/${address}`,
-      ).catch(() => ({}));
+      const currentNodeId = nodeNetworkId.value!;
+      const preferredName = await getPreferredName(address as Encoded.AccountAddress)
+        .catch(() => undefined);
 
       if (currentNodeId !== nodeNetworkId.value) {
         return;
       }
 
-      setDefaultName({ address, name: response?.preferredChainName });
+      // An optimistic set/clear may still be waiting for its on-chain tx to mine.
+      // Until the chain reflects the change (or the marker expires) keep the
+      // optimistic value instead of reverting it to stale chain data.
+      const pending = pendingDefaultNames.value[currentNodeId]?.[address];
+      if (pending) {
+        const chainMatchesPending = (preferredName || '') === pending.name;
+        const isExpired = Date.now() - pending.createdAt > PENDING_DEFAULT_NAME_MAX_AGE;
+        if (!chainMatchesPending && !isExpired) {
+          return;
+        }
+        removePendingDefaultName(currentNodeId, address);
+      }
+
+      setDefaultName({ address, name: preferredName });
     }));
   }
 
@@ -1060,6 +1196,7 @@ export function useAeNames({ pollingDisabled = false }: aeNamesOptions = {}) {
     updateOwnedNames,
     resolvedChainNames,
     getName,
+    getDefaultName,
     getNameExtendFee,
     getNameByNameHash,
     getNameAuction,
@@ -1069,5 +1206,7 @@ export function useAeNames({ pollingDisabled = false }: aeNamesOptions = {}) {
     setAuctionEntry,
     setPendingAutoExtendName,
     setDefaultName,
+    setDefaultNameOptimistic,
+    updateDefaultNames,
   };
 }

--- a/src/protocols/aeternity/composables/index.ts
+++ b/src/protocols/aeternity/composables/index.ts
@@ -1,3 +1,5 @@
+export * from './aeAddressLinkBackend';
+export * from './aeAddressLinkContract';
 export * from './aeMiddleware';
 export * from './aeNetworkSettings';
 export * from './aeTippingBackend';

--- a/src/protocols/aeternity/config.ts
+++ b/src/protocols/aeternity/config.ts
@@ -1,4 +1,4 @@
-import { Encoding, Tag } from '@aeternity/aepp-sdk';
+import { Encoded, Encoding, Tag } from '@aeternity/aepp-sdk';
 import type {
   DexFunctionType,
   IDefaultNetworkTypeData,
@@ -59,10 +59,12 @@ export const AE_NETWORK_ADDITIONAL_SETTINGS: IDefaultNetworkTypeData<
   [NETWORK_TYPE_MAINNET]: {
     explorerUrl: 'https://aescan.io',
     multisigBackendUrl: 'https://ga-multisig-backend-mainnet.prd.service.aepps.com',
+    superheroApiUrl: 'https://api.superhero.com',
   },
   [NETWORK_TYPE_TESTNET]: {
     explorerUrl: 'https://testnet.aescan.io',
     multisigBackendUrl: 'https://ga-multisig-backend-testnet.prd.service.aepps.com',
+    superheroApiUrl: 'https://testnet.api.dev.tokensale.org',
   },
 };
 
@@ -282,6 +284,22 @@ export const AE_TIPPING_CONTRACTS_MAINNET: AeTippingContractAddresses = {
 export const AE_TIPPING_CONTRACTS_TESTNET: AeTippingContractAddresses = {
   tippingV1: 'ct_2Cvbf3NYZ5DLoaNYAU71t67DdXLHeSXhodkSNifhgd7Xsw28Xd',
   tippingV2: 'ct_2ZEoCKcqXkbz2uahRrsWeaPooZs9SdCv6pmC4kc55rD4MhqYSu',
+};
+
+/**
+ * Provider key under which the AddressLink contract stores an account's
+ * preferred `.chain` name (formerly served by the tipping backend as
+ * `preferredChainName`).
+ */
+export const AE_ADDRESS_LINK_PREFERRED_NAME_PROVIDER = 'prefaens';
+
+/**
+ * AddressLink contract deployments per network type. Used to resolve accounts'
+ * preferred (default) `.chain` names on-chain instead of via the backend.
+ */
+export const AE_ADDRESS_LINK_CONTRACTS: Partial<Record<string, Encoded.ContractAddress>> = {
+  [NETWORK_TYPE_MAINNET]: 'ct_2rxYHp3GThDMMCoYZbFdjgUAeiKwFMhQ72ohYFt463t1A53knS',
+  [NETWORK_TYPE_TESTNET]: 'ct_Fdw5ftxSS3asjXrt7fnTwSgzFBxV7kKkgtQPCZpkDyYAwGDUt',
 };
 
 export const UPDATE_POINTER_ACTION = {

--- a/src/protocols/aeternity/types.ts
+++ b/src/protocols/aeternity/types.ts
@@ -15,7 +15,8 @@ export type AeNetworkProtocolSettings =
  */
 export type AeNetworkProtocolPredefinedSettings =
   | 'explorerUrl'
-  | 'multisigBackendUrl';
+  | 'multisigBackendUrl'
+  | 'superheroApiUrl';
 
 export type IAeNetworkSettings = INetworkProtocolSettings<AeNetworkProtocolSettings>;
 
@@ -49,6 +50,34 @@ export interface AeTippingContracts {
 export interface AeTippingContractAddresses {
   tippingV1?: Encoded.ContractAddress;
   tippingV2?: Encoded.ContractAddress;
+}
+
+export interface AeAddressLinkContractApi extends ContractMethodsBase {
+  get_link: (addr: Encoded.AccountAddress, provider: string) => string | undefined;
+  get_links: (addr: Encoded.AccountAddress) => Map<string, string>;
+}
+
+/**
+ * Response of the Superhero API `.../claim` address-link endpoints. The wallet
+ * signs `message` to prove ownership; the backend then broadcasts (and pays for)
+ * the on-chain `link` transaction on `.../submit`.
+ */
+export interface AeAddressLinkClaimResponse {
+  message: string;
+  nonce: number;
+  value: string;
+  verification_token: string;
+}
+
+/** Response of the Superhero API `.../unclaim` address-link endpoints. */
+export interface AeAddressLinkUnclaimResponse {
+  message: string;
+  nonce: number;
+}
+
+/** Response of the Superhero API `.../submit` address-link endpoints. */
+export interface AeAddressLinkSubmitResponse {
+  txHash: string;
 }
 
 export interface AeDecodedCallData {

--- a/tests/unit/popup/components/NameItem.spec.js
+++ b/tests/unit/popup/components/NameItem.spec.js
@@ -1,13 +1,13 @@
 import { mount } from '@vue/test-utils';
 import { computed as mockComputed, ref as mockRef } from 'vue';
 
-const mockPostJson = vi.fn();
 const mockHandleUnknownError = vi.fn();
 const mockOpenConfirmModal = vi.fn();
 const mockUpdateNamePointer = vi.fn();
 const mockUpdateOwnedNames = vi.fn();
-const mockFetchRespondChallenge = vi.fn();
-const mockSetDefaultName = vi.fn();
+const mockLinkPreferredAensName = vi.fn();
+const mockUnlinkPreferredAensName = vi.fn();
+const mockSetDefaultNameOptimistic = vi.fn();
 let NameItem;
 
 vi.mock('@aeternity/aepp-sdk', () => ({
@@ -26,7 +26,6 @@ vi.mock('vue-i18n', () => ({
 vi.mock('@/utils', () => ({
   blocksToRelativeTime: vi.fn(() => '1 day'),
   handleUnknownError: mockHandleUnknownError,
-  postJson: mockPostJson,
 }));
 
 vi.mock('@/composables', () => ({
@@ -35,7 +34,6 @@ vi.mock('@/composables', () => ({
   })),
   useAeSdk: vi.fn(() => ({
     nodeNetworkId: mockRef('ae_testnet'),
-    fetchRespondChallenge: mockFetchRespondChallenge,
   })),
   useModals: vi.fn(() => ({
     openConfirmModal: mockOpenConfirmModal,
@@ -56,7 +54,7 @@ vi.mock('@/protocols/aeternity/composables/aeNames', () => ({
   useAeNames: vi.fn(() => ({
     setAutoExtend: vi.fn(),
     updateNamePointer: mockUpdateNamePointer,
-    getName: vi.fn(() => mockComputed(() => 'default.chain')),
+    getDefaultName: vi.fn(() => mockComputed(() => 'default.chain')),
     getNameExtendFee: vi.fn(() => 0.001),
     extendExpiringOwnedNames: vi.fn(),
     ownedNames: mockRef([{
@@ -66,13 +64,14 @@ vi.mock('@/protocols/aeternity/composables/aeNames', () => ({
       pointers: { accountPubkey: 'ak_test' },
     }]),
     updateOwnedNames: mockUpdateOwnedNames,
-    setDefaultName: mockSetDefaultName,
+    setDefaultNameOptimistic: mockSetDefaultNameOptimistic,
   })),
 }));
 
 vi.mock('@/protocols/aeternity/composables', () => ({
-  useAeNetworkSettings: vi.fn(() => ({
-    aeActiveNetworkSettings: mockRef({ backendUrl: 'https://backend.test' }),
+  useAeAddressLinkBackend: vi.fn(() => ({
+    linkPreferredAensName: mockLinkPreferredAensName,
+    unlinkPreferredAensName: mockUnlinkPreferredAensName,
   })),
 }));
 
@@ -98,8 +97,8 @@ describe('NameItem', () => {
     mockOpenConfirmModal.mockResolvedValue(undefined);
     mockUpdateNamePointer.mockResolvedValue(true);
     mockUpdateOwnedNames.mockResolvedValue(undefined);
-    mockFetchRespondChallenge.mockResolvedValue({ signed: true });
-    mockPostJson.mockResolvedValue({ challenge: true });
+    mockLinkPreferredAensName.mockResolvedValue('th_link');
+    mockUnlinkPreferredAensName.mockResolvedValue('th_unlink');
   });
 
   it('clears the backend default name when transferring the default without a fallback', async () => {
@@ -139,15 +138,47 @@ describe('NameItem', () => {
       address: 'ak_recipient',
       type: 'transfer',
     });
-    expect(mockPostJson).toHaveBeenNthCalledWith(1, 'https://backend.test/profile/ak_test', {
-      body: {
-        preferredChainName: '',
+    // Clearing the default name uses the signed unlink flow, not a link.
+    expect(mockUnlinkPreferredAensName).toHaveBeenCalledWith('ak_test');
+    expect(mockLinkPreferredAensName).not.toHaveBeenCalled();
+    expect(mockSetDefaultNameOptimistic).toHaveBeenCalledWith({ address: 'ak_test', name: '' });
+    expect(mockHandleUnknownError).not.toHaveBeenCalled();
+  });
+
+  it('sets the default name through the signed link flow', async () => {
+    const wrapper = mount(NameItem, {
+      props: {
+        nameEntry: {
+          name: 'default.chain',
+          owner: 'ak_test',
+          pending: false,
+          pointers: { accountPubkey: 'ak_test' },
+          createdAtHeight: 1,
+          expiresAt: 150,
+          autoExtend: false,
+          hash: 'nm_default',
+        },
+      },
+      global: {
+        stubs: {
+          BtnHelp: true,
+          BtnPlain: true,
+          DetailsItem: true,
+          InputField: true,
+          Truncate: true,
+          Transition: false,
+        },
+        mocks: {
+          $t: (key) => key,
+        },
       },
     });
-    expect(mockFetchRespondChallenge).toHaveBeenCalledWith({ challenge: true });
-    expect(mockPostJson).toHaveBeenNthCalledWith(2, 'https://backend.test/profile/ak_test', {
-      body: { signed: true },
-    });
+
+    await wrapper.vm.handleSetDefault();
+
+    expect(mockLinkPreferredAensName).toHaveBeenCalledWith('ak_test', 'default.chain');
+    expect(mockUnlinkPreferredAensName).not.toHaveBeenCalled();
+    expect(mockSetDefaultNameOptimistic).toHaveBeenCalledWith({ address: 'ak_test', name: 'default.chain' });
     expect(mockHandleUnknownError).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/protocols/aeternity/composables/aeAddressLinkBackend.spec.js
+++ b/tests/unit/protocols/aeternity/composables/aeAddressLinkBackend.spec.js
@@ -1,0 +1,97 @@
+import { ref } from 'vue';
+
+/**
+ * `useAeAddressLinkBackend` drives the Superhero API preferred-AENS-name flow:
+ * request a challenge (`/claim` or `/unclaim`), sign it with the active account,
+ * then POST the signature to `/submit` so the backend broadcasts (and pays for)
+ * the on-chain link. `postJson` (the HTTP boundary), the SDK message signing and
+ * the network settings are mocked so the tests assert the request payloads, the
+ * hex signature and the base-URL handling.
+ */
+
+const BASE_PATH = '/api/address-links/prefered-aens-name';
+
+async function loadComposable(opts = {}) {
+  const superheroApiUrl = 'superheroApiUrl' in opts ? opts.superheroApiUrl : 'https://api.test';
+  const signature = opts.signature ?? new Uint8Array([1, 2, 255]);
+  vi.resetModules();
+
+  const postJson = vi.fn().mockImplementation((url) => {
+    if (url.endsWith('/unclaim')) return Promise.resolve({ message: 'sign-unlink', nonce: 9 });
+    if (url.endsWith('/claim')) {
+      return Promise.resolve({
+        message: 'sign-me', nonce: 7, value: 'name.chain', verification_token: 'vt',
+      });
+    }
+    if (url.endsWith('/submit')) return Promise.resolve({ txHash: 'th_ok' });
+    return Promise.resolve(null);
+  });
+  const signMessage = vi.fn().mockResolvedValue(signature);
+  const getAeSdk = vi.fn().mockResolvedValue({ signMessage });
+
+  vi.doMock('@/utils', () => ({ postJson }));
+  vi.doMock('@/composables', () => ({ useAeSdk: () => ({ getAeSdk }) }));
+  vi.doMock('@/protocols/aeternity/composables/aeNetworkSettings', () => ({
+    useAeNetworkSettings: () => ({
+      aeActiveNetworkPredefinedSettings: ref({ superheroApiUrl }),
+    }),
+  }));
+
+  const mod = await import('@/protocols/aeternity/composables/aeAddressLinkBackend');
+  return { composable: mod.useAeAddressLinkBackend(), postJson, signMessage };
+}
+
+describe('useAeAddressLinkBackend', () => {
+  it('links a preferred name via claim -> sign -> submit', async () => {
+    const { composable, postJson, signMessage } = await loadComposable();
+
+    const txHash = await composable.linkPreferredAensName('ak_test', 'name.chain');
+
+    expect(postJson).toHaveBeenNthCalledWith(1, `https://api.test${BASE_PATH}/claim`, {
+      body: { address: 'ak_test', value: 'name.chain' },
+    });
+    // The backend-issued challenge is what gets signed.
+    expect(signMessage).toHaveBeenCalledWith('sign-me');
+    // Signature is the hex encoding of the raw signed bytes.
+    expect(postJson).toHaveBeenNthCalledWith(2, `https://api.test${BASE_PATH}/submit`, {
+      body: {
+        address: 'ak_test',
+        value: 'name.chain',
+        nonce: 7,
+        signature: '0102ff',
+        verification_token: 'vt',
+      },
+    });
+    expect(txHash).toBe('th_ok');
+  });
+
+  it('unlinks a preferred name via unclaim -> sign -> submit', async () => {
+    const { composable, postJson, signMessage } = await loadComposable();
+
+    const txHash = await composable.unlinkPreferredAensName('ak_test');
+
+    expect(postJson).toHaveBeenNthCalledWith(1, `https://api.test${BASE_PATH}/unclaim`, {
+      body: { address: 'ak_test' },
+    });
+    expect(signMessage).toHaveBeenCalledWith('sign-unlink');
+    expect(postJson).toHaveBeenNthCalledWith(2, `https://api.test${BASE_PATH}/unclaim/submit`, {
+      body: { address: 'ak_test', nonce: 9, signature: '0102ff' },
+    });
+    expect(txHash).toBe('th_ok');
+  });
+
+  it('strips a trailing slash from the configured API URL', async () => {
+    const { composable, postJson } = await loadComposable({ superheroApiUrl: 'https://api.test/' });
+
+    await composable.linkPreferredAensName('ak_test', 'name.chain');
+
+    expect(postJson).toHaveBeenNthCalledWith(1, `https://api.test${BASE_PATH}/claim`, expect.anything());
+  });
+
+  it('throws when the Superhero API URL is not configured for the network', async () => {
+    const { composable, postJson } = await loadComposable({ superheroApiUrl: undefined });
+
+    await expect(composable.linkPreferredAensName('ak_test', 'name.chain')).rejects.toThrow();
+    expect(postJson).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/protocols/aeternity/composables/aeAddressLinkContract.spec.js
+++ b/tests/unit/protocols/aeternity/composables/aeAddressLinkContract.spec.js
@@ -1,0 +1,135 @@
+import { ref } from 'vue';
+
+/**
+ * `useAeAddressLinkContract` reads the preferred `.chain` name from the on-chain
+ * AddressLink contract. The aeternity SDK (`Contract.initialize`), the network
+ * boundary (`useAeSdk`/`useNetworks`) and the address config are mocked so the
+ * tests assert the composable's own logic: network-type resolution, the
+ * `get_link(addr, 'prefaens')` decode, and single/deduped contract init.
+ *
+ * `@/constants` is kept real (plain `NETWORK_TYPE_*` string constants) so the
+ * mocked `AE_ADDRESS_LINK_CONTRACTS` keys line up with the resolved network type.
+ */
+
+const CONTRACTS = { mainnet: 'ct_main', testnet: 'ct_test' };
+const PROVIDER = 'prefaens';
+
+const flush = () => new Promise((resolve) => { setTimeout(resolve, 0); });
+
+async function loadComposable({
+  networkType = 'testnet',
+  getLinkResult = { decodedResult: 'name.chain' },
+  network,
+  contractInitialize: customInit,
+} = {}) {
+  vi.resetModules();
+
+  const activeNetwork = network || ref({ type: networkType });
+  const getContext = vi.fn(() => ({ ctx: true }));
+  const getAeSdk = vi.fn().mockResolvedValue({ getContext });
+  const getLink = vi.fn().mockResolvedValue(getLinkResult);
+  const contractInitialize = customInit || vi.fn().mockImplementation(async ({ address }) => ({
+    $options: { address },
+    get_link: getLink,
+  }));
+
+  vi.doMock('@aeternity/aepp-sdk', () => ({
+    Contract: { initialize: contractInitialize },
+  }));
+  vi.doMock('@/composables', () => ({
+    useAeSdk: () => ({ getAeSdk }),
+    useNetworks: () => ({ activeNetwork }),
+  }));
+  vi.doMock('@/protocols/aeternity/config', () => ({
+    AE_ADDRESS_LINK_CONTRACTS: CONTRACTS,
+    AE_ADDRESS_LINK_PREFERRED_NAME_PROVIDER: PROVIDER,
+  }));
+
+  const mod = await import('@/protocols/aeternity/composables/aeAddressLinkContract');
+  return {
+    composable: mod.useAeAddressLinkContract(),
+    contractInitialize,
+    getLink,
+    getAeSdk,
+    activeNetwork,
+  };
+}
+
+describe('useAeAddressLinkContract', () => {
+  it('resolves the preferred name via get_link(addr, prefaens)', async () => {
+    const { composable, getLink } = await loadComposable();
+
+    const name = await composable.getPreferredName('ak_test');
+
+    expect(getLink).toHaveBeenCalledWith('ak_test', PROVIDER);
+    expect(name).toBe('name.chain');
+  });
+
+  it('returns undefined when the account has no preferred name (None)', async () => {
+    const { composable } = await loadComposable({ getLinkResult: { decodedResult: undefined } });
+
+    expect(await composable.getPreferredName('ak_test')).toBeUndefined();
+  });
+
+  it('returns undefined without initializing when no contract is configured', async () => {
+    const { composable, contractInitialize } = await loadComposable({ networkType: 'unconfigured' });
+
+    expect(await composable.getPreferredName('ak_test')).toBeUndefined();
+    expect(contractInitialize).not.toHaveBeenCalled();
+  });
+
+  it('resolves custom networks to the testnet deployment', async () => {
+    const { composable } = await loadComposable({ networkType: 'custom' });
+
+    expect(composable.addressLinkContractAddress.value).toBe(CONTRACTS.testnet);
+  });
+
+  it('initializes the contract only once for concurrent reads', async () => {
+    const { composable, contractInitialize } = await loadComposable();
+
+    await Promise.all([
+      composable.getPreferredName('ak_a'),
+      composable.getPreferredName('ak_b'),
+      composable.getPreferredName('ak_c'),
+    ]);
+
+    expect(contractInitialize).toHaveBeenCalledTimes(1);
+    expect(contractInitialize).toHaveBeenCalledWith(
+      expect.objectContaining({ address: CONTRACTS.testnet }),
+    );
+  });
+
+  it('reuses the cached contract instance across sequential reads', async () => {
+    const { composable, contractInitialize } = await loadComposable();
+
+    await composable.getPreferredName('ak_a');
+    await composable.getPreferredName('ak_b');
+
+    expect(contractInitialize).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not return the previous network contract after a mid-init switch', async () => {
+    // Hold each initialization open until its address is explicitly resolved.
+    const resolvers = {};
+    const contractInitialize = vi.fn(({ address }) => new Promise((resolve) => {
+      resolvers[address] = () => resolve({ $options: { address }, get_link: vi.fn() });
+    }));
+    const activeNetwork = ref({ type: 'mainnet' });
+    const { composable } = await loadComposable({ network: activeNetwork, contractInitialize });
+
+    const mainnetContract = composable.getAddressLinkContract(); // targets ct_main
+    activeNetwork.value = { type: 'testnet' }; // switch mid-init
+    const testnetContract = composable.getAddressLinkContract(); // targets ct_test
+    await flush();
+
+    // A separate init was started per deployment; the switch didn't reuse the first.
+    expect(contractInitialize).toHaveBeenCalledTimes(2);
+
+    resolvers[CONTRACTS.mainnet]();
+    resolvers[CONTRACTS.testnet]();
+    const [c1, c2] = await Promise.all([mainnetContract, testnetContract]);
+
+    expect(c1.$options.address).toBe(CONTRACTS.mainnet);
+    expect(c2.$options.address).toBe(CONTRACTS.testnet);
+  });
+});

--- a/tests/unit/protocols/aeternity/composables/aeNames.spec.js
+++ b/tests/unit/protocols/aeternity/composables/aeNames.spec.js
@@ -123,9 +123,12 @@ const createTestContext = async ({
       getLastActiveProtocolAccount: () => ({ address: 'ak_test' }),
     }),
   }));
+  // A single shared ref (not a fresh one per `useAeSdk()` call) so tests can switch
+  // the active network and have the composable observe it.
+  const nodeNetworkId = ref('ae_testnet');
   vi.doMock('@/composables/aeSdk', () => ({
     useAeSdk: () => ({
-      nodeNetworkId: ref('ae_testnet'),
+      nodeNetworkId,
       getAeSdk: vi.fn().mockResolvedValue(sdk),
     }),
   }));
@@ -157,6 +160,13 @@ const createTestContext = async ({
       getMiddleware: vi.fn().mockResolvedValue({ getNames }),
       fetchFromMiddlewareCamelCased: vi.fn(),
     }),
+  }));
+
+  // The preferred (default) name now comes from the on-chain AddressLink contract.
+  // Mock the reader so default-name polling is deterministic and offline.
+  const getPreferredName = vi.fn().mockResolvedValue(undefined);
+  vi.doMock('@/protocols/aeternity/composables/aeAddressLinkContract', () => ({
+    useAeAddressLinkContract: () => ({ getPreferredName }),
   }));
 
   // Seed real `localStorage` BEFORE `registerAdapters` (below) is imported.
@@ -192,6 +202,8 @@ const createTestContext = async ({
     aeNames,
     fetchPendingTransactions,
     fetchAllPages,
+    getPreferredName,
+    nodeNetworkId,
     sdk,
     openDefaultModal,
     NAME_CLAIM_STATUS: aeNamesModule.NAME_CLAIM_STATUS,
@@ -821,5 +833,142 @@ describe('useAeNames name transfers', () => {
       pending: false,
       pendingStatus: undefined,
     });
+  });
+});
+
+describe('useAeNames default (preferred) names', () => {
+  it('keeps an optimistic default name while its link tx is still unmined', async () => {
+    const { aeNames, getPreferredName } = await createTestContext();
+    // The link tx has been broadcast but not mined, so the chain still has no name.
+    getPreferredName.mockResolvedValue(undefined);
+
+    aeNames.setDefaultNameOptimistic({ address: 'ak_test', name: 'new.chain' });
+    await aeNames.updateDefaultNames();
+
+    // Polling must not revert the optimistic value to the stale chain state.
+    expect(aeNames.getName('ak_test').value).toBe('new.chain');
+  });
+
+  it('adopts the chain value and stops protecting once the change is mined', async () => {
+    const { aeNames, getPreferredName } = await createTestContext();
+    aeNames.setDefaultNameOptimistic({ address: 'ak_test', name: 'new.chain' });
+
+    // Tx mined: the chain now returns the name, so the pending marker is cleared.
+    getPreferredName.mockResolvedValue('new.chain');
+    await aeNames.updateDefaultNames();
+    expect(aeNames.getName('ak_test').value).toBe('new.chain');
+
+    // With protection gone, a later chain change (e.g. name removed) is applied.
+    getPreferredName.mockResolvedValue(undefined);
+    await aeNames.updateDefaultNames();
+    expect(aeNames.getName('ak_test').value).toBe('');
+  });
+
+  it('clears the optimistic default name immediately and keeps it cleared while unmined', async () => {
+    const { aeNames, getPreferredName } = await createTestContext();
+    // Chain still reports the old name because the unlink tx is not mined yet.
+    getPreferredName.mockResolvedValue('old.chain');
+
+    aeNames.setDefaultNameOptimistic({ address: 'ak_test', name: '' });
+    expect(aeNames.getName('ak_test').value).toBe('');
+
+    await aeNames.updateDefaultNames();
+    expect(aeNames.getName('ak_test').value).toBe('');
+  });
+});
+
+describe('useAeNames last-claimed-name fallback', () => {
+  /** Middleware-shaped name; `activeFrom` becomes the claim height (`createdAtHeight`). */
+  const middlewareName = (name, activeFrom, owner = 'ak_test') => ({
+    info: {
+      activeFrom,
+      expireHeight: 50000,
+      ownership: { current: owner },
+      pointers: { accountPubkey: owner },
+    },
+    name,
+    hash: `nm_${name}`,
+  });
+
+  /**
+   * Names are published through `updateOwnedNames` (rather than assigned onto
+   * `ownedNames` directly) so they get tagged with the network they belong to -
+   * which is exactly what the fallback checks before using them.
+   */
+  const publishOwnedNames = async ({ aeNames, fetchAllPages }, names) => {
+    fetchAllPages.mockResolvedValueOnce(names);
+    await aeNames.updateOwnedNames();
+  };
+
+  it('falls back to the most recently claimed name when no default is set', async () => {
+    const ctx = await createTestContext();
+    await publishOwnedNames(ctx, [
+      middlewareName('older.chain', 10),
+      middlewareName('newest.chain', 30),
+      middlewareName('middle.chain', 20),
+    ]);
+
+    expect(ctx.aeNames.getName('ak_test').value).toBe('newest.chain');
+    // The fallback is a display convenience - no default is actually linked on-chain.
+    expect(ctx.aeNames.getDefaultName('ak_test').value).toBe('');
+  });
+
+  it('prefers the linked default name over the last claimed name', async () => {
+    const ctx = await createTestContext();
+    await publishOwnedNames(ctx, [middlewareName('newest.chain', 30)]);
+    ctx.getPreferredName.mockResolvedValue('preferred.chain');
+
+    await ctx.aeNames.updateDefaultNames();
+
+    expect(ctx.aeNames.getName('ak_test').value).toBe('preferred.chain');
+    expect(ctx.aeNames.getDefaultName('ak_test').value).toBe('preferred.chain');
+  });
+
+  it('ignores names that are not confirmed on-chain yet', async () => {
+    const ctx = await createTestContext();
+    // A newer, still-pending claim must not win over the confirmed name.
+    ctx.fetchPendingTransactions.mockResolvedValueOnce([{
+      hash: 'th_claiming',
+      pending: true,
+      tx: { type: 'NameClaimTx', accountId: 'ak_test', name: 'claiming.chain' },
+    }]);
+    await publishOwnedNames(ctx, [middlewareName('confirmed.chain', 10)]);
+
+    expect(ctx.aeNames.getName('ak_test').value).toBe('confirmed.chain');
+  });
+
+  it('does not leak one account\'s claimed name to another account', async () => {
+    const ctx = await createTestContext();
+    await publishOwnedNames(ctx, [middlewareName('other.chain', 30, 'ak_other')]);
+
+    expect(ctx.aeNames.getName('ak_test').value).toBe('');
+  });
+
+  it('stops using the previous network\'s claimed names after a network switch', async () => {
+    const ctx = await createTestContext();
+    await publishOwnedNames(ctx, [middlewareName('testnet-only.chain', 30)]);
+    expect(ctx.aeNames.getName('ak_test').value).toBe('testnet-only.chain');
+
+    ctx.nodeNetworkId.value = 'ae_mainnet';
+
+    // The names still cached in memory belong to testnet - they must not show here.
+    expect(ctx.aeNames.getName('ak_test').value).toBe('');
+  });
+
+  it('does not publish names fetched for a network that is no longer active', async () => {
+    const ctx = await createTestContext();
+    let resolveNames;
+    ctx.fetchAllPages.mockImplementationOnce(() => new Promise((resolve) => {
+      resolveNames = resolve;
+    }));
+
+    const update = ctx.aeNames.updateOwnedNames();
+    await flushAsync(); // let the fetch actually start before switching
+    ctx.nodeNetworkId.value = 'ae_mainnet'; // switched while the fetch was in flight
+    resolveNames([middlewareName('testnet-only.chain', 30)]);
+    await update;
+
+    expect(ctx.aeNames.ownedNames.value).toEqual([]);
+    expect(ctx.aeNames.getName('ak_test').value).toBe('');
   });
 });


### PR DESCRIPTION
fixes #3632,
fixes #3599


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how preferred names are stored and resolved across the wallet UI and depends on Superhero API + message signing for writes; edge cases around network switches and optimistic state are addressed but the flow is user-visible and cross-cutting.
> 
> **Overview**
> **Preferred (default) `.chain` names** move off the tipping backend profile API onto the on-chain **AddressLink** contract, with **Superhero API** handling sponsored link/unlink transactions.
> 
> Setting or clearing a default in **NameItem** now runs a **claim → sign challenge → submit** flow (`useAeAddressLinkBackend`) instead of POSTing `preferredChainName` to `/profile/{address}`. Reads and polling use **`getPreferredName`** from the contract (`prefaens` provider) via **`useAeAddressLinkContract`**, including per-network deployments and **`superheroApiUrl`** in network config.
> 
> **`useAeNames`** gains **`getDefaultName`** (on-chain default only) vs **`getName`** (default, then **most recently claimed** name for display), **`setDefaultNameOptimistic`** plus **`pendingDefaultNames`** so polling does not undo UI before the backend tx mines, and **`ownedNamesNetworkId`** / fetch guards so names and fallbacks do not bleed across network switches. External address resolution also reads AddressLink instead of the profile endpoint.
> 
> Unit tests cover the backend flow, contract reader, **NameItem** link/unlink, and the new default-name / fallback behavior in **aeNames**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7c7cbbdb30dc4a7d71487d71b239da116443d7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->