### PR TITLE
refactor: extract missed wording

### DIFF
--- a/src/popup/components/AppsBrowser/AppsBrowserHistoryListItem.vue
+++ b/src/popup/components/AppsBrowser/AppsBrowserHistoryListItem.vue
@@ -9,7 +9,7 @@
         v-if="image"
         :src="imageUrl"
         class="app-image"
-        alt="Dapp favicon"
+        :alt="$t('common.altDappFavicon')"
       >
       <IconWrapper
         v-else

--- a/src/popup/components/AppsBrowser/AppsBrowserListItem.vue
+++ b/src/popup/components/AppsBrowser/AppsBrowserListItem.vue
@@ -8,7 +8,7 @@
         v-if="imageUrl"
         :src="imageUrl"
         class="app-image"
-        alt="Dapp favicon"
+        :alt="$t('common.altDappFavicon')"
       >
     </div>
     <div

--- a/src/popup/components/AssetIcon.vue
+++ b/src/popup/components/AssetIcon.vue
@@ -12,7 +12,7 @@
     class="asset-icon"
     :class="[iconSize]"
     :title="asset?.name || asset?.symbol"
-    alt="Solana"
+    :alt="$t('common.altSolana')"
   >
   <img
     v-else
@@ -20,7 +20,7 @@
     :src="asset.image || getTokenPlaceholderUrl(asset)"
     :class="[iconSize, { 'is-placeholder': !asset?.image }]"
     :title="asset?.name || asset?.symbol"
-    alt="Asset image"
+    :alt="$t('common.altAssetImage')"
   >
 </template>
 

--- a/src/popup/components/Assets/DetailsRow.vue
+++ b/src/popup/components/Assets/DetailsRow.vue
@@ -8,7 +8,7 @@
 
     <div class="text">
       <slot name="text">
-        {{ text }}
+        {{ text ?? $t('common.notAvailable') }}
       </slot>
     </div>
   </div>
@@ -18,7 +18,7 @@
 export default {
   props: {
     label: { type: String, default: null },
-    text: { type: [String, Number], default: 'N/A' },
+    text: { type: [String, Number], default: null },
   },
 };
 </script>

--- a/src/popup/components/Avatar.vue
+++ b/src/popup/components/Avatar.vue
@@ -17,7 +17,7 @@
         v-if="!isPlaceholder && avatarUrl"
         class="avatar-img"
         :src="avatarUrl"
-        alt="Avatar"
+        :alt="$t('common.altAvatar')"
       >
     </slot>
   </div>

--- a/src/popup/components/Modals/QrCodeScanner.vue
+++ b/src/popup/components/Modals/QrCodeScanner.vue
@@ -62,7 +62,7 @@
           ref="qrCodeVideoEl"
           class="video"
         >
-          <track kind="captions" title="Scanning Qr Code" />
+          <track kind="captions" :title="$t('modals.qrCodeReader.scanningVideoTitle')" />
         </video>
       </div>
     </div>

--- a/src/popup/components/Platforms.vue
+++ b/src/popup/components/Platforms.vue
@@ -11,14 +11,14 @@
         <img
           :class="{ grey: !IS_IOS || !IS_MOBILE_DEVICE }"
           src="../../icons/platforms/app-store-mobile.svg"
-          alt="App Store"
+          :alt="$t('common.altAppStore')"
         >
       </LinkButton>
       <LinkButton :href="APP_LINK_ANDROID">
         <img
           :class="{ grey: IS_IOS || !IS_MOBILE_DEVICE }"
           src="../../icons/platforms/google-play-mobile.svg"
-          alt="Google Play"
+          :alt="$t('common.altGooglePlay')"
         >
       </LinkButton>
     </div>
@@ -35,13 +35,13 @@
             :href="APP_LINK_FIREFOX"
             :disabled="!IS_FIREFOX || IS_MOBILE_DEVICE"
             :src="firefoxIcon"
