### PR TITLE
Rewrite old mocked unit tests

### DIFF
--- a/tests/unit/composables/deepLinkApi.callback.spec.ts
+++ b/tests/unit/composables/deepLinkApi.callback.spec.ts
@@ -1,14 +1,25 @@
 // @ts-nocheck
 /**
- * Unit tests for HIGH-09 — the callback-URL validation layer added to
- * `useDeepLinkApi.openCallbackOrGoHome`. Everything outside of the
- * validation flow (router, modals, logger, window.open, timers) is mocked so
- * the tests pin down exactly:
- *   1. dangerous schemes are rejected outright,
- *   2. malformed URLs are rejected outright,
- *   3. the trusted aggregator origin is redirected to without a prompt,
- *   4. any other origin requires an explicit confirm-modal approval, and
- *   5. user rejection on that modal prevents the redirect.
+ * Unit tests for HIGH-09 — the callback-URL validation layer in
+ * `useDeepLinkApi.openCallbackOrGoHome`.
+ *
+ * The security logic itself (`validateCallbackUrl` / `isTrustedCallbackUrl` from
+ * `@/utils`) runs REAL here, together with the real `@/constants`, the real
+ * `@/popup/router/routeNames` and the real i18n. An earlier version of this file
+ * mocked `@/utils` and re-implemented those two functions inline, which meant the
+ * shipping security code was never actually exercised — the tests validated the
+ * test's own copy and would have stayed green through a regression in the real one.
+ * (That copy had also drifted: it rejected the `superhero:` / `wc:` app schemes that
+ * the real implementation explicitly trusts.)
+ *
+ * Only genuine external boundaries are stubbed:
+ *   - `vue-router`'s `useRoute` — the deeplink query IS the test input.
+ *   - `@ionic/vue`'s `useIonRouter` — needs an `IonPage` context. Partially mocked
+ *     (via `importOriginal`) so that `isPlatform`, which the real `@/constants`
+ *     imports from the same module, keeps working.
+ *   - `@/composables/modals` — the real one mounts modal components.
+ *   - `@/lib/logger` — telemetry side-effect, and the assertion target.
+ *   - `window.open` — actual browser navigation.
  */
 describe('useDeepLinkApi.openCallbackOrGoHome — security gating (HIGH-09)', () => {
   const routerReplace = vi.fn();
@@ -18,27 +29,6 @@ describe('useDeepLinkApi.openCallbackOrGoHome — security gating (HIGH-09)', ()
   let confirmModalImpl: () => Promise<void>;
   let route: { query: Record<string, string> };
 
-  const validateCallbackUrl = (rawUrl: string) => {
-    try {
-      const url = new URL(rawUrl);
-      if (['https:', 'http:'].includes(url.protocol)) return url;
-      return null;
-    } catch {
-      return null;
-    }
-  };
-
-  const isTrustedCallbackUrl = (url: URL) => {
-    const parsed = validateCallbackUrl(url.toString());
-    return !!parsed && (
-      url.protocol === 'https:'
-      && (
-        url.hostname === 'superhero.com'
-        || url.hostname.endsWith('.superhero.com')
-      )
-    );
-  };
-
   const setup = () => {
     vi.resetModules();
     routerReplace.mockClear();
@@ -46,25 +36,13 @@ describe('useDeepLinkApi.openCallbackOrGoHome — security gating (HIGH-09)', ()
     windowOpen.mockClear();
     openConfirmModalMock.mockClear();
 
-    vi.doMock('vue-router', () => ({
+    vi.doMock('vue-router', async (importOriginal) => ({
+      ...(await importOriginal()),
       useRoute: () => route,
-      RouteLocationNormalized: class {},
     }));
-    vi.doMock('@ionic/vue', () => ({
+    vi.doMock('@ionic/vue', async (importOriginal) => ({
+      ...(await importOriginal()),
       useIonRouter: () => ({ replace: routerReplace }),
-    }));
-    vi.doMock('@/popup/router/routeNames', () => ({ ROUTE_ACCOUNT: 'account' }));
-    vi.doMock('@/utils', () => ({
-      checkIfSuperheroCallbackUrl: () => false,
-      isTrustedCallbackUrl,
-      validateCallbackUrl,
-    }));
-    vi.doMock('@/constants', () => ({
-      AGGREGATOR_URL: 'https://superhero.com',
-      IS_IOS: false,
-      IS_MOBILE_APP: false,
-      IS_WEB: true,
-      MODAL_TRANSFER_SEND: 'transfer-send',
     }));
     vi.doMock('@/composables/modals', () => ({
       useModals: () => ({
@@ -76,352 +54,333 @@ describe('useDeepLinkApi.openCallbackOrGoHome — security gating (HIGH-09)', ()
       __esModule: true,
       default: { write: loggerWrite },
     }));
-    vi.doMock('@/popup/plugins/i18n', () => ({
-      tg: (key: string, params: Record<string, string> = {}) => {
-        if (key === 'pages.deepLink.invalidCallbackTitle') {
-          return 'Localized invalid callback title';
-        }
-        if (key === 'pages.deepLink.invalidCallbackMsg') {
-          return `Localized invalid callback message: ${params.url}`;
-        }
-        if (key === 'pages.deepLink.externalCallbackMsg') {
-          return `Localized external callback message: ${params.url}`;
-        }
-        return key;
-      },
-    }));
 
-    // Stub `window.open` on the jsdom window used by jest
-    (global as any).window = Object.assign((global as any).window || {}, {
-      open: windowOpen,
-    });
+    window.open = windowOpen;
   };
 
-  beforeEach(async () => {
+  const loadApi = async () => {
+    const { useDeepLinkApi } = await import('@/composables/deepLinkApi');
+    return useDeepLinkApi();
+  };
+
+  beforeEach(() => {
     confirmModalImpl = () => Promise.resolve();
     openConfirmModalMock.mockImplementation(() => confirmModalImpl());
     route = { query: {} };
     setup();
   });
 
-  it('rejects javascript: callback without any redirect and logs a modal-visible error', async () => {
-    route = {
-      query: {
-        // eslint-disable-next-line no-script-url
-        'x-success': encodeURIComponent('javascript:alert(1)'),
-      },
-    };
-    setup();
-
-    // eslint-disable-next-line global-require
-    const { useDeepLinkApi } = (await import('@/composables/deepLinkApi'));
-    const api = useDeepLinkApi();
-    await api.openCallbackOrGoHome(true);
-
-    expect(loggerWrite).toHaveBeenCalledTimes(1);
-    const [writeArgs] = loggerWrite.mock.calls[0];
-    expect(writeArgs.title).toBe('Localized invalid callback title');
-    expect(writeArgs.message).toBe('Localized invalid callback message: javascript:alert(1)');
-    expect(writeArgs.modal).toBe(true);
-    // Router redirects home, but `window.open` must NEVER be called for a
-    // dangerous scheme.
-    expect(routerReplace).toHaveBeenCalledWith({ name: 'account' });
-    expect(windowOpen).not.toHaveBeenCalled();
-  });
-
-  it.each([
-    ['data: payload', 'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg=='],
-    ['file: path', 'file:///etc/passwd'],
-    ['vbscript: payload', 'vbscript:msgbox'],
-    ['blob: URL', 'blob:https://example.com/abc'],
-    ['chrome-extension: URL', 'chrome-extension://abc/popup.html'],
-    ['custom app scheme', 'myapp://callback?signature={signature}'],
-    ['intent scheme', 'intent://wallet/callback#Intent;scheme=myapp;end'],
-    ['mailto scheme', 'mailto:test@example.com?body={signature}'],
-  ])('rejects %s without redirecting', async (_label, rawUrl) => {
-    route = { query: { 'x-success': encodeURIComponent(rawUrl) } };
-    setup();
-
-    // eslint-disable-next-line global-require
-    const { useDeepLinkApi } = (await import('@/composables/deepLinkApi'));
-    await useDeepLinkApi().openCallbackOrGoHome(true);
-
-    expect(loggerWrite).toHaveBeenCalledTimes(1);
-    expect(windowOpen).not.toHaveBeenCalled();
-  });
-
-  it('rejects malformed callback URLs', async () => {
-    route = { query: { 'x-success': encodeURIComponent('not a url at all') } };
-    setup();
-
-    // eslint-disable-next-line global-require
-    const { useDeepLinkApi } = (await import('@/composables/deepLinkApi'));
-    await useDeepLinkApi().openCallbackOrGoHome(true);
-
-    expect(loggerWrite).toHaveBeenCalledTimes(1);
-    expect(windowOpen).not.toHaveBeenCalled();
-  });
-
-  it('redirects to the trusted aggregator origin without a confirmation prompt', async () => {
-    vi.useFakeTimers();
-    route = {
-      query: { 'x-success': encodeURIComponent('https://superhero.com/callback?a=1') },
-    };
-    setup();
-
-    // openConfirmModal must NOT be awaited; if it were, this promise would
-    // hang until we resolved `confirmModalImpl`.
-    confirmModalImpl = () => {
-      throw new Error('openConfirmModal should not be called for trusted origin');
-    };
-
-    // eslint-disable-next-line global-require
-    const { useDeepLinkApi } = (await import('@/composables/deepLinkApi'));
-    const openPromise = useDeepLinkApi().openCallbackOrGoHome(true);
-    await openPromise;
-
-    // `setTimeout(() => openCallbackUrl(...), 0)` on IS_WEB=true path
-    vi.runAllTimers();
-
-    expect(loggerWrite).not.toHaveBeenCalled();
-    expect(routerReplace).toHaveBeenCalledWith({ name: 'account' });
-    expect(windowOpen).toHaveBeenCalledWith('https://superhero.com/callback?a=1', '_self');
+  afterEach(() => {
     vi.useRealTimers();
   });
 
-  it('requires user confirmation for non-trusted origins before redirecting', async () => {
-    vi.useFakeTimers();
-    let resolveModal: (v?: unknown) => void;
-    confirmModalImpl = () => new Promise((resolve) => { resolveModal = resolve; });
+  describe('rejected callbacks', () => {
+    it('rejects a javascript: callback without redirecting, and surfaces a modal error', async () => {
+      // eslint-disable-next-line no-script-url
+      route = { query: { 'x-success': encodeURIComponent('javascript:alert(1)') } };
+      setup();
 
-    route = {
-      query: { 'x-success': encodeURIComponent('https://attacker.example/?s={signature}') },
-    };
-    setup();
+      await (await loadApi()).openCallbackOrGoHome(true);
 
-    // eslint-disable-next-line global-require
-    const { useDeepLinkApi } = (await import('@/composables/deepLinkApi'));
-    const openPromise = useDeepLinkApi().openCallbackOrGoHome(true, { signature: 'SIG123' });
+      expect(loggerWrite).toHaveBeenCalledTimes(1);
+      const [writeArgs] = loggerWrite.mock.calls[0];
+      // The i18n keys must actually resolve (real i18n -> not the raw key back).
+      expect(writeArgs.title).not.toBe('pages.deepLink.invalidCallbackTitle');
+      expect(writeArgs.title).toBeTruthy();
+      // The user must be shown which destination was refused.
+      // eslint-disable-next-line no-script-url
+      expect(writeArgs.message).toContain('javascript:alert(1)');
+      expect(writeArgs.type).toBe('api-response');
+      expect(writeArgs.modal).toBe(true);
 
-    // At this point the composable is awaiting the confirm modal. Nothing
-    // should have been opened yet.
-    await Promise.resolve();
-    expect(windowOpen).not.toHaveBeenCalled();
-    expect(openConfirmModalMock).toHaveBeenCalledWith({
-      title: 'pages.deepLink.externalCallbackTitle',
-      msg: 'Localized external callback message: https://attacker.example/?s=SIG123',
+      // Router goes home, but `window.open` must NEVER run for a dangerous scheme.
+      expect(routerReplace).toHaveBeenCalledWith({ name: 'account' });
+      expect(windowOpen).not.toHaveBeenCalled();
     });
 
-    // User approves.
-    resolveModal!();
-    await openPromise;
-    vi.runAllTimers();
+    it.each([
+      ['data: payload', 'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg=='],
+      ['file: path', 'file:///etc/passwd'],
+      ['vbscript: payload', 'vbscript:msgbox'],
+      ['blob: URL', 'blob:https://example.com/abc'],
+      ['chrome-extension: URL', 'chrome-extension://abc/popup.html'],
+      ['unregistered app scheme', 'myapp://callback?signature={signature}'],
+      ['intent scheme', 'intent://wallet/callback#Intent;scheme=myapp;end'],
+      ['mailto scheme', 'mailto:test@example.com?body={signature}'],
+    ])('rejects %s without redirecting', async (_label, rawUrl) => {
+      route = { query: { 'x-success': encodeURIComponent(rawUrl) } };
+      setup();
 
-    // The `{signature}` template must be substituted (URI-encoded) into the
-    // callback URL that ultimately reaches `window.open`.
-    expect(windowOpen).toHaveBeenCalledTimes(1);
-    const [forwardedUrl] = windowOpen.mock.calls[0];
-    expect(forwardedUrl).toContain('https://attacker.example/?s=SIG123');
-    vi.useRealTimers();
-  });
+      await (await loadApi()).openCallbackOrGoHome(true);
 
-  it('cancels the redirect when the user rejects the external-site confirmation', async () => {
-    vi.useFakeTimers();
-    confirmModalImpl = () => Promise.reject(new Error('rejected-by-user'));
-
-    route = {
-      query: { 'x-success': encodeURIComponent('https://attacker.example/') },
-    };
-    setup();
-
-    // eslint-disable-next-line global-require
-    const { useDeepLinkApi } = (await import('@/composables/deepLinkApi'));
-    await useDeepLinkApi().openCallbackOrGoHome(true);
-    vi.runAllTimers();
-
-    // Rejection must route the user home and skip `window.open` entirely.
-    expect(routerReplace).toHaveBeenCalledWith({ name: 'account' });
-    expect(windowOpen).not.toHaveBeenCalled();
-    vi.useRealTimers();
-  });
-
-  it('redirects home without logging or opening when no x-success query is present', async () => {
-    route = { query: {} };
-    setup();
-
-    // eslint-disable-next-line global-require
-    const { useDeepLinkApi } = (await import('@/composables/deepLinkApi'));
-    await useDeepLinkApi().openCallbackOrGoHome(true);
-
-    expect(loggerWrite).not.toHaveBeenCalled();
-    expect(routerReplace).toHaveBeenCalledWith({ name: 'account' });
-    expect(windowOpen).not.toHaveBeenCalled();
-  });
-
-  it.each([
-    'https://chat.superhero.com/callback',
-    'https://wallet.superhero.com/success',
-    'https://deep.nested.superhero.com/a/b',
-  ])('treats %s as trusted and skips the confirm prompt', async (trustedUrl) => {
-    vi.useFakeTimers();
-    route = { query: { 'x-success': encodeURIComponent(trustedUrl) } };
-    setup();
-    confirmModalImpl = () => {
-      throw new Error('openConfirmModal must not be called for superhero.com subdomains');
-    };
-
-    // eslint-disable-next-line global-require
-    const { useDeepLinkApi } = (await import('@/composables/deepLinkApi'));
-    await useDeepLinkApi().openCallbackOrGoHome(true);
-    vi.runAllTimers();
-
-    expect(loggerWrite).not.toHaveBeenCalled();
-    expect(windowOpen).toHaveBeenCalledWith(trustedUrl, '_self');
-    vi.useRealTimers();
-  });
-
-  it.each([
-    // Suffix spoofing: same seven letters at the end, different owner.
-    'https://evilsuperhero.com/',
-    // Embedded hostname: `superhero.com` as a path / query / credential
-    // is not the destination host and must not grant trust.
-    'https://attacker.example/?r=https://superhero.com',
-    'https://superhero.com.attacker.example/',
-  ])('still prompts for spoof-shaped URL %s', async (spoofedUrl) => {
-    vi.useFakeTimers();
-    let confirmCalled = 0;
-    confirmModalImpl = () => { confirmCalled += 1; return Promise.resolve(); };
-
-    route = { query: { 'x-success': encodeURIComponent(spoofedUrl) } };
-    setup();
-
-    // eslint-disable-next-line global-require
-    const { useDeepLinkApi } = (await import('@/composables/deepLinkApi'));
-    await useDeepLinkApi().openCallbackOrGoHome(true);
-    vi.runAllTimers();
-
-    expect(confirmCalled).toBe(1);
-    vi.useRealTimers();
-  });
-
-  it('warns before redirecting to http callbacks', async () => {
-    vi.useFakeTimers();
-    confirmModalImpl = () => Promise.resolve();
-    route = {
-      query: { 'x-success': encodeURIComponent('http://superhero.com/?s={signature}') },
-    };
-    setup();
-
-    // eslint-disable-next-line global-require
-    const { useDeepLinkApi } = (await import('@/composables/deepLinkApi'));
-    await useDeepLinkApi().openCallbackOrGoHome(true, { signature: 'SIG123' });
-    vi.runAllTimers();
-
-    expect(loggerWrite).not.toHaveBeenCalled();
-    expect(openConfirmModalMock).toHaveBeenCalledTimes(1);
-    expect(windowOpen).toHaveBeenCalledWith('http://superhero.com/?s=SIG123', '_self');
-    vi.useRealTimers();
-  });
-
-  it('warns before redirecting to localhost-style http callbacks', async () => {
-    vi.useFakeTimers();
-    confirmModalImpl = () => Promise.resolve();
-    route = {
-      query: { 'x-success': encodeURIComponent('http://192.168.100.42:5173/callback?s={signature}') },
-    };
-    setup();
-
-    // eslint-disable-next-line global-require
-    const { useDeepLinkApi } = (await import('@/composables/deepLinkApi'));
-    await useDeepLinkApi().openCallbackOrGoHome(true, { signature: 'SIG123' });
-    vi.runAllTimers();
-
-    expect(openConfirmModalMock).toHaveBeenCalledTimes(1);
-    expect(windowOpen).toHaveBeenCalledWith('http://192.168.100.42:5173/callback?s=SIG123', '_self');
-    vi.useRealTimers();
-  });
-
-  it('does not double-decode already-decoded callback templates from router query', async () => {
-    vi.useFakeTimers();
-    confirmModalImpl = () => Promise.resolve();
-    route = {
-      // Simulates Vue Router already decoding the outer x-success parameter.
-      // `%26` is data inside payload and must stay encoded when redirected.
-      query: { 'x-success': 'http://localhost:3000/callback?payload=A%26B&sig={signature}' },
-    };
-    setup();
-    // eslint-disable-next-line global-require
-    const { useDeepLinkApi } = (await import('@/composables/deepLinkApi'));
-    await useDeepLinkApi().openCallbackOrGoHome(true, { signature: 'SIG123' });
-    vi.runAllTimers();
-    expect(windowOpen).toHaveBeenCalledWith(
-      'http://localhost:3000/callback?payload=A%26B&sig=SIG123',
-      '_self',
-    );
-    vi.useRealTimers();
-  });
-
-  it('routes home without throwing when x-success contains malformed percent-encoding', async () => {
-    route = { query: { 'x-success': '%ZZ' } };
-    setup();
-
-    // eslint-disable-next-line global-require
-    const { useDeepLinkApi } = (await import('@/composables/deepLinkApi'));
-    // The call MUST resolve (not reject). Previously a URIError thrown from
-    // `decodeURIComponent` would propagate out as an unhandled rejection
-    // since every caller invokes this function fire-and-forget.
-    await expect(useDeepLinkApi().openCallbackOrGoHome(true)).resolves.toBeUndefined();
-
-    expect(routerReplace).toHaveBeenCalledWith({ name: 'account' });
-    expect(windowOpen).not.toHaveBeenCalled();
-  });
-
-  it('substitutes template params as literals even when keys contain regex-special chars', async () => {
-    vi.useFakeTimers();
-    confirmModalImpl = () => Promise.resolve();
-    route = {
-      query: { 'x-success': encodeURIComponent('http://localhost:3000/callback?v={sig$}&name={name.with.dot}') },
-    };
-    setup();
-
-    // eslint-disable-next-line global-require
-    const { useDeepLinkApi } = (await import('@/composables/deepLinkApi'));
-    await useDeepLinkApi().openCallbackOrGoHome(true, {
-      sig$: 'abc123',
-      'name.with.dot': 'john/doe',
+      expect(loggerWrite).toHaveBeenCalledTimes(1);
+      expect(windowOpen).not.toHaveBeenCalled();
     });
-    vi.runAllTimers();
 
-    expect(windowOpen).toHaveBeenCalledWith(
-      'http://localhost:3000/callback?v=abc123&name=john%2Fdoe',
-      '_self',
-    );
-    vi.useRealTimers();
+    it('rejects malformed callback URLs', async () => {
+      route = { query: { 'x-success': encodeURIComponent('not a url at all') } };
+      setup();
+
+      await (await loadApi()).openCallbackOrGoHome(true);
+
+      expect(loggerWrite).toHaveBeenCalledTimes(1);
+      expect(windowOpen).not.toHaveBeenCalled();
+    });
+
+    it('routes home without throwing when x-success has malformed percent-encoding', async () => {
+      route = { query: { 'x-success': '%ZZ' } };
+      setup();
+
+      // Must RESOLVE, not reject: every caller invokes this fire-and-forget, so a
+      // URIError from `decodeURIComponent` would become an unhandled rejection.
+      await expect((await loadApi()).openCallbackOrGoHome(true)).resolves.toBeUndefined();
+
+      expect(routerReplace).toHaveBeenCalledWith({ name: 'account' });
+      expect(windowOpen).not.toHaveBeenCalled();
+    });
+
+    it('redirects home without logging or opening when no x-success query is present', async () => {
+      route = { query: {} };
+      setup();
+
+      await (await loadApi()).openCallbackOrGoHome(true);
+
+      expect(loggerWrite).not.toHaveBeenCalled();
+      expect(routerReplace).toHaveBeenCalledWith({ name: 'account' });
+      expect(windowOpen).not.toHaveBeenCalled();
+    });
+
+    it('awaits the invalid-callback logger modal before redirecting home', async () => {
+      // eslint-disable-next-line no-script-url
+      route = { query: { 'x-success': encodeURIComponent('javascript:alert(1)') } };
+      setup();
+
+      let resolveLogger: () => void;
+      loggerWrite.mockImplementationOnce(
+        () => new Promise((resolve) => { resolveLogger = resolve; }),
+      );
+
+      const openPromise = (await loadApi()).openCallbackOrGoHome(true);
+
+      await Promise.resolve();
+      expect(routerReplace).not.toHaveBeenCalled();
+
+      resolveLogger!();
+      await openPromise;
+      expect(routerReplace).toHaveBeenCalledWith({ name: 'account' });
+    });
   });
 
-  it('awaits invalid-callback logger modal before redirecting home', async () => {
-    route = {
-      query: {
-        // eslint-disable-next-line no-script-url
-        'x-success': encodeURIComponent('javascript:alert(1)'),
-      },
-    };
-    setup();
+  describe('trusted destinations (no confirmation prompt)', () => {
+    it.each([
+      'https://superhero.com/callback?a=1',
+      'https://chat.superhero.com/callback',
+      'https://wallet.superhero.com/success',
+      'https://deep.nested.superhero.com/a/b',
+    ])('redirects to trusted aggregator origin %s without prompting', async (trustedUrl) => {
+      vi.useFakeTimers();
+      route = { query: { 'x-success': encodeURIComponent(trustedUrl) } };
+      setup();
+      confirmModalImpl = () => {
+        throw new Error('openConfirmModal must not be called for a trusted origin');
+      };
 
-    let resolveLogger: () => void;
-    loggerWrite.mockImplementationOnce(
-      () => new Promise((resolve) => { resolveLogger = resolve; }),
-    );
+      await (await loadApi()).openCallbackOrGoHome(true);
+      vi.runAllTimers();
 
-    // eslint-disable-next-line global-require
-    const { useDeepLinkApi } = (await import('@/composables/deepLinkApi'));
-    const openPromise = useDeepLinkApi().openCallbackOrGoHome(true);
+      expect(loggerWrite).not.toHaveBeenCalled();
+      expect(openConfirmModalMock).not.toHaveBeenCalled();
+      expect(routerReplace).toHaveBeenCalledWith({ name: 'account' });
+      expect(windowOpen).toHaveBeenCalledWith(trustedUrl, '_self');
+    });
 
-    await Promise.resolve();
-    expect(routerReplace).not.toHaveBeenCalled();
+    /**
+     * `superhero:` and `wc:` are this app's registered native schemes (see
+     * ALLOWED_NATIVE_CALLBACK_PROTOCOLS in `src/utils/callbackUrl.ts`). The real
+     * implementation both ACCEPTS and TRUSTS them, so returning to a native dApp
+     * must not be gated behind a confirmation prompt.
+     */
+    it('trusts the registered superhero: app scheme and substitutes template params', async () => {
+      vi.useFakeTimers();
+      route = {
+        query: { 'x-success': encodeURIComponent('superhero://wallet/callback?tx={transaction}') },
+      };
+      setup();
+      confirmModalImpl = () => {
+        throw new Error('openConfirmModal must not be called for a registered app scheme');
+      };
 
-    resolveLogger!();
-    await openPromise;
-    expect(routerReplace).toHaveBeenCalledWith({ name: 'account' });
+      await (await loadApi()).openCallbackOrGoHome(true, { transaction: 'tx_abc123' });
+      vi.runAllTimers();
+
+      expect(loggerWrite).not.toHaveBeenCalled();
+      expect(openConfirmModalMock).not.toHaveBeenCalled();
+      expect(windowOpen).toHaveBeenCalledTimes(1);
+      const [forwardedUrl] = windowOpen.mock.calls[0];
+      expect(forwardedUrl).toContain('superhero://wallet/callback');
+      expect(forwardedUrl).toContain('tx_abc123');
+    });
+
+    it('trusts the registered wc: (WalletConnect) scheme', async () => {
+      vi.useFakeTimers();
+      const wcUrl = 'wc:7f6e12@2?relay-protocol=irn&symKey=abc';
+      route = { query: { 'x-success': encodeURIComponent(wcUrl) } };
+      setup();
+      confirmModalImpl = () => {
+        throw new Error('openConfirmModal must not be called for a registered app scheme');
+      };
+
+      await (await loadApi()).openCallbackOrGoHome(true);
+      vi.runAllTimers();
+
+      expect(loggerWrite).not.toHaveBeenCalled();
+      expect(openConfirmModalMock).not.toHaveBeenCalled();
+      expect(windowOpen).toHaveBeenCalledTimes(1);
+      expect(windowOpen.mock.calls[0][0]).toContain('wc:7f6e12');
+    });
+  });
+
+  describe('untrusted destinations (confirmation required)', () => {
+    it('requires user confirmation before forwarding signed data to a foreign origin', async () => {
+      vi.useFakeTimers();
+      let resolveModal: (v?: unknown) => void;
+      confirmModalImpl = () => new Promise((resolve) => { resolveModal = resolve; });
+
+      route = {
+        query: { 'x-success': encodeURIComponent('https://attacker.example/?s={signature}') },
+      };
+      setup();
+
+      const openPromise = (await loadApi()).openCallbackOrGoHome(true, { signature: 'SIG123' });
+
+      // While the confirm modal is pending, nothing may be opened.
+      await Promise.resolve();
+      expect(windowOpen).not.toHaveBeenCalled();
+      expect(openConfirmModalMock).toHaveBeenCalledTimes(1);
+
+      // The prompt must name the destination the signed data would go to.
+      const [confirmArgs] = openConfirmModalMock.mock.calls[0];
+      expect(confirmArgs.title).not.toBe('pages.deepLink.externalCallbackTitle');
+      expect(confirmArgs.title).toBeTruthy();
+      expect(confirmArgs.msg).toContain('https://attacker.example/?s=SIG123');
+
+      resolveModal!();
+      await openPromise;
+      vi.runAllTimers();
+
+      // `{signature}` must be substituted into the URL that reaches `window.open`.
+      expect(windowOpen).toHaveBeenCalledTimes(1);
+      expect(windowOpen.mock.calls[0][0]).toContain('https://attacker.example/?s=SIG123');
+    });
+
+    it('cancels the redirect when the user rejects the external-site confirmation', async () => {
+      vi.useFakeTimers();
+      confirmModalImpl = () => Promise.reject(new Error('rejected-by-user'));
+
+      route = { query: { 'x-success': encodeURIComponent('https://attacker.example/') } };
+      setup();
+
+      await (await loadApi()).openCallbackOrGoHome(true);
+      vi.runAllTimers();
+
+      // Rejection routes home and skips `window.open` entirely.
+      expect(routerReplace).toHaveBeenCalledWith({ name: 'account' });
+      expect(windowOpen).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      // Suffix spoofing: same seven letters at the end, different owner.
+      'https://evilsuperhero.com/',
+      // `superhero.com` in a path/query is not the destination host.
+      'https://attacker.example/?r=https://superhero.com',
+      // Prefix spoofing: the real host is `attacker.example`.
+      'https://superhero.com.attacker.example/',
+    ])('still prompts for spoof-shaped URL %s', async (spoofedUrl) => {
+      vi.useFakeTimers();
+      route = { query: { 'x-success': encodeURIComponent(spoofedUrl) } };
+      setup();
+
+      await (await loadApi()).openCallbackOrGoHome(true);
+      vi.runAllTimers();
+
+      expect(openConfirmModalMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('warns before redirecting to an http (downgraded) superhero.com callback', async () => {
+      vi.useFakeTimers();
+      route = {
+        query: { 'x-success': encodeURIComponent('http://superhero.com/?s={signature}') },
+      };
+      setup();
+
+      await (await loadApi()).openCallbackOrGoHome(true, { signature: 'SIG123' });
+      vi.runAllTimers();
+
+      expect(loggerWrite).not.toHaveBeenCalled();
+      expect(openConfirmModalMock).toHaveBeenCalledTimes(1);
+      expect(windowOpen).toHaveBeenCalledWith('http://superhero.com/?s=SIG123', '_self');
+    });
+
+    it('warns before redirecting to localhost-style http callbacks', async () => {
+      vi.useFakeTimers();
+      route = {
+        query: {
+          'x-success': encodeURIComponent('http://192.168.100.42:5173/callback?s={signature}'),
+        },
+      };
+      setup();
+
+      await (await loadApi()).openCallbackOrGoHome(true, { signature: 'SIG123' });
+      vi.runAllTimers();
+
+      expect(openConfirmModalMock).toHaveBeenCalledTimes(1);
+      expect(windowOpen).toHaveBeenCalledWith(
+        'http://192.168.100.42:5173/callback?s=SIG123',
+        '_self',
+      );
+    });
+  });
+
+  describe('template expansion', () => {
+    it('does not double-decode an already-decoded callback template', async () => {
+      vi.useFakeTimers();
+      route = {
+        // Simulates Vue Router having already decoded the outer x-success value.
+        // `%26` is data inside the payload and must stay encoded when redirected.
+        query: { 'x-success': 'http://localhost:3000/callback?payload=A%26B&sig={signature}' },
+      };
+      setup();
+
+      await (await loadApi()).openCallbackOrGoHome(true, { signature: 'SIG123' });
+      vi.runAllTimers();
+
+      expect(windowOpen).toHaveBeenCalledWith(
+        'http://localhost:3000/callback?payload=A%26B&sig=SIG123',
+        '_self',
+      );
+    });
+
+    it('substitutes template params literally even when keys contain regex-special chars', async () => {
+      vi.useFakeTimers();
+      route = {
+        query: {
+          'x-success': encodeURIComponent(
+            'http://localhost:3000/callback?v={sig$}&name={name.with.dot}',
+          ),
+        },
+      };
+      setup();
+
+      await (await loadApi()).openCallbackOrGoHome(true, {
+        sig$: 'abc123',
+        'name.with.dot': 'john/doe',
+      });
+      vi.runAllTimers();
+
+      expect(windowOpen).toHaveBeenCalledWith(
+        'http://localhost:3000/callback?v=abc123&name=john%2Fdoe',
+        '_self',
+      );
+    });
   });
 });

--- a/tests/unit/utils/callbackUrl.spec.ts
+++ b/tests/unit/utils/callbackUrl.spec.ts
@@ -1,19 +1,26 @@
 // @ts-nocheck
+import {
+  checkIfSuperheroCallbackUrl,
+  isTrustedCallbackUrl,
+  validateCallbackUrl,
+} from '@/utils/callbackUrl';
+import { AGGREGATOR_URL } from '@/constants';
+
+/**
+ * Pure security helpers — no mocks at all. The trusted host is derived from the REAL
+ * `AGGREGATOR_URL` constant rather than a stubbed one, so this spec keeps testing the
+ * host the app actually ships with.
+ */
 describe('callback URL security helpers', () => {
-  const loadHelpers = async () => {
-    vi.resetModules();
-    vi.doMock('@/constants', () => ({
-      AGGREGATOR_URL: 'https://superhero.com',
-    }));
-    return import('@/utils/callbackUrl');
-  };
+  it('derives the trusted host from the real AGGREGATOR_URL', () => {
+    expect(new URL(AGGREGATOR_URL).hostname).toBe('superhero.com');
+  });
 
   it.each([
     'https://superhero.com/callback',
     'https://chat.superhero.com/callback',
     'https://deep.nested.superhero.com/callback',
-  ])('trusts the aggregator host and https subdomain %s', async (url) => {
-    const { isTrustedCallbackUrl, validateCallbackUrl } = await loadHelpers();
+  ])('trusts the aggregator host and its https subdomains: %s', (url) => {
     const parsed = validateCallbackUrl(url);
 
     expect(parsed).toBeInstanceOf(URL);
@@ -21,12 +28,16 @@ describe('callback URL security helpers', () => {
   });
 
   it.each([
+    // Prefix spoofing — the real host is `attacker.example`.
     'https://superhero.com.attacker.example/callback',
+    // Suffix spoofing — same letters at the end, different owner. Guards the
+    // leading dot in the `.${host}` subdomain check.
     'https://evilsuperhero.com/callback',
+    // `superhero.com` in a query/path is not the destination host.
     'https://attacker.example/?next=https://superhero.com',
+    // Protocol downgrade must not inherit trust.
     'http://superhero.com/callback',
-  ])('does not trust spoofed or downgraded URL %s', async (url) => {
-    const { isTrustedCallbackUrl, validateCallbackUrl } = await loadHelpers();
+  ])('does not trust spoofed or downgraded URL: %s', (url) => {
     const parsed = validateCallbackUrl(url);
 
     if (parsed) {
@@ -42,8 +53,7 @@ describe('callback URL security helpers', () => {
     'http://0.0.0.0:8080/callback',
     'http://192.168.100.42:5173/callback',
     'http://example.com/callback',
-  ])('allows http callbacks but does not trust them %s', async (url) => {
-    const { validateCallbackUrl, isTrustedCallbackUrl } = await loadHelpers();
+  ])('allows http callbacks but never trusts them: %s', (url) => {
     const parsed = validateCallbackUrl(url);
 
     expect(parsed).toBeInstanceOf(URL);
@@ -53,8 +63,7 @@ describe('callback URL security helpers', () => {
   it.each([
     'superhero://wallet/callback?tx={transaction}',
     'wc:7f6e12@2?relay-protocol=irn&symKey=abc',
-  ])('allows registered native callback scheme %s', async (url) => {
-    const { validateCallbackUrl, isTrustedCallbackUrl } = await loadHelpers();
+  ])('allows and trusts the app\'s own registered native scheme: %s', (url) => {
     const parsed = validateCallbackUrl(url);
 
     expect(parsed).toBeInstanceOf(URL);
@@ -64,28 +73,47 @@ describe('callback URL security helpers', () => {
   it.each([
     // eslint-disable-next-line no-script-url
     'javascript:alert(1)',
+    'data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==',
+    'file:///etc/passwd',
+    'vbscript:msgbox',
+    'blob:https://example.com/abc',
+    'chrome-extension://abc/popup.html',
+    // An app scheme we did NOT register must stay rejected.
     'myapp://callback',
+    'intent://wallet/callback#Intent;scheme=myapp;end',
+    'mailto:test@example.com',
     'not a url',
     '%ZZ',
-  ])('rejects unsafe callback URL %s', async (url) => {
-    const { validateCallbackUrl } = await loadHelpers();
-
+    '',
+  ])('rejects unsafe or malformed callback URL: %s', (url) => {
     expect(validateCallbackUrl(url)).toBeNull();
   });
 
-  it('requires both success and cancel callbacks to be trusted Superhero URLs', async () => {
-    const { checkIfSuperheroCallbackUrl } = await loadHelpers();
+  it('rejects non-string query values', () => {
+    expect(validateCallbackUrl(undefined)).toBeNull();
+    expect(validateCallbackUrl(null)).toBeNull();
+    expect(validateCallbackUrl(['https://superhero.com'])).toBeNull();
+  });
 
-    expect(checkIfSuperheroCallbackUrl({
-      'x-success': 'https://superhero.com/success',
-      'x-cancel': 'https://wallet.superhero.com/cancel',
-    })).toBe(true);
-    expect(checkIfSuperheroCallbackUrl({
-      'x-success': 'https://superhero.com.attacker.example/success',
-      'x-cancel': 'https://superhero.com/cancel',
-    })).toBe(false);
-    expect(checkIfSuperheroCallbackUrl({
-      'x-success': 'https://superhero.com/success',
-    })).toBe(false);
+  describe('checkIfSuperheroCallbackUrl', () => {
+    it('requires BOTH success and cancel callbacks to be trusted Superhero URLs', () => {
+      expect(checkIfSuperheroCallbackUrl({
+        'x-success': 'https://superhero.com/success',
+        'x-cancel': 'https://wallet.superhero.com/cancel',
+      })).toBe(true);
+
+      // One spoofed side is enough to fail the whole check.
+      expect(checkIfSuperheroCallbackUrl({
+        'x-success': 'https://superhero.com.attacker.example/success',
+        'x-cancel': 'https://superhero.com/cancel',
+      })).toBe(false);
+
+      // A missing side is not trusted either.
+      expect(checkIfSuperheroCallbackUrl({
+        'x-success': 'https://superhero.com/success',
+      })).toBe(false);
+
+      expect(checkIfSuperheroCallbackUrl({})).toBe(false);
+    });
   });
 });

--- a/tests/unit/utils/crypto.spec.ts
+++ b/tests/unit/utils/crypto.spec.ts
@@ -1,0 +1,192 @@
+// @ts-nocheck
+import {
+  AES_GCM_TAG_LENGTH_BYTES,
+  decodeBase64,
+  decrypt,
+  encodeBase64,
+  encrypt,
+  generateEncryptionKey,
+  generateSalt,
+  IV_LENGTH,
+} from '@/utils/crypto';
+
+/**
+ * The wallet's encryption core: PBKDF2 password -> AES-GCM key, and the
+ * encrypt/decrypt used for the mnemonic, imported private keys and other secrets
+ * at rest. Runs against REAL WebCrypto — no mocks — so these assertions pin the
+ * actual cryptographic guarantees, not a stand-in.
+ *
+ * The properties below are the ones whose silent failure would compromise the
+ * wallet: a wrong password must THROW rather than yield garbage plaintext, the IV
+ * must be fresh per message (or identical secrets become linkable), and tampered
+ * ciphertext must be rejected by the GCM auth tag rather than decrypted.
+ */
+const PASSWORD = 'correct horse battery staple';
+const MNEMONIC = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
+
+describe('utils/crypto', () => {
+  let salt: Uint8Array;
+  let key: CryptoKey;
+
+  beforeAll(async () => {
+    salt = generateSalt();
+    key = await generateEncryptionKey(PASSWORD, salt);
+  });
+
+  describe('generateSalt', () => {
+    it('returns 16 fresh random bytes each call', () => {
+      const a = generateSalt();
+      const b = generateSalt();
+
+      expect(a).toBeInstanceOf(Uint8Array);
+      expect(a).toHaveLength(16);
+      expect(encodeBase64(a)).not.toBe(encodeBase64(b));
+    });
+  });
+
+  describe('generateEncryptionKey', () => {
+    it('derives a 256-bit AES-GCM key usable for encrypt and decrypt', () => {
+      expect(key.algorithm.name).toBe('AES-GCM');
+      expect(key.algorithm.length).toBe(256);
+      expect(key.usages).toEqual(expect.arrayContaining(['encrypt', 'decrypt']));
+    });
+
+    it('is deterministic: the same password + salt re-derives a key that decrypts', async () => {
+      const ciphertext = await encrypt(key, MNEMONIC);
+      const rederived = await generateEncryptionKey(PASSWORD, salt);
+
+      await expect(decrypt(rederived, ciphertext)).resolves.toBe(MNEMONIC);
+    });
+
+    it('salts the derivation: the same password + a different salt cannot decrypt', async () => {
+      const ciphertext = await encrypt(key, MNEMONIC);
+      const otherSaltKey = await generateEncryptionKey(PASSWORD, generateSalt());
+
+      // Must REJECT — never resolve to garbage plaintext.
+      await expect(decrypt(otherSaltKey, ciphertext)).rejects.toThrow();
+    });
+  });
+
+  describe('encrypt / decrypt round-trip', () => {
+    it.each([
+      ['a BIP-39 mnemonic', MNEMONIC],
+      ['a hex private key', 'a'.repeat(64)],
+      ['JSON state', '{"names":["foo.chain"],"n":1}'],
+      ['unicode', '助记词 🔐 ünïcødé'],
+      ['an empty string', ''],
+      ['a long blob', 'x'.repeat(10_000)],
+    ])('round-trips %s', async (_label, plaintext) => {
+      const ciphertext = await encrypt(key, plaintext);
+
+      expect(ciphertext).not.toBe(plaintext);
+      await expect(decrypt(key, ciphertext)).resolves.toBe(plaintext);
+    });
+  });
+
+  describe('ciphertext shape', () => {
+    it('is base64 of [16-byte IV || ciphertext+16-byte GCM tag]', async () => {
+      const ciphertext = await encrypt(key, '');
+      const bytes = new Uint8Array(decodeBase64(ciphertext));
+
+      expect(ciphertext).toMatch(/^[A-Za-z0-9+/]+={0,2}$/);
+      // Encrypting an empty string yields IV + tag only — the minimum possible blob.
+      expect(bytes).toHaveLength(IV_LENGTH + AES_GCM_TAG_LENGTH_BYTES);
+    });
+
+    /**
+     * Reusing an IV under the same AES-GCM key is catastrophic (it leaks the XOR of
+     * the plaintexts and can expose the auth key). Encrypting identical plaintext
+     * twice must therefore never produce identical output.
+     */
+    it('uses a fresh random IV per message, so identical plaintext encrypts differently', async () => {
+      const first = await encrypt(key, MNEMONIC);
+      const second = await encrypt(key, MNEMONIC);
+
+      expect(first).not.toBe(second);
+
+      const ivOf = (blob: string) => (
+        encodeBase64(new Uint8Array(decodeBase64(blob)).slice(0, IV_LENGTH))
+      );
+      expect(ivOf(first)).not.toBe(ivOf(second));
+
+      // Both still decrypt back to the same secret.
+      await expect(decrypt(key, first)).resolves.toBe(MNEMONIC);
+      await expect(decrypt(key, second)).resolves.toBe(MNEMONIC);
+    });
+  });
+
+  describe('decrypt rejects rather than returning garbage', () => {
+    it('rejects a wrong password (this is what makes a wrong password detectable)', async () => {
+      const ciphertext = await encrypt(key, MNEMONIC);
+      const wrongKey = await generateEncryptionKey('wrong password', salt);
+
+      await expect(decrypt(wrongKey, ciphertext)).rejects.toThrow();
+    });
+
+    it('rejects ciphertext whose body has been tampered with (GCM auth tag)', async () => {
+      const bytes = new Uint8Array(decodeBase64(await encrypt(key, MNEMONIC)));
+      // Mutate a byte past the IV — i.e. inside the ciphertext/tag region.
+      bytes[IV_LENGTH + 1] = (bytes[IV_LENGTH + 1] + 1) % 256;
+
+      await expect(decrypt(key, encodeBase64(bytes))).rejects.toThrow();
+    });
+
+    it('rejects ciphertext whose IV has been tampered with', async () => {
+      const bytes = new Uint8Array(decodeBase64(await encrypt(key, MNEMONIC)));
+      bytes[0] = (bytes[0] + 1) % 256;
+
+      await expect(decrypt(key, encodeBase64(bytes))).rejects.toThrow();
+    });
+
+    it.each([
+      ['plain text that is not a blob', 'not ciphertext at all'],
+      ['an empty string', ''],
+      ['a truncated blob', 'AAAA'],
+    ])('rejects %s', async (_label, value) => {
+      await expect(decrypt(key, value)).rejects.toThrow();
+    });
+  });
+});
+
+/**
+ * `IS_EXTRACTABLE` is derived from `IS_EXTENSION` at module load: the extension needs
+ * to export the raw key to persist it in `browser.storage.session` so the background /
+ * offscreen pages can reuse it, while other platforms deliberately keep the key
+ * non-extractable. `IS_EXTENSION` is false under vitest, hence the module reload.
+ */
+describe('utils/crypto — extension session-key export', () => {
+  const loadCrypto = async ({ isExtension }: { isExtension: boolean }) => {
+    vi.resetModules();
+    vi.doMock('@/constants', async (importOriginal) => ({
+      ...(await importOriginal()),
+      IS_EXTENSION: isExtension,
+    }));
+    return import('@/utils/crypto');
+  };
+
+  afterEach(() => {
+    vi.resetModules();
+  });
+
+  it('exports the raw key and re-imports it into one that decrypts the same data', async () => {
+    const crypto = await loadCrypto({ isExtension: true });
+    const extKey = await crypto.generateEncryptionKey(PASSWORD, crypto.generateSalt());
+    const ciphertext = await crypto.encrypt(extKey, MNEMONIC);
+
+    const raw = await crypto.exportEncryptionKey(extKey);
+    expect(raw).toBeInstanceOf(Uint8Array);
+    expect(raw).toHaveLength(32); // AES-256
+
+    // Round-trip through the raw bytes, exactly as the session-storage handoff does.
+    const reimported = await crypto.importEncryptionKey(raw);
+    await expect(crypto.decrypt(reimported, ciphertext)).resolves.toBe(MNEMONIC);
+  });
+
+  it('keeps the key non-extractable off-extension, so it cannot leak via export', async () => {
+    const crypto = await loadCrypto({ isExtension: false });
+    const nonExtractableKey = await crypto.generateEncryptionKey(PASSWORD, crypto.generateSalt());
+
+    expect(nonExtractableKey.extractable).toBe(false);
+    await expect(crypto.exportEncryptionKey(nonExtractableKey)).rejects.toThrow();
+  });
+});

--- a/tests/unit/utils/mobileEncryption.spec.ts
+++ b/tests/unit/utils/mobileEncryption.spec.ts
@@ -1,140 +1,181 @@
 // @ts-nocheck
+/**
+ * `mobileEncryption` exists to answer one question about a stored blob: "is this
+ * already ciphertext I can read, or is it legacy plaintext that needs encrypting?"
+ * That decision is driven by whether a REAL `decrypt()` succeeds and by whether the
+ * value looks like REAL `encrypt()` output — so this spec runs the real AES-GCM
+ * (`@/utils/crypto` over Node's WebCrypto) and the real `SecureMobileStorage`
+ * (whose web implementation is plain `localStorage` — see `SecureStorageWeb`).
+ *
+ * A previous version mocked `@/utils/crypto`, replacing `encrypt` with
+ * `` `encrypted:${value}` `` string concatenation. That made the tests vacuous: the
+ * fake output is not even base64, so `looksLikeCiphertext()` — the heuristic that
+ * prevents double-wrapping (and thus permanent data loss) — was never once evaluated
+ * against a real ciphertext blob.
+ *
+ * The ONLY mock left is `IS_MOBILE_APP: true`, an environment fact that cannot be
+ * derived in a jsdom test run (`process.env.PLATFORM` is unset).
+ */
 describe('mobileEncryption', () => {
-  const secureStoreMock = new Map<string, any>();
-  const secureMobileStorageMock = {
-    get: vi.fn((key: string) => Promise.resolve(secureStoreMock.get(key) ?? null)),
-    set: vi.fn((key: string, value: any) => {
-      secureStoreMock.set(key, value);
-      return Promise.resolve();
-    }),
+  const loadModule = async ({ isMobileApp = true } = {}) => {
+    vi.resetModules();
+    vi.doMock('@/constants', async (importOriginal) => ({
+      ...(await importOriginal()),
+      IS_MOBILE_APP: isMobileApp,
+    }));
+
+    const mod = await import('@/utils/mobileEncryption');
+    const { SecureMobileStorage } = await import('@/lib/SecureMobileStorage');
+    return { ...mod, SecureMobileStorage };
   };
-  const decryptMock = vi.fn();
-  const encryptMock = vi.fn();
-  const importEncryptionKeyMock = vi.fn();
-  const getRandomValuesMock = vi.fn((bytes: Uint8Array) => {
-    bytes.fill(7);
-    return bytes;
+
+  /** Re-import with module state reset but storage retained — i.e. an app restart. */
+  const restartApp = () => loadModule();
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
   });
 
-  const loadModule = async () => {
-    vi.resetModules();
-    secureStoreMock.clear();
-    secureMobileStorageMock.get.mockClear();
-    secureMobileStorageMock.set.mockClear();
-    decryptMock.mockReset();
-    encryptMock.mockReset();
-    importEncryptionKeyMock.mockReset();
-    getRandomValuesMock.mockClear();
+  describe('encryptMobileStateIfPlaintext', () => {
+    it('encrypts legacy plaintext into real ciphertext that decrypts back to the original', async () => {
+      const { encryptMobileStateIfPlaintext, tryDecryptWithMobileKey } = await loadModule();
+      const plaintext = 'abandon abandon abandon about';
 
-    vi.spyOn(globalThis.crypto, 'getRandomValues').mockImplementation(getRandomValuesMock);
+      const ciphertext = await encryptMobileStateIfPlaintext(plaintext);
 
-    importEncryptionKeyMock.mockImplementation(async (bytes: Uint8Array) => ({
-      byteLength: bytes.length,
-    }));
-    encryptMock.mockImplementation(async (_key, value) => `encrypted:${value}`);
-
-    vi.doMock('@/constants', async () => ({
-      ...(await vi.importActual('@/constants')),
-      IS_MOBILE_APP: true,
-      STORAGE_KEYS: { mobileDataKey: 'mobile-data-key' },
-    }));
-    vi.doMock('@/lib/SecureMobileStorage', () => ({
-      SecureMobileStorage: secureMobileStorageMock,
-    }));
-    vi.doMock('@/utils/crypto', async () => {
-      const { IV_LENGTH, AES_GCM_TAG_LENGTH_BYTES } = await vi.importActual('@/utils/crypto');
-      return {
-        IV_LENGTH,
-        AES_GCM_TAG_LENGTH_BYTES,
-        decodeBase64: (value: string) => Buffer.from(value, 'base64'),
-        decrypt: decryptMock,
-        encodeBase64: (bytes: Uint8Array) => Buffer.from(bytes).toString('base64'),
-        encrypt: encryptMock,
-        importEncryptionKey: importEncryptionKeyMock,
-      };
+      expect(ciphertext).not.toBe(plaintext);
+      // Real round-trip through AES-GCM — the whole point of the module.
+      await expect(tryDecryptWithMobileKey(ciphertext)).resolves.toBe(plaintext);
     });
 
-    return import('@/utils/mobileEncryption');
-  };
+    it('is idempotent: re-encrypting its own output returns it unchanged', async () => {
+      const { encryptMobileStateIfPlaintext, tryDecryptWithMobileKey } = await loadModule();
+      const plaintext = 'abandon abandon abandon about';
 
-  afterEach(async () => {
-    vi.restoreAllMocks();
+      const once = await encryptMobileStateIfPlaintext(plaintext);
+      const twice = await encryptMobileStateIfPlaintext(once);
+
+      expect(twice).toBe(once);
+      await expect(tryDecryptWithMobileKey(twice)).resolves.toBe(plaintext);
+    });
+
+    it('passes empty values through untouched', async () => {
+      const { encryptMobileStateIfPlaintext } = await loadModule();
+
+      await expect(encryptMobileStateIfPlaintext('')).resolves.toBe('');
+    });
+
+    /**
+     * The data-loss guard. After a Keychain wipe the old ciphertext is no longer
+     * decryptable, but it must NOT be treated as plaintext and wrapped in a second
+     * layer of encryption — that would destroy any chance of recovery. This only
+     * means something when `looksLikeCiphertext()` is fed a genuine `encrypt()` blob,
+     * which is exactly what the previously-mocked crypto made impossible to check.
+     */
+    it('leaves ciphertext from a rotated/wiped key unchanged instead of double-wrapping it', async () => {
+      const first = await loadModule();
+      const ciphertext = await first.encryptMobileStateIfPlaintext('critical seed phrase');
+
+      // Simulate a Keychain wipe: drop the mobile key, keep the encrypted blob.
+      await first.SecureMobileStorage.remove('mobile-data-key');
+
+      const afterWipe = await restartApp();
+      // The new install mints a different key, so this blob is undecryptable now...
+      await expect(afterWipe.tryDecryptWithMobileKey(ciphertext)).resolves.toBeNull();
+      // ...and must therefore be returned untouched, not re-encrypted.
+      await expect(afterWipe.encryptMobileStateIfPlaintext(ciphertext)).resolves.toBe(ciphertext);
+    });
+
+    it('does not misclassify a 64-char hex private key as ciphertext', async () => {
+      const { encryptMobileStateIfPlaintext, tryDecryptWithMobileKey } = await loadModule();
+      // 64 hex chars are a subset of the base64 alphabet and satisfy the length /
+      // modulo-4 checks, so without the explicit hex exclusion this would be
+      // mistaken for ciphertext and silently left unencrypted.
+      const hexPrivateKey = 'a'.repeat(64);
+
+      const result = await encryptMobileStateIfPlaintext(hexPrivateKey);
+
+      expect(result).not.toBe(hexPrivateKey);
+      await expect(tryDecryptWithMobileKey(result)).resolves.toBe(hexPrivateKey);
+    });
+
+    it('encrypts base64-shaped plaintext that is too short to be a real ciphertext', async () => {
+      const { encryptMobileStateIfPlaintext, tryDecryptWithMobileKey } = await loadModule();
+      // 40 chars — below the 44-char minimum for base64(16-byte IV + 16-byte GCM tag).
+      const shortBase64Shaped = `${'Q'.repeat(38)}==`;
+
+      const result = await encryptMobileStateIfPlaintext(shortBase64Shaped);
+
+      expect(result).not.toBe(shortBase64Shaped);
+      await expect(tryDecryptWithMobileKey(result)).resolves.toBe(shortBase64Shaped);
+    });
   });
 
-  it('encrypts legacy plaintext with the per-install mobile key', async () => {
-    const { encryptMobileStateIfPlaintext } = await loadModule();
-    decryptMock.mockRejectedValue(new Error('not ciphertext'));
+  describe('tryDecryptWithMobileKey', () => {
+    it('returns null for values that are not decryptable with the mobile key', async () => {
+      const { tryDecryptWithMobileKey } = await loadModule();
 
-    await expect(encryptMobileStateIfPlaintext('seed words here')).resolves.toBe(
-      'encrypted:seed words here',
-    );
-
-    expect(secureMobileStorageMock.set).toHaveBeenCalledWith(
-      'mobile-data-key',
-      Buffer.from(new Uint8Array(32).fill(7)).toString('base64'),
-    );
-    expect(encryptMock).toHaveBeenCalledWith(expect.any(Object), 'seed words here');
+      await expect(tryDecryptWithMobileKey('plain text, not ciphertext')).resolves.toBeNull();
+      await expect(tryDecryptWithMobileKey(`${'A'.repeat(42)}==`)).resolves.toBeNull();
+    });
   });
 
-  it('leaves ciphertext encrypted with the current mobile key unchanged', async () => {
-    const { encryptMobileStateIfPlaintext } = await loadModule();
-    decryptMock.mockResolvedValue('plain text');
+  describe('getOrCreateMobileEncryptionKey', () => {
+    it('refuses to mint a key when not running as the mobile app', async () => {
+      const { getOrCreateMobileEncryptionKey } = await loadModule({ isMobileApp: false });
 
-    await expect(encryptMobileStateIfPlaintext('current-ciphertext')).resolves.toBe(
-      'current-ciphertext',
-    );
+      await expect(getOrCreateMobileEncryptionKey()).rejects.toThrow(/only be called on mobile/);
+    });
 
-    expect(encryptMock).not.toHaveBeenCalled();
-  });
+    it('persists the key once, reuses it in-memory, and reloads it after a restart', async () => {
+      const {
+        getOrCreateMobileEncryptionKey,
+        encryptMobileStateIfPlaintext,
+        SecureMobileStorage,
+      } = await loadModule();
+      const setSpy = vi.spyOn(SecureMobileStorage, 'set');
 
-  it('leaves unreadable ciphertext-shaped values unchanged to avoid double wrapping', async () => {
-    const { encryptMobileStateIfPlaintext } = await loadModule();
-    decryptMock.mockRejectedValue(new Error('wrong key'));
-    /** Minimum base64 length for real `encrypt()` output (16-byte IV + 16-byte GCM tag). */
-    const ciphertextShaped = `${'A'.repeat(42)}==`;
+      const key = await getOrCreateMobileEncryptionKey();
+      expect(key.algorithm.name).toBe('AES-GCM');
 
-    await expect(encryptMobileStateIfPlaintext(ciphertextShaped)).resolves.toBe(ciphertextShaped);
+      // Second call is served from the in-memory cache — no extra Keychain write.
+      await expect(getOrCreateMobileEncryptionKey()).resolves.toBe(key);
+      expect(setSpy).toHaveBeenCalledTimes(1);
 
-    expect(encryptMock).not.toHaveBeenCalled();
-  });
+      // The SAME key material must come back after a restart, or data encrypted in
+      // this session would be unreadable in the next one.
+      const ciphertext = await encryptMobileStateIfPlaintext('survives restart');
+      const restarted = await restartApp();
+      await expect(restarted.tryDecryptWithMobileKey(ciphertext)).resolves.toBe('survives restart');
+    });
 
-  it('does not misclassify hex private keys as ciphertext', async () => {
-    const { encryptMobileStateIfPlaintext } = await loadModule();
-    decryptMock.mockRejectedValue(new Error('not ciphertext'));
-    const hexPrivateKey = 'a'.repeat(64);
+    /**
+     * Persist-before-cache. If a failed Keychain write still published the key into
+     * the module cache, that key would encrypt fresh state and then vanish on restart,
+     * making the state permanently unrecoverable.
+     */
+    it('does not cache an un-persisted key when the Keychain write fails', async () => {
+      const {
+        getOrCreateMobileEncryptionKey,
+        encryptMobileStateIfPlaintext,
+        SecureMobileStorage,
+      } = await loadModule();
+      const setSpy = vi.spyOn(SecureMobileStorage, 'set')
+        .mockRejectedValueOnce(new Error('keychain locked'));
 
-    await expect(encryptMobileStateIfPlaintext(hexPrivateKey)).resolves.toBe(
-      `encrypted:${hexPrivateKey}`,
-    );
+      await expect(getOrCreateMobileEncryptionKey()).rejects.toThrow('keychain locked');
 
-    expect(encryptMock).toHaveBeenCalledWith(expect.any(Object), hexPrivateKey);
-  });
+      // A retry mints a fresh key and persists it for real (spy falls through).
+      const key = await getOrCreateMobileEncryptionKey();
+      expect(key.algorithm.name).toBe('AES-GCM');
+      expect(setSpy).toHaveBeenCalledTimes(2);
 
-  it('encrypts 40-char base64-shaped legacy plaintext (below min ciphertext size)', async () => {
-    const { encryptMobileStateIfPlaintext } = await loadModule();
-    decryptMock.mockRejectedValue(new Error('wrong key'));
-    const base64ShapedPlaintext = `${'Q'.repeat(38)}==`;
-
-    await expect(encryptMobileStateIfPlaintext(base64ShapedPlaintext)).resolves.toBe(
-      `encrypted:${base64ShapedPlaintext}`,
-    );
-
-    expect(encryptMock).toHaveBeenCalledWith(expect.any(Object), base64ShapedPlaintext);
-  });
-
-  it('does not cache a newly generated key when persisting it fails', async () => {
-    const { getOrCreateMobileEncryptionKey } = await loadModule();
-    secureMobileStorageMock.set
-      .mockRejectedValueOnce(new Error('keychain locked'))
-      .mockImplementationOnce((key: string, value: any) => {
-        secureStoreMock.set(key, value);
-        return Promise.resolve();
-      });
-
-    await expect(getOrCreateMobileEncryptionKey()).rejects.toThrow('keychain locked');
-    await expect(getOrCreateMobileEncryptionKey()).resolves.toEqual({ byteLength: 32 });
-
-    expect(importEncryptionKeyMock).toHaveBeenCalledTimes(2);
-    expect(secureMobileStorageMock.set).toHaveBeenCalledTimes(2);
+      // Whatever key we ended up holding must be the one on disk: anything encrypted
+      // now has to still be readable after a restart.
+      const ciphertext = await encryptMobileStateIfPlaintext('must survive');
+      const restarted = await restartApp();
+      await expect(restarted.tryDecryptWithMobileKey(ciphertext)).resolves.toBe('must survive');
+    });
   });
 });


### PR DESCRIPTION
part of #1445 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test files; production behavior is unchanged, though CI now more strictly validates security-sensitive paths.
> 
> **Overview**
> Rewrites wallet **security and encryption unit tests** so they run against **shipping implementations** instead of inline or fake mocks that could stay green while production regressed.
> 
> **Deep-link callback gating (HIGH-09):** `deepLinkApi.callback.spec.ts` drops duplicated `validateCallbackUrl` / `isTrustedCallbackUrl` and mocks of `@/utils`, `@/constants`, i18n, and route names. It now imports real helpers and constants, stubs only router/modals/logger/`window.open`, and adds coverage for trusted **`superhero:`** / **`wc:`** schemes, malformed percent-encoding that must resolve (not throw), and real i18n strings in error modals.
> 
> **Callback URL helpers:** `callbackUrl.spec.ts` imports `@/utils/callbackUrl` directly with **no** dynamic mocks, uses real `AGGREGATOR_URL`, and expands cases (unsafe schemes, non-string inputs, `checkIfSuperheroCallbackUrl` edge cases).
> 
> **Crypto:** New `crypto.spec.ts` tests PBKDF2/AES-GCM round-trips, IV uniqueness, tamper rejection, and extension-only extractable key export via `IS_EXTENSION` module reload.
> 
> **Mobile encryption:** `mobileEncryption.spec.ts` removes fake `encrypt`/`decrypt` mocks and uses real WebCrypto plus `SecureMobileStorage`/`localStorage`, with scenarios for idempotent encryption, keychain-wipe **no double-wrap**, hex-key misclassification, key persistence across restart, and persist-before-cache on failed Keychain writes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26eecbb4058e16d07e9d024abfc1b19411479de7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->