### PR TITLE
fix: disable the inAppBrowser window scrolling

### DIFF
--- a/src/popup/pages/AppsBrowser.vue
+++ b/src/popup/pages/AppsBrowser.vue
@@ -264,18 +264,15 @@ export default defineComponent({
 <style lang="scss" scoped>
 @use '@/styles/variables' as *;
 @use '@/styles/typography';
-@use '@/styles/mixins';
 
 .apps-browser {
   height: 100%;
 
   &.app-selected {
-    height: 100vh;
+    // Fill the content area exactly. Using viewport/extension height here would
+    // exceed it by the fixed header's height and make the whole page scrollable.
+    height: 100%;
     overflow: hidden;
-
-    @include mixins.desktop {
-      height: $extension-height;
-    }
   }
 
   .input-url {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CSS-only layout fix in AppsBrowser with no logic or security impact.
> 
> **Overview**
> When a dApp is open in the in-app browser, the main container no longer uses **viewport/extension height** (`100vh` / `$extension-height` on desktop). It now stays at **`height: 100%`** so it only fills the **PageWrapper content area** below the fixed header, with **`overflow: hidden`** unchanged.
> 
> That removes the extra height that counted the header and caused the **whole popup/page to scroll** instead of keeping scroll inside the iframe. The unused **`mixins`** import and the desktop-only height override were dropped as part of the same styling change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11b264d39655c6585e297cf9ccb2e1b1b4194ae7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->