-            alt="Firefox"
+            :alt="$t('common.altFirefox')"
           />
           <PlatformIcon
             :href="APP_LINK_CHROME"
             :disabled="IS_FIREFOX || IS_MOBILE_DEVICE"
             :src="chromeIcon"
-            alt="Chrome"
+            :alt="$t('common.altChrome')"
           />
         </div>
       </div>
@@ -54,13 +54,13 @@
             :href="APP_LINK_IOS"
             :disabled="!IS_IOS || !IS_MOBILE_DEVICE"
             :src="appStoreIcon"
-            alt="App Store"
+            :alt="$t('common.altAppStore')"
           />
           <PlatformIcon
             :href="APP_LINK_ANDROID"
             :disabled="IS_IOS || !IS_MOBILE_DEVICE"
             :src="googlePlayIcon"
-            alt="Google Play"
+            :alt="$t('common.altGooglePlay')"
           />
         </div>
       </div>

--- a/src/popup/components/ProtocolIcon.vue
+++ b/src/popup/components/ProtocolIcon.vue
@@ -37,7 +37,7 @@
     src="../../icons/coin/solana.svg"
     class="protocol-icon"
     :class="[iconSize]"
-    alt="Solana"
+    :alt="$t('common.altSolana')"
   />
 </template>
 

--- a/src/popup/components/ProtocolSpecificView.vue
+++ b/src/popup/components/ProtocolSpecificView.vue
@@ -10,7 +10,7 @@
   <div v-else>
     <InfoBox
       type="danger"
-      text="Missing component name"
+      :text="$t('common.missingComponentName')"
     />
   </div>
 </template>

--- a/src/popup/components/form/FormNumberSelect.vue
+++ b/src/popup/components/form/FormNumberSelect.vue
@@ -4,7 +4,7 @@
       v-if="modelValue"
       :value="modelValue"
       class="number-select-input"
-      aria-label="choose number"
+      :aria-label="$t('common.chooseNumber')"
       @change="$emit('update:modelValue', +($event?.target as HTMLInputElement).value)"
     >
       <option

--- a/src/popup/locales/en-US.json
+++ b/src/popup/locales/en-US.json
@@ -3,7 +3,17 @@
     "activeAccount": "Active account",
     "address": "Address",
     "allow": "Allow",
+    "altAppStore": "App Store",
+    "altAssetImage": "Asset image",
+    "altAvatar": "Avatar",
+    "altChrome": "Chrome",
+    "altDappFavicon": "Dapp favicon",
+    "altFirefox": "Firefox",
+    "altGooglePlay": "Google Play",
+    "altSolana": "Solana",
+    "chooseNumber": "choose number",
     "name": "Name",
+    "notAvailable": "N/A",
     "addressCopied": "Copied",
     "all": "All",
     "allAddresses": "All account addresses",
@@ -33,6 +43,7 @@
     "hours": "{n} hours | {n} hour | {n} hours",
     "hoursShort": "{n} h",
     "key": "Key",
+    "missingComponentName": "Missing component name",
     "minutes": "{n} minutes | {n} minute | {n} minutes",
     "minutesShort": "{n} mins | {n} min | {n} mins",
     "next": "Next",
@@ -418,7 +429,8 @@
       "subtitle": "Allow Superhero Wallet to access your camera in order to scan QR codes.",
       "settings": "Settings",
       "qrCodeHasMultipleFragments": "In order to sign this transaction you need to scan multiple QR codes. Keep your camera focused on the changing QRs until all codes have been scanned.",
-      "scanningProgress": "scanned"
+      "scanningProgress": "scanned",
+      "scanningVideoTitle": "Scanning Qr Code"
     },
     "name-pointers-help": {
       "title": "Name pointers",
@@ -916,7 +928,8 @@
       "header": "Lost in space?",
       "description": "The feature could not be found in this Universe. Keep calm and safely fly back home.",
       "backToHome": "Return home",
-      "reportBug": "Report a bug"
+      "reportBug": "Report a bug",
+      "imageAlt": "Feature not found"
     },
     "recentTransactions": {
       "noTransactionsFound": "There are no recent transactions for this account.",
@@ -947,7 +960,8 @@
       "transactionRequest": "This dApp may propose transactions. You are in charge of confirming them.",
       "rememberMe": "Remember me",
       "selectAccount": "Select account to connect with",
-      "ensureNetwork": "Kindly ensure that Superhero Wallet and dApp are connected to the same network before making any transaction."
+      "ensureNetwork": "Kindly ensure that Superhero Wallet and dApp are connected to the same network before making any transaction.",
+      "dappLogoAlt": "DAPP logo"
     },
     "fungible-tokens": {
       "tokens": "Tokens | Token | Tokens",
@@ -1387,7 +1401,8 @@
     "appsBrowser": {
       "popularApps": "Featured",
       "recentApps": "Latest visited",
-      "inputPlaceholder": "Enter URL"
+      "inputPlaceholder": "Enter URL",
+      "iframeTitle": "Selected app"
     },
     "warningDappBrowser": {
       "title": "You are going to visit a \n third-party website",

--- a/src/popup/locales/zh-CN.json
+++ b/src/popup/locales/zh-CN.json
@@ -3,7 +3,17 @@
     "activeAccount": "活跃账户",
     "address": "地址",
     "allow": "允许",
+    "altAppStore": "App Store",
+    "altAssetImage": "资产图片",
+    "altAvatar": "头像",
+    "altChrome": "Chrome",
+    "altDappFavicon": "Dapp 图标",
+    "altFirefox": "Firefox",
+    "altGooglePlay": "Google Play",
+    "altSolana": "Solana",
+    "chooseNumber": "选择数字",
     "name": "名称",
+    "notAvailable": "不可用",
     "addressCopied": "已复制",
     "all": "全部",
     "allAddresses": "所有账户地址",
@@ -33,6 +43,7 @@
     "hours": "{n} 小时 | {n} 小时 | {n} 小时",
     "hoursShort": "{n} 小时",
     "key": "密钥",
+    "missingComponentName": "缺少组件名称",
     "minutes": "{n} 分钟 | {n} 分钟 | {n} 分钟",
     "minutesShort": "{n} 分 | {n} 分 | {n} 分",
     "next": "下一步",
@@ -235,6 +246,7 @@
       "btnText": "导入账户"
     },
     "name-exist": {
+      "title": "名称注册错误",
       "msg": "该名称已被注册。"
     },
     "name-already-preclaimed": {
@@ -254,6 +266,15 @@
       "name": "名称",
       "cost": "续期费用",
       "autoExtend": "下次自动延长此名称"
+    },
+    "name-length": {
+      "msg": "SUPERHERO 上的名称长度必须至少为 13 个字符。"
+    },
+    "incorrect-address": {
+      "msg": "请确保你输入了有效的公共地址。"
+    },
+    "incorrect-amount": {
+      "msg": "请确保你输入了有效的金额。"
     },
     "insufficient-balance": {
       "msg": "你的余额不足以完成此交易。"
@@ -408,7 +429,8 @@
       "subtitle": "允许 Superhero 钱包访问你的相机以扫描二维码。",
       "settings": "设置",
       "qrCodeHasMultipleFragments": "要签名此交易，你需要扫描多个二维码。请将相机对准变化的二维码，直到全部扫描完成。",
-      "scanningProgress": "已扫描"
+      "scanningProgress": "已扫描",
+      "scanningVideoTitle": "正在扫描二维码"
     },
     "name-pointers-help": {
       "title": "名称指针",
@@ -906,7 +928,8 @@
       "header": "迷失在太空中？",
       "description": "本宇宙中找不到该功能。保持冷静并安全返回主页。",
       "backToHome": "返回主页",
-      "reportBug": "报告错误"
+      "reportBug": "报告错误",
+      "imageAlt": "未找到功能"
     },
     "recentTransactions": {
       "noTransactionsFound": "该账户没有最近交易。",
@@ -937,7 +960,8 @@
       "transactionRequest": "此 dApp 可能会提议交易。你负责确认它们。",
       "rememberMe": "记住我",
       "selectAccount": "选择用于连接的账户",
-      "ensureNetwork": "进行任何交易前，请确保 Superhero 钱包与 dApp 连接到相同网络。"
+      "ensureNetwork": "进行任何交易前，请确保 Superhero 钱包与 dApp 连接到相同网络。",
+      "dappLogoAlt": "DAPP 图标"
     },
     "fungible-tokens": {
       "tokens": "代币 | 代币 | 代币",
@@ -1377,7 +1401,8 @@
     "appsBrowser": {
       "popularApps": "精选",
       "recentApps": "最近访问",
-      "inputPlaceholder": "输入 URL"
+      "inputPlaceholder": "输入 URL",
+      "iframeTitle": "已选择的应用"
     },
     "warningDappBrowser": {
       "title": "你将访问\n第三方网站",

--- a/src/popup/pages/AppsBrowser.vue
+++ b/src/popup/pages/AppsBrowser.vue
@@ -70,7 +70,7 @@
       <iframe
         v-else
         ref="iframeEl"
-        title="selectedApp"
+        :title="$t('pages.appsBrowser.iframeTitle')"
         class="apps-browser-iframe"
         :src="selectedApp.url"
         @load="onAppLoaded()"

--- a/src/popup/pages/NotFound.vue
+++ b/src/popup/pages/NotFound.vue
@@ -4,7 +4,7 @@
       <img
         class="image"
         :src="NotFoundImage"
-        alt="Feature not found"
+        :alt="$t('pages.notFound.imageAlt')"
       >
       <div
         class="text-heading-1 heading"

--- a/src/popup/pages/Popups/ConnectBase.vue
+++ b/src/popup/pages/Popups/ConnectBase.vue
@@ -32,7 +32,7 @@
       >
         <template #icon>
           <Avatar size="rg" borderless>
-            <img v-if="dappIcon" :src="dappIcon" class="dapp-logo" alt="DAPP logo" />
+            <img v-if="dappIcon" :src="dappIcon" class="dapp-logo" :alt="$t('pages.connectConfirm.dappLogoAlt')" />
             <DappIcon v-else class="dapp-icon" />
           </Avatar>
         </template>
@@ -96,7 +96,7 @@
           <div v-for="(accessName, index) in accessList" :key="index">
             <div class="label">
               <CheckMark class="icon" />
-              {{ accessLabels[accessName]?.label || 'Unknown' }}
+              {{ accessLabels[accessName]?.label || $t('common.unknown') }}
             </div>
             <TemplateRenderer
               class="description"


### PR DESCRIPTION
fixes https://github.com/superhero-com/superhero-wallet/issues/887
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Copy and accessibility-label changes only; no business logic or security paths modified. Minor UX note: zh-CN `notAvailable` is “不可用” vs English “N/A”.
> 
> **Overview**
> Replaces **hardcoded English** in popup Vue components with **`$t(...)`** keys so alt text, aria labels, iframe titles, and inline messages follow the wallet locale.
> 
> Adds matching entries in **`en-US.json`** and **`zh-CN.json`** (shared `common.*` keys plus page/modal-specific strings like `pages.notFound.imageAlt`, `pages.appsBrowser.iframeTitle`, `modals.qrCodeReader.scanningVideoTitle`, and several modal message blocks in zh-CN).
> 
> **`DetailsRow`** now defaults missing `text` to **`common.notAvailable`** via nullish coalescing instead of a prop default of `'N/A'`. **`ConnectBase`** uses **`common.unknown`** for unrecognized permission labels instead of the literal `'Unknown'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d41e46a95b83319a32d9edcc3a6f90f2bb09344. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->